### PR TITLE
fix(composition): preserve terminal n conversion

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -221,6 +221,18 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn should_shrink_before_direct_append(
+        composition: &Composition,
+        start_temporary_latin: bool,
+    ) -> bool {
+        start_temporary_latin
+            && composition.raw_input.ends_with('n')
+            && composition.raw_hiragana.ends_with('ん')
+            && Self::current_raw_suffix(&composition.raw_hiragana, composition.corresponding_count)
+                .is_empty()
+    }
+
+    #[inline]
     fn normalize_direct_symbol_char(c: char) -> char {
         let halfwidth_ascii = Self::to_halfwidth_ascii_char(c);
         if halfwidth_ascii.is_ascii_punctuation() {
@@ -2317,7 +2329,12 @@ impl TextServiceFactory {
                     if start_temporary_latin {
                         actions.push(ClientAction::SetTemporaryLatin(true));
                     }
-                    actions.push(ClientAction::AppendTextDirect(text));
+                    if Self::should_shrink_before_direct_append(composition, start_temporary_latin)
+                    {
+                        actions.push(ClientAction::ShrinkTextDirect(text));
+                    } else {
+                        actions.push(ClientAction::AppendTextDirect(text));
+                    }
                     Some((CompositionState::Composing, actions))
                 }
                 UserAction::NumpadSymbol(symbol) if *mode == InputMode::Kana => {

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -228,8 +228,11 @@ impl TextServiceFactory {
         start_temporary_latin
             && composition.raw_input.ends_with('n')
             && composition.raw_hiragana.ends_with('ん')
-            && Self::current_raw_suffix(&composition.raw_hiragana, composition.corresponding_count)
-                .is_empty()
+            && Self::current_raw_input_suffix(
+                &composition.raw_input,
+                composition.corresponding_count,
+            )
+            .is_empty()
     }
 
     #[inline]
@@ -1460,6 +1463,14 @@ impl TextServiceFactory {
     #[inline]
     fn current_raw_suffix(raw_hiragana: &str, corresponding_count: i32) -> String {
         raw_hiragana
+            .chars()
+            .skip(corresponding_count.max(0) as usize)
+            .collect()
+    }
+
+    #[inline]
+    fn current_raw_input_suffix(raw_input: &str, corresponding_count: i32) -> String {
+        raw_input
             .chars()
             .skip(corresponding_count.max(0) as usize)
             .collect()

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -193,3 +193,33 @@ fn temporary_latin_keeps_direct_append_without_finalized_terminal_n() {
         ]
     );
 }
+
+#[test]
+fn temporary_latin_keeps_direct_append_when_raw_input_suffix_remains() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        preview: "かん".to_string(),
+        raw_input: "kann".to_string(),
+        raw_hiragana: "かんん".to_string(),
+        corresponding_count: 3,
+        ..Composition::default()
+    };
+
+    let (_, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Input('Ａ'),
+        &InputMode::Kana,
+        true,
+        &AppConfig::default(),
+        true,
+    )
+    .expect("temporary latin should keep direct append when suffix remains");
+
+    assert_eq!(
+        actions,
+        vec![
+            ClientAction::SetTemporaryLatin(true),
+            ClientAction::AppendTextDirect("A".to_string()),
+        ]
+    );
+}

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -112,3 +112,84 @@ fn delayed_candidate_window_shows_when_space_opens_preview() {
         ]
     );
 }
+
+#[test]
+fn fkeys_use_finalized_terminal_n_hiragana() {
+    assert_eq!(
+        TextServiceFactory::converted_clause_preview_text(
+            &SetTextType::Hiragana,
+            "kagen",
+            "かげん",
+        ),
+        "かげん"
+    );
+    assert_eq!(
+        TextServiceFactory::converted_clause_preview_text(
+            &SetTextType::Katakana,
+            "kagen",
+            "かげん",
+        ),
+        "カゲン"
+    );
+}
+
+#[test]
+fn temporary_latin_after_finalized_terminal_n_starts_direct_remainder() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        preview: "加減".to_string(),
+        raw_input: "kagen".to_string(),
+        raw_hiragana: "かげん".to_string(),
+        corresponding_count: 5,
+        ..Composition::default()
+    };
+
+    let (transition, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Input('Ａ'),
+        &InputMode::Kana,
+        true,
+        &AppConfig::default(),
+        true,
+    )
+    .expect("temporary latin should append direct text");
+
+    assert_eq!(transition, CompositionState::Composing);
+    assert_eq!(
+        actions,
+        vec![
+            ClientAction::SetTemporaryLatin(true),
+            ClientAction::ShrinkTextDirect("A".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn temporary_latin_keeps_direct_append_without_finalized_terminal_n() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        preview: "かげn".to_string(),
+        raw_input: "kagen".to_string(),
+        raw_hiragana: "かげn".to_string(),
+        corresponding_count: 5,
+        ..Composition::default()
+    };
+
+    let (_, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Input('Ａ'),
+        &InputMode::Kana,
+        true,
+        &AppConfig::default(),
+        true,
+    )
+    .expect("temporary latin should append direct text");
+
+    assert_eq!(
+        actions,
+        vec![
+            ClientAction::SetTemporaryLatin(true),
+            ClientAction::AppendTextDirect("A".to_string()),
+        ]
+    );
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -97,6 +97,11 @@ struct RawComposingText {
     cursor: i8,
 }
 
+struct ComposedText {
+    hiragana: Option<String>,
+    suggestions: Vec<Suggestion>,
+}
+
 #[derive(Debug, Clone)]
 #[repr(C)]
 struct FFICandidate {
@@ -360,7 +365,7 @@ fn update_active_composition_state(text: &str) {
     HAS_ACTIVE_COMPOSITION.store(!text.is_empty(), Ordering::Relaxed);
 }
 
-fn get_composed_text(use_cursor_prefix: bool) -> Result<Vec<Suggestion>, String> {
+fn get_composed_text(use_cursor_prefix: bool) -> Result<ComposedText, String> {
     unsafe {
         let mut length: c_int = 0;
         let result = if use_cursor_prefix {
@@ -385,6 +390,7 @@ fn get_composed_text(use_cursor_prefix: bool) -> Result<Vec<Suggestion>, String>
         }
 
         let mut suggestions = Vec::with_capacity(length);
+        let mut hiragana = None;
         log_event_lazy!(
             ServerLogLevel::Debug,
             "[{call_name}] candidate_count={length}"
@@ -411,6 +417,14 @@ fn get_composed_text(use_cursor_prefix: bool) -> Result<Vec<Suggestion>, String>
                 continue;
             }
 
+            if hiragana.is_none() && !candidate.hiragana.is_null() {
+                hiragana = Some(
+                    CStr::from_ptr(candidate.hiragana)
+                        .to_string_lossy()
+                        .into_owned(),
+                );
+            }
+
             let text = CStr::from_ptr(candidate.text)
                 .to_string_lossy()
                 .into_owned();
@@ -434,7 +448,10 @@ fn get_composed_text(use_cursor_prefix: bool) -> Result<Vec<Suggestion>, String>
             suggestions.push(suggestion);
         }
 
-        Ok(suggestions)
+        Ok(ComposedText {
+            hiragana,
+            suggestions,
+        })
     }
 }
 
@@ -479,7 +496,7 @@ impl AzookeyService for MyAzookeyService {
             "[append_text:{request_id}] add_text elapsed_ms={}",
             t1.saturating_sub(t0)
         );
-        let suggestions =
+        let composed_text =
             get_composed_text(false).map_err(|error| status_from_error("append_text", error))?;
         let t2 = now_timestamp_millis();
         log_event_lazy!(
@@ -494,14 +511,14 @@ impl AzookeyService for MyAzookeyService {
             "[append_text:{request_id}] success cursor={} hiragana_len={} suggestions={} total_elapsed_ms={}",
             composing_text.cursor,
             composing_text.text.chars().count(),
-            suggestions.len(),
+            composed_text.suggestions.len(),
             t2.saturating_sub(handler_start)
         );
 
         Ok(Response::new(AppendTextResponse {
             composing_text: Some(ComposingText {
-                hiragana: composing_text.text,
-                suggestions,
+                hiragana: composed_text.hiragana.unwrap_or(composing_text.text),
+                suggestions: composed_text.suggestions,
             }),
         }))
     }
@@ -523,7 +540,7 @@ impl AzookeyService for MyAzookeyService {
             "[remove_text:{request_id}] remove_text elapsed_ms={}",
             t1.saturating_sub(t0)
         );
-        let suggestions =
+        let composed_text =
             get_composed_text(false).map_err(|error| status_from_error("remove_text", error))?;
         let t2 = now_timestamp_millis();
         log_event_lazy!(
@@ -538,14 +555,14 @@ impl AzookeyService for MyAzookeyService {
             "[remove_text:{request_id}] success cursor={} hiragana_len={} suggestions={} total_elapsed_ms={}",
             composing_text.cursor,
             composing_text.text.chars().count(),
-            suggestions.len(),
+            composed_text.suggestions.len(),
             t2.saturating_sub(handler_start)
         );
 
         Ok(Response::new(RemoveTextResponse {
             composing_text: Some(ComposingText {
-                hiragana: composing_text.text,
-                suggestions,
+                hiragana: composed_text.hiragana.unwrap_or(composing_text.text),
+                suggestions: composed_text.suggestions,
             }),
         }))
     }
@@ -573,7 +590,7 @@ impl AzookeyService for MyAzookeyService {
             "[move_cursor:{request_id}] move_cursor elapsed_ms={}",
             t1.saturating_sub(t0)
         );
-        let suggestions = get_composed_text(use_cursor_prefix)
+        let composed_text = get_composed_text(use_cursor_prefix)
             .map_err(|error| status_from_error("move_cursor", error))?;
         let t2 = now_timestamp_millis();
         log_event_lazy!(
@@ -588,14 +605,14 @@ impl AzookeyService for MyAzookeyService {
             "[move_cursor:{request_id}] success cursor={} hiragana_len={} suggestions={} use_cursor_prefix={use_cursor_prefix} total_elapsed_ms={}",
             composing_text.cursor,
             composing_text.text.chars().count(),
-            suggestions.len(),
+            composed_text.suggestions.len(),
             t2.saturating_sub(handler_start)
         );
 
         Ok(Response::new(MoveCursorResponse {
             composing_text: Some(ComposingText {
-                hiragana: composing_text.text,
-                suggestions,
+                hiragana: composed_text.hiragana.unwrap_or(composing_text.text),
+                suggestions: composed_text.suggestions,
             }),
         }))
     }
@@ -642,7 +659,7 @@ impl AzookeyService for MyAzookeyService {
             "[shrink_text:{request_id}] shrink_text elapsed_ms={}",
             t1.saturating_sub(t0)
         );
-        let suggestions =
+        let composed_text =
             get_composed_text(false).map_err(|error| status_from_error("shrink_text", error))?;
         let t2 = now_timestamp_millis();
         log_event_lazy!(
@@ -656,14 +673,14 @@ impl AzookeyService for MyAzookeyService {
             ServerLogLevel::Info,
             "[shrink_text:{request_id}] success hiragana_len={} suggestions={} total_elapsed_ms={}",
             composing_text.text.chars().count(),
-            suggestions.len(),
+            composed_text.suggestions.len(),
             t2.saturating_sub(handler_start)
         );
 
         Ok(Response::new(ShrinkTextResponse {
             composing_text: Some(ComposingText {
-                hiragana: composing_text.text,
-                suggestions,
+                hiragana: composed_text.hiragana.unwrap_or(composing_text.text),
+                suggestions: composed_text.suggestions,
             }),
         }))
     }


### PR DESCRIPTION
## Summary
- 文末 `n` が `ん` として扱われている状態で、F6/F7 や Shift+英字で `n` に戻る問題を修正しました。
- サーバが返す composing hiragana に terminal `n` の正規化結果を反映し、クライアント側でも一時英数入力開始時の direct append を調整しました。
- F6/F7 と一時英数入力の回帰 test を追加しました。

## Background
- Issue: Closes #30
- `kagen` のような入力では候補生成時には `かげん` として扱われる一方、`ComposingText.hiragana` には元の `かげn` が残っていました。
- そのため F6/F7 の表示変換や Shift+英字開始時の処理が `n` を参照し、`ん` が `n` に戻ることがありました。

## Changes
- server / Rust bridge
  - FFI candidate の `hiragana` を `ComposingText.hiragana` に反映し、候補側で正規化された terminal `n` を composing text に引き継ぐよう修正
- client / composition
  - 文末 `n` が `ん` に対応する状態で Shift+英字から一時英数入力を始めるときは `ShrinkTextDirect` を使うよう修正
  - F6/F7 と一時英数入力の回帰 test を追加

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/24861728405
- [x] Windows 実機確認
  - ユーザー確認済み
- [x] ローカル Windows VM 事前確認
  - `.local/vm_build_master.sh fix/issue-30-terminal-n-conversion`
  - `.local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-fix_issue-30-terminal-n-conversion-20260423-212256.exe`

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した
