### PR TITLE
fix(tsf): consolidate update_pos state

### DIFF
--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -12,12 +12,7 @@ use windows::{
     },
 };
 
-use std::{
-    cell::Cell,
-    mem::ManuallyDrop,
-    rc::Rc,
-    time::{Duration, Instant},
-};
+use std::{cell::Cell, mem::ManuallyDrop, rc::Rc, time::Instant};
 
 use anyhow::{Context, Result};
 
@@ -298,16 +293,13 @@ impl TextServiceFactory {
                 }
             };
 
-            if text_service.is_updating_pos {
+            if !text_service
+                .update_pos_state
+                .try_begin_update(Instant::now())
+            {
                 tracing::debug!("Skip re-entrant update_pos call");
                 return Ok(());
             }
-
-            text_service.is_updating_pos = true;
-            // GetTextExt can trigger a layout-change callback in some apps (e.g. Mery).
-            // Suppress the immediate callback to avoid feedback loops.
-            text_service.suppress_layout_change_until =
-                Some(Instant::now() + Duration::from_millis(200));
         }
 
         let result: Result<()> = (|| {
@@ -358,7 +350,7 @@ impl TextServiceFactory {
 
         match self.borrow_mut() {
             Ok(mut text_service) => {
-                text_service.is_updating_pos = false;
+                text_service.update_pos_state.finish_update(Instant::now());
             }
             Err(error) => {
                 tracing::warn!("Failed to reset update_pos guard: {error:?}");

--- a/crates/client/src/tsf/text_layout_sink.rs
+++ b/crates/client/src/tsf/text_layout_sink.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use windows::{
     core::Interface as _,
     Win32::UI::TextServices::{
@@ -24,16 +22,10 @@ impl ITfTextLayoutSink_Impl for TextServiceFactory_Impl {
         _lcode: TfLayoutCode,
         _pview: Option<&ITfContextView>,
     ) -> Result<()> {
-        let now = Instant::now();
         let should_skip = match self.borrow_mut() {
-            Ok(mut text_service) => match text_service.suppress_layout_change_until {
-                Some(until) if now <= until => true,
-                Some(_) => {
-                    text_service.suppress_layout_change_until = None;
-                    false
-                }
-                None => false,
-            },
+            Ok(mut text_service) => text_service
+                .update_pos_state
+                .should_skip_layout_change(std::time::Instant::now()),
             Err(error) => {
                 tracing::warn!("Skip OnLayoutChange due to borrow conflict: {error:?}");
                 true

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::{Ref, RefCell, RefMut},
     collections::HashMap,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use windows::{
@@ -13,14 +13,65 @@ use anyhow::{Context, Result};
 
 use crate::engine::{composition::Composition, input_mode::InputMode};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UpdatePosState {
+    #[default]
+    Idle,
+    Updating {
+        suppress_layout_until: Instant,
+    },
+    SuppressingLayoutChange {
+        until: Instant,
+    },
+}
+
+impl UpdatePosState {
+    const LAYOUT_CHANGE_SUPPRESSION: Duration = Duration::from_millis(200);
+
+    pub fn try_begin_update(&mut self, now: Instant) -> bool {
+        if matches!(self, Self::Updating { .. }) {
+            return false;
+        }
+
+        *self = Self::Updating {
+            suppress_layout_until: now + Self::LAYOUT_CHANGE_SUPPRESSION,
+        };
+
+        true
+    }
+
+    pub fn finish_update(&mut self, now: Instant) {
+        *self = match *self {
+            Self::Updating {
+                suppress_layout_until,
+            } if now <= suppress_layout_until => Self::SuppressingLayoutChange {
+                until: suppress_layout_until,
+            },
+            Self::Updating { .. } => Self::Idle,
+            state => state,
+        };
+    }
+
+    pub fn should_skip_layout_change(&mut self, now: Instant) -> bool {
+        match *self {
+            Self::Idle => false,
+            Self::Updating { .. } => true,
+            Self::SuppressingLayoutChange { until } if now <= until => true,
+            Self::SuppressingLayoutChange { .. } => {
+                *self = Self::Idle;
+                false
+            }
+        }
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct TextService {
     pub tid: u32,
     pub thread_mgr: Option<ITfThreadMgr>,
     pub context: Option<ITfContext>,
     pub composition: RefCell<Composition>,
-    pub is_updating_pos: bool,
-    pub suppress_layout_change_until: Option<Instant>,
+    pub update_pos_state: UpdatePosState,
     pub display_attribute_atom: HashMap<GUID, u32>,
     pub mode: InputMode,
     pub this: Option<ITfTextInputProcessor>,


### PR DESCRIPTION
## Summary
- consolidate `update_pos` state into `UpdatePosState`
- use the shared state for both re-entrant guard and layout-change suppression
- keep the change scoped to TSF update-position handling

## Verification
- CI passed
- `ALLOW_DIRTY_WORKTREE=1 ./.local/vm_build_master.sh verify/master-update-pos-state` (default Swift 6.1.2 snapshot build)
- installer staging on Win11 completed successfully