### PR TITLE
chore(release): prepare v0.1.0-batao.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 > 現在開発中であるため、安定性や機能に関しては保証できません。使用する際は自己責任でお願いします。
 
 # インストール方法
-[Release](https://github.com/fkunn1326/azooKey-Windows/releases)から`azookey-setup.exe`をダウンロードし、インストーラーを実行してください。
+[Release](https://github.com/batao9/azooKey-Windows/releases)からazookey-setup.exeをダウンロードし、インストーラーを実行してください。
+こちらは fkunn1326/azooKey-Windows の fork ですので注意してください。
 
 # 機能
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "0.1.0-batao.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0",
+      "version": "0.1.0-batao.1",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-dialog": "^1.1.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.0-batao.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Azookey",
-  "version": "0.1.0",
+  "version": "0.1.0-batao.1",
   "identifier": "com.azookey.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/frontend/src/pages/general.tsx
+++ b/frontend/src/pages/general.tsx
@@ -431,11 +431,11 @@ export const General = () => {
                     <div className="flex items-center space-x-4 rounded-md border p-4">
                         <RefreshCcw />
                         <div className="flex-1 space-y-1">
-                            <p className="text-sm font-medium leading-none">v0.1.0-alpha.1</p>
+                            <p className="text-sm font-medium leading-none">v0.1.0-batao.1</p>
                         </div>
                         <Button variant="secondary">
                             <a
-                                href="https://github.com/fkunn1326/azooKey-Windows/releases"
+                                href="https://github.com/batao9/azooKey-Windows/releases"
                                 className="flex items-center gap-x-2"
                                 target="_blank"
                                 rel="noopener noreferrer"

--- a/installer/Installer.iss
+++ b/installer/Installer.iss
@@ -3,9 +3,9 @@
 #include "CodeDependencies.iss"
 
 #define MyAppName "Azookey"
-#define MyAppVersion "0.1.0-alpha.1"
-#define MyAppPublisher "fkunn1326"
-#define MyAppURL "https://github.com/fkunn1326/azooKey-Windows/"
+#define MyAppVersion "0.1.0-batao.1"
+#define MyAppPublisher "batao9"
+#define MyAppURL "https://github.com/batao9/azooKey-Windows/"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -43,7 +43,7 @@ Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Source: "../build/azookey_windows.dll"; DestDir: "{app}"; DestName: "azookey.dll"; Flags: ignoreversion regserver 64bit
 Source: "../build/x86/azookey_windows.dll"; DestDir: "{app}"; DestName: "azookey32.dll"; Flags: ignoreversion regserver 32bit
 Source: "../build/*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "../target/release/bundle/nsis/Azookey_0.1.0_x64-setup.exe"; Flags: dontcopy noencryption
+Source: "../target/release/bundle/nsis/Azookey_0.1.0-batao.1_x64-setup.exe"; Flags: dontcopy noencryption
 Source: "./Azookey Startup.xml"; Flags: dontcopy noencryption
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
@@ -65,10 +65,10 @@ Filename: "schtasks"; \
 [Code]
 function InitializeSetup: Boolean;
 begin
-  ExtractTemporaryFile('Azookey_0.1.0_x64-setup.exe');
+  ExtractTemporaryFile('Azookey_0.1.0-batao.1_x64-setup.exe');
   Dependency_AddVC2015To2022x64;
   Dependency_AddVC2015To2022x86;
-  Dependency_Add('Azookey_0.1.0_x64-setup.exe',
+  Dependency_Add('Azookey_0.1.0-batao.1_x64-setup.exe',
     '/S',
     'Azookey',
     '', '', True, False);


### PR DESCRIPTION
## Summary
- 初回 fork release 向けにアプリ版数を `0.1.0-batao.1` へ更新
- 設定画面の更新確認リンクと Inno Setup の公開先 URL を fork 側へ更新
- README の release 導線を fork 側に寄せ、fork である旨を明記

## Background
- Issue: N/A
- GitHub Release を fork 側で配布するため、アプリ内表示と release 導線を fork リポジトリに揃える必要がありました。

## Changes
- frontend / tauri
  - app version を `0.1.0-batao.1` に更新
  - 設定画面のバージョン表示と releases リンクを fork 側へ更新
- installer
  - Inno Setup の version / publisher / URL / 内包する NSIS installer 名を fork release 向けに更新
- docs
  - README の release リンクを fork 側へ更新し、fork である旨を追記

## Verification
- [ ] GitHub Actions build 成功
  - run: 未実行
- [x] 設定値確認
  - `frontend/src-tauri/tauri.conf.json` の version が `0.1.0-batao.1` であることを確認
  - README と設定画面リンクが `batao9/azooKey-Windows` を向くことを確認

## Checklist
- [ ] CI run URL と結果を記載した
- [x] 影響範囲を確認した
