### PR TITLE
fix(ime): 候補ウィンドウ表示とdisabled状態を修正

### DIFF
--- a/crates/client/src/engine/client_action.rs
+++ b/crates/client/src/engine/client_action.rs
@@ -4,6 +4,7 @@ use super::input_mode::InputMode;
 pub enum ClientAction {
     StartComposition,
     EndComposition,
+    ShowCandidateWindow,
 
     AppendText(String),
     AppendTextRaw(String),

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -2594,6 +2594,7 @@ impl TextServiceFactory {
         let keyboard_disabled = keyboard_disabled_from_context(context);
         self.set_keyboard_disabled_state(keyboard_disabled)?;
         if keyboard_disabled {
+            self.cancel_composition_for_disabled_context();
             return Ok(None);
         }
 
@@ -2725,6 +2726,7 @@ impl TextServiceFactory {
         let keyboard_disabled = keyboard_disabled_from_context(context);
         self.set_keyboard_disabled_state(keyboard_disabled)?;
         if keyboard_disabled {
+            self.cancel_composition_for_disabled_context();
             return Ok(None);
         }
         if !Self::is_shift_key(wparam) {
@@ -2816,6 +2818,10 @@ impl TextServiceFactory {
     }
 
     fn recover_after_key_error(&self) {
+        self.cancel_composition_for_disabled_context();
+    }
+
+    fn cancel_composition_for_disabled_context(&self) {
         let _ = self.abort_composition();
 
         if let Ok(text_service) = self.borrow() {
@@ -2824,11 +2830,16 @@ impl TextServiceFactory {
             }
         }
 
-        if let Ok(mut ime_state) = IMEState::get() {
-            if let Some(mut ipc_service) = ime_state.ipc_service.clone() {
-                let _ = ipc_service.hide_window();
-                let _ = ipc_service.set_candidates(vec![]);
-                let _ = ipc_service.clear_text();
+        let ipc_service = IMEState::get()
+            .ok()
+            .and_then(|state| state.ipc_service.clone());
+
+        if let Some(mut ipc_service) = ipc_service {
+            let _ = ipc_service.hide_window();
+            let _ = ipc_service.set_candidates(vec![]);
+            let _ = ipc_service.clear_text();
+
+            if let Ok(mut ime_state) = IMEState::get() {
                 ime_state.ipc_service = Some(ipc_service);
             }
         }

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -10,7 +10,7 @@ use super::{
     full_width::{convert_kana_symbol, to_fullwidth, to_halfwidth},
     input_mode::InputMode,
     ipc_service::{Candidates, IPCService},
-    state::IMEState,
+    state::{keyboard_disabled_from_context, IMEState},
     text_util::{to_half_katakana, to_katakana},
     user_action::{Function, Navigation},
 };
@@ -1000,6 +1000,7 @@ impl TextServiceFactory {
         match action {
             ClientAction::StartComposition => "StartComposition",
             ClientAction::EndComposition => "EndComposition",
+            ClientAction::ShowCandidateWindow => "ShowCandidateWindow",
             ClientAction::AppendText(_) => "AppendText",
             ClientAction::AppendTextRaw(_) => "AppendTextRaw",
             ClientAction::AppendTextDirect(_) => "AppendTextDirect",
@@ -1424,6 +1425,22 @@ impl TextServiceFactory {
         ipc_service.set_selection(selection_index)?;
         if update_pos {
             self.update_pos()?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn sync_candidate_window_after_text_update(
+        &self,
+        ipc_service: &mut IPCService,
+        app_config: &AppConfig,
+        transition: &CompositionState,
+    ) -> Result<()> {
+        self.update_pos()?;
+        if !app_config.general.show_candidate_window_after_space
+            && *transition != CompositionState::None
+        {
+            ipc_service.show_window()?;
         }
         Ok(())
     }
@@ -2183,6 +2200,16 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn candidate_preview_actions(app_config: &AppConfig) -> Vec<ClientAction> {
+        let mut actions = Vec::with_capacity(2);
+        if app_config.general.show_candidate_window_after_space {
+            actions.push(ClientAction::ShowCandidateWindow);
+        }
+        actions.push(ClientAction::SetSelection(SetSelectionType::Down));
+        actions
+    }
+
+    #[inline]
     fn plan_actions_for_user_action(
         composition: &Composition,
         action: &UserAction,
@@ -2388,7 +2415,7 @@ impl TextServiceFactory {
                 )),
                 UserAction::Space | UserAction::Tab => Some((
                     CompositionState::Previewing,
-                    vec![ClientAction::SetSelection(SetSelectionType::Down)],
+                    Self::candidate_preview_actions(app_config),
                 )),
                 UserAction::Function(key) => match key {
                     Function::Six => Some((
@@ -2521,7 +2548,7 @@ impl TextServiceFactory {
                 )),
                 UserAction::Space | UserAction::Tab => Some((
                     CompositionState::Previewing,
-                    vec![ClientAction::SetSelection(SetSelectionType::Down)],
+                    Self::candidate_preview_actions(app_config),
                 )),
                 UserAction::Function(key) => match key {
                     Function::Six => Some((
@@ -2560,9 +2587,15 @@ impl TextServiceFactory {
         wparam: WPARAM,
         lparam: LPARAM,
     ) -> Result<Option<(Vec<ClientAction>, CompositionState)>> {
-        if context.is_none() {
+        let Some(context) = context else {
+            self.set_keyboard_disabled_state(true)?;
             return Ok(None);
         };
+        let keyboard_disabled = keyboard_disabled_from_context(context);
+        self.set_keyboard_disabled_state(keyboard_disabled)?;
+        if keyboard_disabled {
+            return Ok(None);
+        }
 
         let is_ctrl_pressed = Self::is_ctrl_pressed();
         let is_shift_pressed = Self::is_shift_pressed();
@@ -2685,7 +2718,16 @@ impl TextServiceFactory {
         wparam: WPARAM,
         _lparam: LPARAM,
     ) -> Result<Option<(Vec<ClientAction>, CompositionState)>> {
-        if context.is_none() || !Self::is_shift_key(wparam) {
+        let Some(context) = context else {
+            self.set_keyboard_disabled_state(true)?;
+            return Ok(None);
+        };
+        let keyboard_disabled = keyboard_disabled_from_context(context);
+        self.set_keyboard_disabled_state(keyboard_disabled)?;
+        if keyboard_disabled {
+            return Ok(None);
+        }
+        if !Self::is_shift_key(wparam) {
             return Ok(None);
         }
 
@@ -2718,6 +2760,7 @@ impl TextServiceFactory {
             if let Some(context) = context {
                 self.borrow_mut()?.context = Some(context.clone());
             } else {
+                self.set_keyboard_disabled_state(true)?;
                 return Ok(false);
             };
 
@@ -2750,6 +2793,7 @@ impl TextServiceFactory {
             if let Some(context) = context {
                 self.borrow_mut()?.context = Some(context.clone());
             } else {
+                self.set_keyboard_disabled_state(true)?;
                 return Ok(false);
             };
 
@@ -2836,6 +2880,11 @@ impl TextServiceFactory {
             match action {
                 ClientAction::StartComposition => {
                     self.start_composition()?;
+                    if app_config.general.show_candidate_window_after_space {
+                        ipc_service.hide_window()?;
+                    }
+                }
+                ClientAction::ShowCandidateWindow => {
                     self.update_pos()?;
                     ipc_service.show_window()?;
                 }
@@ -2894,6 +2943,11 @@ impl TextServiceFactory {
                         self.set_text(&preview, &suffix)?;
                         ipc_service.set_candidates(candidates.texts.clone())?;
                         ipc_service.set_selection(selection_index)?;
+                        self.sync_candidate_window_after_text_update(
+                            &mut ipc_service,
+                            &app_config,
+                            &transition,
+                        )?;
                     }
                 }
                 ClientAction::AppendTextRaw(text) => {
@@ -2918,6 +2972,11 @@ impl TextServiceFactory {
                         self.set_text(&preview, &suffix)?;
                         ipc_service.set_candidates(candidates.texts.clone())?;
                         ipc_service.set_selection(selection_index)?;
+                        self.sync_candidate_window_after_text_update(
+                            &mut ipc_service,
+                            &app_config,
+                            &transition,
+                        )?;
                     }
                 }
                 ClientAction::AppendTextDirect(text) => {
@@ -2943,6 +3002,11 @@ impl TextServiceFactory {
                         self.set_text(&preview, &suffix)?;
                         ipc_service.set_candidates(candidates.texts.clone())?;
                         ipc_service.set_selection(selection_index)?;
+                        self.sync_candidate_window_after_text_update(
+                            &mut ipc_service,
+                            &app_config,
+                            &transition,
+                        )?;
                     }
                 }
                 ClientAction::RemoveText => {
@@ -3178,8 +3242,10 @@ impl TextServiceFactory {
                     self.update_pos()?;
                     self.end_composition()?;
 
-                    let mut ime_state = IMEState::get()?;
-                    ime_state.input_mode = mode.clone();
+                    {
+                        let mut ime_state = IMEState::get()?;
+                        ime_state.input_mode = mode.clone();
+                    }
 
                     // update the language bar
                     self.update_lang_bar()?;

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -3,7 +3,8 @@ use super::{
     CompositionState, FutureClauseSnapshot, TextServiceFactory,
 };
 use crate::engine::{
-    client_action::{ClientAction, SetTextType},
+    client_action::{ClientAction, SetSelectionType, SetTextType},
+    input_mode::InputMode,
     user_action::{Function, Navigation, UserAction},
 };
 use shared::{get_default_romaji_rows, AppConfig, RomajiRule, WidthMode};
@@ -58,3 +59,56 @@ mod integration_patterns;
 mod snapshot_restore;
 pub(super) mod stateful_harness;
 mod symbol_and_width;
+
+#[test]
+fn delayed_candidate_window_does_not_show_on_composition_start() {
+    let mut app_config = AppConfig::default();
+    app_config.general.show_candidate_window_after_space = true;
+
+    let (_, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &Composition::default(),
+        &UserAction::Input('a'),
+        &InputMode::Kana,
+        false,
+        &app_config,
+        false,
+    )
+    .expect("input should start composition");
+
+    assert_eq!(
+        actions,
+        vec![
+            ClientAction::StartComposition,
+            ClientAction::AppendText("a".to_string())
+        ]
+    );
+}
+
+#[test]
+fn delayed_candidate_window_shows_when_space_opens_preview() {
+    let mut app_config = AppConfig::default();
+    app_config.general.show_candidate_window_after_space = true;
+    let composition = Composition {
+        state: CompositionState::Composing,
+        raw_input: "a".to_string(),
+        ..Composition::default()
+    };
+
+    let (_, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Space,
+        &InputMode::Kana,
+        false,
+        &app_config,
+        false,
+    )
+    .expect("space should enter preview");
+
+    assert_eq!(
+        actions,
+        vec![
+            ClientAction::ShowCandidateWindow,
+            ClientAction::SetSelection(SetSelectionType::Down)
+        ]
+    );
+}

--- a/crates/client/src/engine/composition/tests/stateful_harness.rs
+++ b/crates/client/src/engine/composition/tests/stateful_harness.rs
@@ -1466,6 +1466,7 @@ fn apply_user_action(
             ClientAction::StartComposition => {
                 harness.state = CompositionState::Composing;
             }
+            ClientAction::ShowCandidateWindow => {}
             ClientAction::EndComposition => {
                 let snapshot_count = harness.clause_snapshots.len();
                 for index in 0..snapshot_count {

--- a/crates/client/src/engine/state.rs
+++ b/crates/client/src/engine/state.rs
@@ -3,7 +3,10 @@ use std::{
     sync::{LazyLock, Mutex, MutexGuard},
 };
 
-use windows::{core::GUID, Win32::UI::TextServices::ITfContext};
+use windows::{
+    core::{Interface as _, GUID},
+    Win32::UI::TextServices::{ITfCompartmentMgr, ITfContext, GUID_COMPARTMENT_KEYBOARD_DISABLED},
+};
 
 use super::{input_mode::InputMode, ipc_service::IPCService};
 
@@ -11,6 +14,7 @@ use super::{input_mode::InputMode, ipc_service::IPCService};
 pub struct IMEState {
     pub ipc_service: Option<IPCService>,
     pub input_mode: InputMode,
+    pub keyboard_disabled: bool,
     pub cookies: HashMap<GUID, u32>,
     pub context: Option<ITfContext>,
 }
@@ -20,6 +24,7 @@ pub static IME_STATE: LazyLock<Mutex<IMEState>> = LazyLock::new(|| {
     Mutex::new(IMEState {
         ipc_service: None,
         input_mode: InputMode::default(),
+        keyboard_disabled: false,
         cookies: HashMap::new(),
         context: None,
     })
@@ -33,5 +38,24 @@ impl IMEState {
             Ok(guard) => Ok(guard),
             Err(e) => anyhow::bail!("Failed to lock state: {:?}", e),
         }
+    }
+}
+
+pub fn keyboard_disabled_from_context(context: &ITfContext) -> bool {
+    unsafe {
+        let Ok(compartment_mgr) = context.cast::<ITfCompartmentMgr>() else {
+            return false;
+        };
+        let Ok(compartment) = compartment_mgr.GetCompartment(&GUID_COMPARTMENT_KEYBOARD_DISABLED)
+        else {
+            return false;
+        };
+        let Ok(value) = compartment.GetValue() else {
+            return false;
+        };
+
+        i32::try_from(&value)
+            .map(|value| value != 0)
+            .unwrap_or(false)
     }
 }

--- a/crates/client/src/tsf/factory.rs
+++ b/crates/client/src/tsf/factory.rs
@@ -11,7 +11,7 @@ use windows::{
         UI::TextServices::{
             ITfCompositionSink, ITfDisplayAttributeProvider, ITfKeyEventSink, ITfLangBarItem,
             ITfLangBarItemButton, ITfSource, ITfTextInputProcessor, ITfTextInputProcessorEx,
-            ITfTextLayoutSink, ITfThreadMgrEventSink,
+            ITfTextLayoutSink, ITfThreadFocusSink, ITfThreadMgrEventSink,
         },
     },
 };
@@ -29,6 +29,7 @@ use super::text_service::TextService;
     ITfTextInputProcessorEx,
     ITfKeyEventSink,
     ITfThreadMgrEventSink,
+    ITfThreadFocusSink,
     ITfTextLayoutSink,
     ITfCompositionSink,
     ITfDisplayAttributeProvider,

--- a/crates/client/src/tsf/key_event_sink.rs
+++ b/crates/client/src/tsf/key_event_sink.rs
@@ -61,7 +61,11 @@ impl ITfKeyEventSink_Impl for TextServiceFactory_Impl {
     }
 
     #[macros::anyhow]
-    fn OnSetFocus(&self, _fforeground: BOOL) -> Result<()> {
+    fn OnSetFocus(&self, fforeground: BOOL) -> Result<()> {
+        if !fforeground.as_bool() {
+            self.set_keyboard_disabled_state(true)?;
+        }
+
         Ok(())
     }
 }

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -23,7 +23,8 @@ use windows::{
             TextServices::{
                 ITfLangBarItemButton_Impl, ITfLangBarItemSink, ITfLangBarItem_Impl, ITfMenu,
                 ITfSource_Impl, TfLBIClick, GUID_LBI_INPUTMODE, TF_LANGBARITEMINFO,
-                TF_LBI_CLK_LEFT, TF_LBI_CLK_RIGHT, TF_LBI_STYLE_BTN_BUTTON, TF_LBI_STYLE_BTN_MENU,
+                TF_LBI_CLK_LEFT, TF_LBI_CLK_RIGHT, TF_LBI_STATUS_DISABLED, TF_LBI_STYLE_BTN_BUTTON,
+                TF_LBI_STYLE_BTN_MENU,
             },
             WindowsAndMessaging::{
                 AppendMenuW, CreatePopupMenu, DestroyMenu, GetAncestor, GetForegroundWindow,
@@ -108,7 +109,11 @@ impl ITfLangBarItem_Impl for TextServiceFactory_Impl {
 
     #[macros::anyhow]
     fn GetStatus(&self) -> Result<u32> {
-        Ok(0)
+        if IMEState::get()?.keyboard_disabled {
+            Ok(TF_LBI_STATUS_DISABLED)
+        } else {
+            Ok(0)
+        }
     }
 
     #[macros::anyhow]
@@ -126,6 +131,10 @@ impl ITfLangBarItem_Impl for TextServiceFactory_Impl {
 impl ITfLangBarItemButton_Impl for TextServiceFactory_Impl {
     #[macros::anyhow]
     fn OnClick(&self, click: TfLBIClick, pt: &POINT, _prcarea: *const RECT) -> Result<()> {
+        if IMEState::get()?.keyboard_disabled {
+            return Ok(());
+        }
+
         match click {
             TF_LBI_CLK_LEFT => self.toggle_input_mode()?,
             TF_LBI_CLK_RIGHT => self.handle_right_click(pt)?,
@@ -157,7 +166,11 @@ impl ITfLangBarItemButton_Impl for TextServiceFactory_Impl {
     fn GetIcon(&self) -> Result<HICON> {
         let dll_module = DllModule::get()?;
         let state = &IMEState::get()?;
-        let input_mode = &state.input_mode;
+        let input_mode = if state.keyboard_disabled {
+            &InputMode::Latin
+        } else {
+            &state.input_mode
+        };
         let theme = get_theme()?;
 
         let icon_id = match input_mode {

--- a/crates/client/src/tsf/text_input_proccesor.rs
+++ b/crates/client/src/tsf/text_input_proccesor.rs
@@ -14,7 +14,7 @@ use windows::{
         UI::TextServices::{
             CLSID_TF_CategoryMgr, ITfCategoryMgr, ITfKeyEventSink, ITfKeystrokeMgr,
             ITfLangBarItemButton, ITfLangBarItemMgr, ITfSource, ITfTextInputProcessorEx_Impl,
-            ITfTextInputProcessor_Impl, ITfThreadMgr, ITfThreadMgrEventSink,
+            ITfTextInputProcessor_Impl, ITfThreadFocusSink, ITfThreadMgr, ITfThreadMgrEventSink,
         },
     },
 };
@@ -71,11 +71,22 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
                 .insert(ITfThreadMgrEventSink::IID, cookie);
         };
 
+        tracing::debug!("AdviseThreadFocusSink");
+        unsafe {
+            let cookie = thread_mgr.cast::<ITfSource>()?.AdviseSink(
+                &ITfThreadFocusSink::IID,
+                &text_service.this::<ITfThreadFocusSink>()?,
+            )?;
+            IMEState::get()?
+                .cookies
+                .insert(ITfThreadFocusSink::IID, cookie);
+        };
+
         // initialize text layout sink
         tracing::debug!("AdviseTextLayoutSink");
-        let doc_mgr = unsafe { thread_mgr.GetFocus() };
-        if let Ok(doc_mgr) = doc_mgr {
-            text_service.advise_text_layout_sink(doc_mgr)?;
+        let doc_mgr = unsafe { thread_mgr.GetFocus().ok() };
+        if let Some(doc_mgr) = doc_mgr.as_ref() {
+            text_service.advise_text_layout_sink(doc_mgr.clone())?;
         }
 
         // initialize display attribute
@@ -99,6 +110,8 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
                 .cast::<ITfLangBarItemMgr>()?
                 .AddItem(&text_service.this::<ITfLangBarItemButton>()?)?;
         };
+        drop(text_service);
+        self.set_keyboard_disabled_for_document_mgr(doc_mgr.as_ref())?;
 
         tracing::debug!("Activate success");
 
@@ -144,6 +157,13 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
         tracing::debug!("UnadviseThreadMgrEventSink");
         unsafe {
             if let Some(cookie) = IMEState::get()?.cookies.remove(&ITfThreadMgrEventSink::IID) {
+                thread_mgr.cast::<ITfSource>()?.UnadviseSink(cookie)?;
+            }
+        };
+
+        tracing::debug!("UnadviseThreadFocusSink");
+        unsafe {
+            if let Some(cookie) = IMEState::get()?.cookies.remove(&ITfThreadFocusSink::IID) {
                 thread_mgr.cast::<ITfSource>()?.UnadviseSink(cookie)?;
             }
         };

--- a/crates/client/src/tsf/thread_mgr_event_sink.rs
+++ b/crates/client/src/tsf/thread_mgr_event_sink.rs
@@ -1,10 +1,59 @@
-use windows::Win32::UI::TextServices::{ITfContext, ITfDocumentMgr, ITfThreadMgrEventSink_Impl};
+use windows::Win32::UI::TextServices::{
+    ITfContext, ITfDocumentMgr, ITfThreadFocusSink_Impl, ITfThreadMgrEventSink_Impl,
+};
 
 use anyhow::Result;
 
-use crate::engine::{client_action::ClientAction, composition::CompositionState};
+use crate::engine::{
+    client_action::ClientAction,
+    composition::CompositionState,
+    state::{keyboard_disabled_from_context, IMEState},
+};
 
-use super::factory::TextServiceFactory_Impl;
+use super::factory::{TextServiceFactory, TextServiceFactory_Impl};
+
+impl TextServiceFactory {
+    pub fn set_keyboard_disabled_state(&self, disabled: bool) -> Result<()> {
+        let changed = {
+            let mut state = IMEState::get()?;
+            let changed = state.keyboard_disabled != disabled;
+            state.keyboard_disabled = disabled;
+
+            if disabled {
+                if let Some(mut ipc_service) = state.ipc_service.clone() {
+                    let _ = ipc_service.hide_window();
+                    let _ = ipc_service.set_candidates(vec![]);
+                    state.ipc_service = Some(ipc_service);
+                }
+            }
+
+            changed
+        };
+
+        if changed {
+            self.update_lang_bar()?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn set_keyboard_disabled_for_document_mgr(
+        &self,
+        focus: Option<&ITfDocumentMgr>,
+    ) -> Result<()> {
+        let disabled = match focus {
+            Some(focus) => unsafe {
+                focus
+                    .GetTop()
+                    .map(|context| keyboard_disabled_from_context(&context))
+                    .unwrap_or(true)
+            },
+            None => true,
+        };
+
+        self.set_keyboard_disabled_state(disabled)
+    }
+}
 
 impl ITfThreadMgrEventSink_Impl for TextServiceFactory_Impl {
     #[macros::anyhow]
@@ -23,15 +72,20 @@ impl ITfThreadMgrEventSink_Impl for TextServiceFactory_Impl {
         focus: Option<&ITfDocumentMgr>,
         _prevfocus: Option<&ITfDocumentMgr>,
     ) -> Result<()> {
-        self.update_lang_bar()?;
-
         // if focus is changed, the text layout sink should be updated
         if let Some(focus) = focus {
             self.borrow_mut()?.advise_text_layout_sink(focus.clone())?;
         }
+        self.set_keyboard_disabled_for_document_mgr(focus)?;
 
         let actions = vec![ClientAction::EndComposition];
         self.handle_action(&actions, CompositionState::None)?;
+
+        if focus.is_none() {
+            let mut text_service = self.borrow_mut()?;
+            text_service.context = None;
+            let _ = text_service.unadvise_text_layout_sink();
+        }
 
         Ok(())
     }
@@ -43,6 +97,27 @@ impl ITfThreadMgrEventSink_Impl for TextServiceFactory_Impl {
 
     #[macros::anyhow]
     fn OnPopContext(&self, _pic: Option<&ITfContext>) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl ITfThreadFocusSink_Impl for TextServiceFactory_Impl {
+    #[macros::anyhow]
+    fn OnSetThreadFocus(&self) -> Result<()> {
+        let focus = {
+            let text_service = self.borrow()?;
+            let thread_mgr = text_service.thread_mgr()?;
+            unsafe { thread_mgr.GetFocus().ok() }
+        };
+        self.set_keyboard_disabled_for_document_mgr(focus.as_ref())?;
+
+        Ok(())
+    }
+
+    #[macros::anyhow]
+    fn OnKillThreadFocus(&self) -> Result<()> {
+        self.set_keyboard_disabled_state(true)?;
+
         Ok(())
     }
 }

--- a/crates/client/src/tsf/thread_mgr_event_sink.rs
+++ b/crates/client/src/tsf/thread_mgr_event_sink.rs
@@ -14,21 +14,26 @@ use super::factory::{TextServiceFactory, TextServiceFactory_Impl};
 
 impl TextServiceFactory {
     pub fn set_keyboard_disabled_state(&self, disabled: bool) -> Result<()> {
-        let changed = {
+        let (changed, ipc_service) = {
             let mut state = IMEState::get()?;
             let changed = state.keyboard_disabled != disabled;
             state.keyboard_disabled = disabled;
+            let ipc_service = if disabled {
+                state.ipc_service.clone()
+            } else {
+                None
+            };
 
-            if disabled {
-                if let Some(mut ipc_service) = state.ipc_service.clone() {
-                    let _ = ipc_service.hide_window();
-                    let _ = ipc_service.set_candidates(vec![]);
-                    state.ipc_service = Some(ipc_service);
-                }
-            }
-
-            changed
+            (changed, ipc_service)
         };
+
+        if let Some(mut ipc_service) = ipc_service {
+            let _ = ipc_service.hide_window();
+            let _ = ipc_service.set_candidates(vec![]);
+
+            let mut state = IMEState::get()?;
+            state.ipc_service = Some(ipc_service);
+        }
 
         if changed {
             self.update_lang_bar()?;

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -226,6 +226,8 @@ pub struct GeneralConfig {
     pub space_input: SpaceInputMode,
     #[serde(default)]
     pub numpad_input: NumpadInputMode,
+    #[serde(default)]
+    pub show_candidate_window_after_space: bool,
 }
 
 impl Default for GeneralConfig {
@@ -235,6 +237,7 @@ impl Default for GeneralConfig {
             symbol_style: SymbolStyle::CornerBracketMiddleDot,
             space_input: SpaceInputMode::AlwaysHalf,
             numpad_input: NumpadInputMode::DirectInput,
+            show_candidate_window_after_space: false,
         }
     }
 }
@@ -303,6 +306,20 @@ pub fn zenzai_cpu_backend_supported() -> bool {
     #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GeneralConfig;
+
+    #[test]
+    fn candidate_window_delay_defaults_to_off() {
+        let default_config = GeneralConfig::default();
+        assert!(!default_config.show_candidate_window_after_space);
+
+        let deserialized: GeneralConfig = serde_json::from_str("{}").unwrap();
+        assert!(!deserialized.show_candidate_window_after_space);
     }
 }
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -17,6 +17,8 @@ serde_json = "1.0"
 [dependencies.windows]
 version = "0.58.0"
 features = [
+    "Win32_Foundation",
     "Win32_System_Diagnostics_ToolHelp",
-    "Win32_System_Environment"
+    "Win32_System_Environment",
+    "Win32_Graphics_Gdi",
 ]

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -15,7 +15,7 @@ use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
 use tonic::transport::Server;
 use uiaccess::prepare_uiaccess_token;
-use utils::get_candidate_window_position;
+use utils::{get_candidate_window_position, CandidateRect};
 use windows::Win32::UI::WindowsAndMessaging::{
     SetWindowPos, HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SW_HIDE,
 };
@@ -29,6 +29,25 @@ pub mod indicator;
 pub mod ipc;
 pub mod uiaccess;
 pub mod utils;
+
+fn place_candidate_windows(
+    candidate_window: &tao::window::Window,
+    indicator_window: &tao::window::Window,
+    rect: CandidateRect,
+) {
+    let (x, y) = get_candidate_window_position(
+        rect.top,
+        rect.left,
+        rect.bottom,
+        rect.right,
+        candidate_window,
+    );
+    candidate_window.set_outer_position(PhysicalPosition::new(x as f64, y as f64));
+    indicator_window.set_outer_position(PhysicalPosition::new(
+        (rect.left - 45) as f64,
+        rect.bottom as f64,
+    ));
+}
 
 #[derive(Debug)]
 pub enum UserEvent {
@@ -147,6 +166,8 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
+    let mut last_candidate_rect: Option<CandidateRect> = None;
+
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
@@ -177,6 +198,9 @@ async fn main() -> anyhow::Result<()> {
                 UserEvent::UpdateHeight(height) => {
                     let width = candidate_window.inner_size().width as i32;
                     candidate_window.set_inner_size(LogicalSize::new(width, height));
+                    if let Some(rect) = last_candidate_rect {
+                        place_candidate_windows(&candidate_window, &indicator_window, rect);
+                    }
                 }
                 UserEvent::WindowAction(action) => {
                     match action {
@@ -222,13 +246,8 @@ async fn main() -> anyhow::Result<()> {
                             bottom,
                             right,
                         } => {
-                            let (x, y) = get_candidate_window_position(
-                                top,
-                                left,
-                                bottom,
-                                right,
-                                &candidate_window,
-                            );
+                            let rect = CandidateRect::new(top, left, bottom, right);
+                            last_candidate_rect = Some(rect);
 
                             unsafe {
                                 let _ = SetWindowPos(
@@ -251,12 +270,7 @@ async fn main() -> anyhow::Result<()> {
                                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
                                 );
                             }
-                            candidate_window
-                                .set_outer_position(PhysicalPosition::new(x as f64, y as f64));
-                            indicator_window.set_outer_position(PhysicalPosition::new(
-                                (left - 45) as f64,
-                                bottom as f64,
-                            ));
+                            place_candidate_windows(&candidate_window, &indicator_window, rect);
                         }
                         WindowAction::SetCandidate { candidates } => {
                             let max_len = candidates
@@ -278,6 +292,9 @@ async fn main() -> anyhow::Result<()> {
                             event_loop_proxy
                                 .send_event(UserEvent::UpdateCandidates(candidates))
                                 .unwrap();
+                            if let Some(rect) = last_candidate_rect {
+                                place_candidate_windows(&candidate_window, &indicator_window, rect);
+                            }
                         }
                         WindowAction::SetSelection { index } => {
                             event_loop_proxy

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -30,6 +30,8 @@ pub mod ipc;
 pub mod uiaccess;
 pub mod utils;
 
+const INDICATOR_WINDOW_LEFT_OFFSET: i32 = 45;
+
 fn place_candidate_windows(
     candidate_window: &tao::window::Window,
     indicator_window: &tao::window::Window,
@@ -42,9 +44,9 @@ fn place_candidate_windows(
         rect.right,
         candidate_window,
     );
-    candidate_window.set_outer_position(PhysicalPosition::new(x as f64, y as f64));
+    candidate_window.set_outer_position(PhysicalPosition::new(x, y));
     indicator_window.set_outer_position(PhysicalPosition::new(
-        (rect.left - 45) as f64,
+        (rect.left - INDICATOR_WINDOW_LEFT_OFFSET) as f64,
         rect.bottom as f64,
     ));
 }

--- a/crates/ui/src/utils.rs
+++ b/crates/ui/src/utils.rs
@@ -4,6 +4,40 @@ use windows::Win32::{
     Graphics::Gdi::{GetMonitorInfoW, MonitorFromRect, MONITORINFO, MONITOR_DEFAULTTONEAREST},
 };
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CandidateRect {
+    pub top: i32,
+    pub left: i32,
+    pub bottom: i32,
+    pub right: i32,
+}
+
+impl CandidateRect {
+    pub fn new(top: i32, left: i32, bottom: i32, right: i32) -> Self {
+        Self {
+            top,
+            left,
+            bottom,
+            right,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CandidateWindowSize {
+    pub width: i32,
+    pub height: i32,
+}
+
+impl CandidateWindowSize {
+    pub fn new(width: i32, height: i32) -> Self {
+        Self { width, height }
+    }
+}
+
+const CANDIDATE_X_OFFSET: i32 = 15;
+const CANDIDATE_Y_GAP: i32 = 6;
+
 pub fn get_candidate_window_position(
     top: i32,
     left: i32,
@@ -11,9 +45,7 @@ pub fn get_candidate_window_position(
     right: i32,
     window: &Window,
 ) -> (f64, f64) {
-    let mut x = left - 15;
-    let mut y = bottom;
-
+    let target_rect = CandidateRect::new(top, left, bottom, right);
     let monitor = unsafe {
         MonitorFromRect(
             &RECT {
@@ -33,26 +65,115 @@ pub fn get_candidate_window_position(
         let _ = GetMonitorInfoW(monitor, &mut monitor_info);
     }
 
-    // If the bottom of the candidate window is hidden, show it above
-    y = if y + window.inner_size().height as i32 > monitor_info.rcWork.bottom {
-        top - window.inner_size().height as i32
-    } else {
-        y
-    };
-
-    // If the right of the candidate window is hidden, show it to the left
-    x = if x + window.inner_size().width as i32 > monitor_info.rcWork.right {
-        monitor_info.rcWork.right - window.inner_size().width as i32
-    } else {
-        x
-    };
-
-    // If the left of the candidate window is hidden, show it to the right
-    x = if x < monitor_info.rcWork.left {
-        monitor_info.rcWork.left
-    } else {
-        x
-    };
+    let size = CandidateWindowSize::new(
+        window.inner_size().width as i32,
+        window.inner_size().height as i32,
+    );
+    let (x, y) = candidate_window_position(target_rect, size, monitor_info.rcWork);
 
     (x as f64, y as f64)
+}
+
+pub fn candidate_window_position(
+    target_rect: CandidateRect,
+    window_size: CandidateWindowSize,
+    work_area: RECT,
+) -> (i32, i32) {
+    let x = clamp_start(
+        target_rect.left - CANDIDATE_X_OFFSET,
+        window_size.width,
+        work_area.left,
+        work_area.right,
+    );
+
+    let below = target_rect.bottom + CANDIDATE_Y_GAP;
+    let above = target_rect.top - window_size.height - CANDIDATE_Y_GAP;
+    let y = if below + window_size.height <= work_area.bottom {
+        below
+    } else if above >= work_area.top {
+        above
+    } else {
+        let below_space = work_area.bottom.saturating_sub(target_rect.bottom);
+        let above_space = target_rect.top.saturating_sub(work_area.top);
+        let preferred = if below_space >= above_space {
+            below
+        } else {
+            above
+        };
+        clamp_start(
+            preferred,
+            window_size.height,
+            work_area.top,
+            work_area.bottom,
+        )
+    };
+
+    (x, y)
+}
+
+fn clamp_start(preferred: i32, length: i32, min: i32, max: i32) -> i32 {
+    if max <= min || length >= max - min {
+        return min;
+    }
+
+    preferred.clamp(min, max - length)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{candidate_window_position, CandidateRect, CandidateWindowSize};
+    use windows::Win32::Foundation::RECT;
+
+    fn work_area() -> RECT {
+        RECT {
+            left: 0,
+            top: 0,
+            right: 800,
+            bottom: 600,
+        }
+    }
+
+    #[test]
+    fn places_window_below_when_there_is_room() {
+        let pos = candidate_window_position(
+            CandidateRect::new(100, 100, 120, 180),
+            CandidateWindowSize::new(240, 120),
+            work_area(),
+        );
+
+        assert_eq!(pos, (85, 126));
+    }
+
+    #[test]
+    fn places_window_above_near_bottom_edge() {
+        let pos = candidate_window_position(
+            CandidateRect::new(560, 100, 580, 180),
+            CandidateWindowSize::new(240, 120),
+            work_area(),
+        );
+
+        assert_eq!(pos, (85, 434));
+    }
+
+    #[test]
+    fn clamps_window_to_right_edge() {
+        let pos = candidate_window_position(
+            CandidateRect::new(100, 760, 120, 780),
+            CandidateWindowSize::new(240, 120),
+            work_area(),
+        );
+
+        assert_eq!(pos, (560, 126));
+    }
+
+    #[test]
+    fn clamps_window_when_neither_vertical_side_fits() {
+        let pos = candidate_window_position(
+            CandidateRect::new(280, 100, 320, 180),
+            CandidateWindowSize::new(240, 500),
+            work_area(),
+        );
+
+        assert_eq!(pos, (85, 100));
+    }
 }

--- a/frontend/src/pages/general.tsx
+++ b/frontend/src/pages/general.tsx
@@ -21,6 +21,7 @@ type GeneralConfigState = {
     symbol_style: string;
     space_input: string;
     numpad_input: string;
+    show_candidate_window_after_space: boolean;
 };
 
 type CharacterWidthGroupsState = {
@@ -48,6 +49,7 @@ const DEFAULT_GENERAL_CONFIG: GeneralConfigState = {
     symbol_style: "corner_bracket_middle_dot",
     space_input: "always_half",
     numpad_input: "direct_input",
+    show_candidate_window_after_space: false,
 };
 
 const DEFAULT_WIDTH_GROUPS: CharacterWidthGroupsState = {
@@ -133,6 +135,10 @@ const normalizeGeneralConfig = (value?: Record<string, unknown>): GeneralConfigS
               : value?.numpad_input === "follow_input_mode"
                 ? "follow_input_mode"
                 : DEFAULT_GENERAL_CONFIG.numpad_input,
+    show_candidate_window_after_space:
+        typeof value?.show_candidate_window_after_space === "boolean"
+            ? value.show_candidate_window_after_space
+            : DEFAULT_GENERAL_CONFIG.show_candidate_window_after_space,
 });
 
 const normalizeWidthGroups = (
@@ -291,12 +297,23 @@ export const General = () => {
     };
 
     const updateGeneralConfig = async (
-        key: keyof GeneralConfigState,
+        key: keyof Omit<GeneralConfigState, "show_candidate_window_after_space">,
         nextValue: string,
     ) => {
         const data = await updateConfig((config) => {
             config.general = config.general ?? {};
             config.general[key] = nextValue;
+        });
+
+        if (data) {
+            setGeneralValue(normalizeGeneralConfig(data.general));
+        }
+    };
+
+    const updateCandidateWindowDelay = async (nextValue: boolean) => {
+        const data = await updateConfig((config) => {
+            config.general = config.general ?? {};
+            config.general.show_candidate_window_after_space = nextValue;
         });
 
         if (data) {
@@ -515,6 +532,19 @@ export const General = () => {
                                     </SelectContent>
                                 </Select>
                             </div>
+                        </div>
+
+                        <div className="flex items-center gap-4">
+                            <div className="flex-1 space-y-1">
+                                <p className="text-sm font-medium leading-none">候補ウィンドウを非表示</p>
+                                <p className="text-xs text-muted-foreground">
+                                    Space または Tab の入力まで候補を表示しません
+                                </p>
+                            </div>
+                            <Switch
+                                checked={generalValue.show_candidate_window_after_space}
+                                onCheckedChange={(value) => void updateCandidateWindowDelay(value)}
+                            />
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
## Summary
- 候補ウィンドウが入力中の文字や画面端に被りにくくなるよう、キャレット位置の保持と再配置処理を追加しました。
- Space / Tab 入力まで候補を表示しない設定を追加し、設定画面から切り替えられるようにしました。
- フォーカスなし・disabled context では IME を disabled 表示にし、候補表示やキー処理へ進まないようにしました。

## Background
- Issue: Closes #33
- 従来は候補ウィンドウが入力位置や画面端に被ることがあり、行頭入力時には古いキャレット矩形で表示されるケースがありました。
- 候補を Space まで出したくない用途に対する設定項目がありませんでした。
- フォーカスがない context でも A/あ 表示や候補表示が残ることがあり、MS-IME / Google 日本語入力に近い disabled 表示へ寄せる必要がありました。

## Changes
- client / TSF
  - `GUID_COMPARTMENT_KEYBOARD_DISABLED` と document manager/context の有無をもとに disabled 状態を反映
  - disabled 時に言語バー item を disabled status にし、候補ウィンドウを非表示化
  - 入力モード変更時の A/あ アイコン更新と、disabled 復帰時のキー処理を修正
- client / composition
  - 候補遅延表示設定を追加し、通常入力開始では候補を隠し、Space / Tab で初めて表示
  - `set_text` 後にキャレット位置を同期して候補ウィンドウを表示し、行頭入力時の被りを防止
- ui / frontend / shared
  - 候補ウィンドウ位置計算を作業領域内に収め、下優先・上 fallback・clamp を行うよう整理
  - `show_candidate_window_after_space` 設定と設定画面の Switch を追加
  - 位置計算、設定 default / serde fallback、disabled 時の回帰テストを追加

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/24828959466
- [x] Windows 実機確認
  - CI build インストーラーを実機へインストールし、候補ウィンドウ位置、設定 ON/OFF、フォーカスなし時の disabled 表示、A/あ アイコン切替を確認済み
- [x] ローカル Windows VM 事前確認
  - `PROTOC=/home/batao9/workspaces/azooKey-Windows/.local/tmp/protoc/bin/protoc cargo test -p shared candidate_window_delay_defaults_to_off`
  - `PROTOC=/home/batao9/workspaces/azooKey-Windows/.local/tmp/protoc/bin/protoc cargo check --target x86_64-pc-windows-msvc -p azookey-windows --tests`
  - `cd frontend && npm run build`
  - `.local/vm_build_master.sh feature/issue-33-candidate-window`
  - `.local/vm_stage_for_manual_test.sh latest`

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した