### PR TITLE
chore(repo): add upstream license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 fkunn1326
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- upstream/master で追加された `LICENSE` を fork 側にも取り込みました。
- 追加内容は upstream の `65835aa Create LICENSE` に合わせた MIT License です。

## Background
- Issue: N/A
- fork 元リポジトリでライセンスファイルが追加されていたため、こちらのリポジトリにも同じ内容を反映します。

## Changes
- repo
  - ルートに `LICENSE` を追加

## Verification
- [ ] GitHub Actions build 成功
  - run: 実行中
- [x] 差分確認
  - `LICENSE` のみ追加されていることを確認
- [x] ローカル確認
  - upstream/master の `LICENSE` 内容と一致することを確認
  - コード変更ではないため追加の test は未実施

## Checklist
- [ ] CI run URL と結果を記載した
- [x] 影響範囲を確認した
