### PR TITLE
fix: Backspace時に未確定文字が確定される不具合を修正

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -310,7 +310,9 @@ impl TextServiceFactory {
                     vec![ClientAction::AppendText(value.to_string())],
                 ),
                 UserAction::Backspace => {
-                    if composition.preview.chars().count() == 1 {
+                    // preview length can differ from raw input (e.g. "れい" -> "例"),
+                    // so decide end-of-composition by remaining raw input length.
+                    if composition.raw_input.chars().count() <= 1 {
                         (
                             CompositionState::None,
                             vec![ClientAction::RemoveText, ClientAction::EndComposition],
@@ -440,7 +442,9 @@ impl TextServiceFactory {
                     vec![ClientAction::ShrinkText(value.to_string())],
                 ),
                 UserAction::Backspace => {
-                    if composition.preview.chars().count() == 1 {
+                    // preview length can differ from raw input (e.g. "れい" -> "例"),
+                    // so decide end-of-composition by remaining raw input length.
+                    if composition.raw_input.chars().count() <= 1 {
                         (
                             CompositionState::None,
                             vec![ClientAction::RemoveText, ClientAction::EndComposition],


### PR DESCRIPTION
## 概要
- Backspace時の終了判定を preview 文字数基準から raw_input 基準に変更しました。
- れい -> 例 のように入力長と表示長が異なるケースで、誤って EndComposition が走る問題を修正しています。

## 変更内容
- crates/client/src/engine/composition.rs
  - Composing / Previewing の UserAction::Backspace 分岐で、判定を composition.raw_input.chars().count() <= 1 に変更
  - 再発防止コメントを追加

## 確認
- ローカルの cargo check -p azookey-windows は protoc 未導入環境のため完走できていません
- 実機での動作確認では問題なしとの報告あり

Fixes #3
