### PR TITLE
fix(release): bundle nsis only for fork version

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": "nsis",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary
- fork 版の app version `0.1.0-batao.1` で Windows bundle build が通るように、Tauri の bundle target を NSIS のみに絞りました。

## Background
- Issue: N/A
- `0.1.0-batao.1` は MSI target の version 制約に引っかかり、`targets: "all"` のままだと CI build が失敗していました。
- 現在の配布導線では NSIS を内包した Inno Setup installer を使っているため、bundle target は NSIS のみで問題ありません。

## Changes
- frontend / tauri
  - `bundle.targets` を `all` から `nsis` に変更

## Verification
- [ ] GitHub Actions build 成功
  - run: 未実行
- [x] CI failure root cause を確認
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/24884390606

## Checklist
- [ ] CI run URL と結果を記載した
- [x] 影響範囲を確認した
