### PR TITLE
fix(composition): support auto clause navigation

### DIFF
--- a/crates/client/src/engine/client_action.rs
+++ b/crates/client/src/engine/client_action.rs
@@ -18,6 +18,7 @@ pub enum ClientAction {
     SetTextWithType(SetTextType),
 
     MoveCursor(i32),
+    EnsureClauseNavigationReady,
     MoveClause(i32),
     AdjustBoundary(i32),
     SetSelection(SetSelectionType),

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -615,6 +615,21 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn display_suffix_after_selected_clause(
+        preview: &str,
+        fixed_prefix: &str,
+        current_suffix: &str,
+        selected: &CandidateSelection,
+    ) -> String {
+        let current_preview = Self::current_clause_preview(preview, fixed_prefix);
+        current_preview
+            .strip_prefix(&selected.text)
+            .or_else(|| current_suffix.strip_prefix(&selected.text))
+            .map(str::to_string)
+            .unwrap_or_else(|| selected.sub_text.clone())
+    }
+
+    #[inline]
     fn merge_preview_with_prefix(fixed_prefix: &str, clause_preview: &str) -> String {
         if fixed_prefix.is_empty() {
             clause_preview.to_string()
@@ -1172,8 +1187,14 @@ impl TextServiceFactory {
         *state.candidates = navigation_candidates;
         *state.selection_index = selected.index;
         *state.corresponding_count = selected.corresponding_count;
+        let display_suffix = Self::display_suffix_after_selected_clause(
+            state.preview,
+            state.fixed_prefix,
+            state.suffix,
+            &selected,
+        );
         *state.preview = Self::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
-        *state.suffix = selected.sub_text.clone();
+        *state.suffix = display_suffix;
         *state.raw_hiragana = selected.hiragana;
         *state.current_clause_is_split_derived = true;
         *state.current_clause_is_direct_split_remainder = false;
@@ -1302,9 +1323,15 @@ impl TextServiceFactory {
                 *state.current_clause_split_group_id = None;
                 *state.selection_index = selected.index;
                 *state.corresponding_count = selected.corresponding_count;
+                let display_suffix = Self::display_suffix_after_selected_clause(
+                    state.preview,
+                    state.fixed_prefix,
+                    state.suffix,
+                    &selected,
+                );
                 *state.preview =
                     Self::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
-                *state.suffix = selected.sub_text.clone();
+                *state.suffix = display_suffix;
                 *state.raw_hiragana = selected.hiragana;
                 return Ok(ClauseActionEffect::applied(true));
             }

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1419,6 +1419,14 @@ impl TextServiceFactory {
             state.suffix,
             &selected,
         );
+        selected.sub_text = display_suffix.clone();
+        if let Some(sub_text) = state
+            .candidates
+            .sub_texts
+            .get_mut(selected.index.max(0) as usize)
+        {
+            *sub_text = display_suffix.clone();
+        }
         *state.preview = Self::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
         *state.suffix = display_suffix;
         *state.raw_hiragana = selected.hiragana.clone();
@@ -2001,6 +2009,65 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn trusted_raw_hiragana_suffix(raw_hiragana: &str, raw_suffix_hint: &str) -> Option<String> {
+        (!raw_suffix_hint.is_empty() && raw_hiragana.ends_with(raw_suffix_hint))
+            .then(|| raw_suffix_hint.to_string())
+    }
+
+    #[inline]
+    fn common_suffix_char_count(left: &str, right: &str) -> usize {
+        left.chars()
+            .rev()
+            .zip(right.chars().rev())
+            .take_while(|(left, right)| left == right)
+            .count()
+    }
+
+    #[inline]
+    fn recover_single_n_raw_hiragana_suffix(
+        full_raw_hiragana: &str,
+        server_raw_hiragana: &str,
+    ) -> Option<String> {
+        if server_raw_hiragana.is_empty() {
+            return None;
+        }
+
+        if full_raw_hiragana.ends_with(server_raw_hiragana) {
+            return Some(server_raw_hiragana.to_string());
+        }
+
+        let common_suffix_len =
+            Self::common_suffix_char_count(full_raw_hiragana, server_raw_hiragana);
+        let server_len = server_raw_hiragana.chars().count();
+        if common_suffix_len == 0 || common_suffix_len + 1 != server_len {
+            return None;
+        }
+
+        let full_len = full_raw_hiragana.chars().count();
+        if full_len <= common_suffix_len {
+            return None;
+        }
+
+        Some(
+            full_raw_hiragana
+                .chars()
+                .skip(full_len - common_suffix_len - 1)
+                .collect(),
+        )
+    }
+
+    #[inline]
+    fn has_recoverable_single_n_raw_hiragana_suffix(
+        server_raw_hiragana: &str,
+        snapshot_raw_hiragana: &str,
+    ) -> bool {
+        !server_raw_hiragana.is_empty()
+            && server_raw_hiragana.chars().count() == snapshot_raw_hiragana.chars().count()
+            && Self::common_suffix_char_count(server_raw_hiragana, snapshot_raw_hiragana) + 1
+                == snapshot_raw_hiragana.chars().count()
+    }
+
+    #[inline]
     fn maybe_push_split_future_clause_snapshot(
         future_clause_snapshots: &mut Vec<FutureClauseSnapshot>,
         raw_input: &str,
@@ -2018,29 +2085,25 @@ impl TextServiceFactory {
             .last()
             .and_then(|snapshot| Self::restore_raw_suffix_from_sub_text(raw_suffix_hint, snapshot))
             .unwrap_or_else(|| raw_suffix_hint.to_string());
-        let has_matching_future_hint = !normalized_raw_suffix_hint.is_empty()
-            && future_clause_snapshots.last().is_some_and(|snapshot| {
-                Self::future_snapshot_matches_raw_suffix(snapshot, &normalized_raw_suffix_hint)
-            });
-        let mut raw_suffix =
-            if has_matching_future_hint {
-                normalized_raw_suffix_hint
-            } else if let Some(snapshot) = future_clause_snapshots.iter().rev().find(|snapshot| {
-                !raw_input_suffix.is_empty() && raw_input_suffix == snapshot.raw_input
-            }) {
-                snapshot.raw_hiragana.clone()
-            } else {
-                let raw_suffix = Self::current_raw_suffix(raw_hiragana, corresponding_count);
-                if raw_suffix.is_empty()
-                    && future_clause_snapshots.is_empty()
-                    && allow_bootstrap_without_existing_future
-                    && !normalized_raw_suffix_hint.is_empty()
-                {
-                    normalized_raw_suffix_hint
-                } else {
-                    raw_suffix
-                }
-            };
+        let mut raw_suffix = if let Some(snapshot) = future_clause_snapshots
+            .iter()
+            .rev()
+            .find(|snapshot| !raw_input_suffix.is_empty() && raw_input_suffix == snapshot.raw_input)
+        {
+            snapshot.raw_hiragana.clone()
+        } else if let Some(raw_suffix) =
+            Self::trusted_raw_hiragana_suffix(raw_hiragana, &normalized_raw_suffix_hint)
+        {
+            raw_suffix
+        } else if let Some(snapshot) = future_clause_snapshots.last().filter(|snapshot| {
+            Self::future_snapshot_matches_raw_suffix(snapshot, &normalized_raw_suffix_hint)
+        }) {
+            snapshot.raw_hiragana.clone()
+        } else if !future_clause_snapshots.is_empty() && !allow_bootstrap_without_existing_future {
+            Self::current_raw_suffix(raw_hiragana, corresponding_count)
+        } else {
+            String::new()
+        };
         if raw_suffix.is_empty() {
             return;
         }
@@ -2301,6 +2364,10 @@ impl TextServiceFactory {
             *state.current_clause_has_split_left_neighbor;
         let mut temp_current_clause_split_group_id = *state.current_clause_split_group_id;
         let mut temp_next_split_group_id = *state.next_split_group_id;
+        let initial_suffix = state.suffix.clone();
+        let initial_raw_input_suffix =
+            Self::current_raw_input_suffix(state.raw_input, *state.corresponding_count);
+        let initial_raw_hiragana = state.raw_hiragana.clone();
         let mut collected = Vec::new();
 
         loop {
@@ -2348,6 +2415,29 @@ impl TextServiceFactory {
                 snapshot.is_direct_split_remainder = true;
                 snapshot.has_split_left_neighbor = true;
                 snapshot.split_group_id = *state.current_clause_split_group_id;
+                if temp_suffix.is_empty()
+                    && !initial_suffix.is_empty()
+                    && !initial_raw_input_suffix.is_empty()
+                    && temp_raw_input == initial_raw_input_suffix
+                {
+                    if let Some(raw_hiragana_suffix) = Self::recover_single_n_raw_hiragana_suffix(
+                        &initial_raw_hiragana,
+                        &snapshot.raw_hiragana,
+                    ) {
+                        let mut repaired_snapshot = Self::build_conservative_future_clause_snapshot(
+                            &initial_suffix,
+                            "",
+                            &initial_raw_input_suffix,
+                            &raw_hiragana_suffix,
+                            initial_raw_input_suffix.chars().count() as i32,
+                        );
+                        repaired_snapshot.is_split_derived = true;
+                        repaired_snapshot.is_direct_split_remainder = true;
+                        repaired_snapshot.has_split_left_neighbor = true;
+                        repaired_snapshot.split_group_id = *state.current_clause_split_group_id;
+                        snapshot = repaired_snapshot;
+                    }
+                }
             } else {
                 snapshot.is_split_derived = temp_current_clause_is_split_derived;
                 snapshot.is_direct_split_remainder = temp_current_clause_is_direct_split_remainder;
@@ -2465,6 +2555,10 @@ impl TextServiceFactory {
                         .starts_with(&snapshot.raw_hiragana)
                     || server_candidates.hiragana.ends_with(&snapshot.raw_hiragana)
                     || snapshot.raw_hiragana.ends_with(&server_candidates.hiragana)
+                    || Self::has_recoverable_single_n_raw_hiragana_suffix(
+                        &server_candidates.hiragana,
+                        &snapshot.raw_hiragana,
+                    )
             })
             .unwrap_or(false)
     }

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -608,6 +608,13 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn candidate_splits_raw_input(selected: &CandidateSelection, raw_input: &str) -> bool {
+        selected.corresponding_count > 0
+            && selected.corresponding_count < raw_input.chars().count() as i32
+            && !selected.sub_text.is_empty()
+    }
+
+    #[inline]
     fn merge_preview_with_prefix(fixed_prefix: &str, clause_preview: &str) -> String {
         if fixed_prefix.is_empty() {
             clause_preview.to_string()
@@ -1022,6 +1029,7 @@ impl TextServiceFactory {
             ClientAction::CommitTextDirect(_) => "CommitTextDirect",
             ClientAction::RemoveText => "RemoveText",
             ClientAction::MoveCursor(_) => "MoveCursor",
+            ClientAction::EnsureClauseNavigationReady => "EnsureClauseNavigationReady",
             ClientAction::MoveClause(_) => "MoveClause",
             ClientAction::AdjustBoundary(_) => "AdjustBoundary",
             ClientAction::SetIMEMode(_) => "SetIMEMode",
@@ -1121,6 +1129,61 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn is_clause_navigation_active(composition: &Composition) -> bool {
+        !composition.clause_snapshots.is_empty()
+            || !composition.future_clause_snapshots.is_empty()
+            || composition.current_clause_is_split_derived
+            || composition.current_clause_split_group_id.is_some()
+    }
+
+    #[inline]
+    fn is_clause_navigation_state_active(state: &ClauseActionStateMut<'_>) -> bool {
+        !state.clause_snapshots.is_empty()
+            || !state.future_clause_snapshots.is_empty()
+            || *state.current_clause_is_split_derived
+            || state.current_clause_split_group_id.is_some()
+    }
+
+    #[inline]
+    fn ensure_clause_navigation_ready<B: ClauseActionBackend>(
+        state: &mut ClauseActionStateMut<'_>,
+        backend: &mut B,
+    ) -> Result<ClauseActionEffect> {
+        if Self::is_clause_navigation_state_active(state)
+            || state.candidates.texts.is_empty()
+            || state.raw_hiragana.is_empty()
+        {
+            return Ok(ClauseActionEffect::skipped());
+        }
+
+        if !state.suffix.is_empty() {
+            return Ok(ClauseActionEffect::skipped());
+        }
+
+        let navigation_candidates = backend.move_cursor(0)?;
+        let Some(selected) = Self::select_candidate(&navigation_candidates, 0) else {
+            return Ok(ClauseActionEffect::skipped());
+        };
+
+        if !Self::candidate_splits_raw_input(&selected, state.raw_input) {
+            return Ok(ClauseActionEffect::skipped());
+        }
+
+        *state.candidates = navigation_candidates;
+        *state.selection_index = selected.index;
+        *state.corresponding_count = selected.corresponding_count;
+        *state.preview = Self::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
+        *state.suffix = selected.sub_text.clone();
+        *state.raw_hiragana = selected.hiragana;
+        *state.current_clause_is_split_derived = true;
+        *state.current_clause_is_direct_split_remainder = false;
+        *state.current_clause_has_split_left_neighbor = false;
+        *state.current_clause_split_group_id = None;
+
+        Ok(ClauseActionEffect::applied(true))
+    }
+
+    #[inline]
     fn apply_move_clause<B: ClauseActionBackend>(
         state: &mut ClauseActionStateMut<'_>,
         backend: &mut B,
@@ -1192,12 +1255,47 @@ impl TextServiceFactory {
                     );
                     return Ok(ClauseActionEffect::applied(true));
                 }
-            } else if let Some(selected) =
-                Self::select_candidate(state.candidates, *state.selection_index)
-            {
+            } else {
                 if !state.future_clause_snapshots.is_empty() {
                     state.future_clause_snapshots.clear();
                 }
+
+                if state.future_clause_snapshots.is_empty() {
+                    let navigation_candidates = backend.move_cursor(0)?;
+                    if let Some(navigation_selected) =
+                        Self::select_candidate(&navigation_candidates, 0)
+                    {
+                        if Self::candidate_splits_raw_input(&navigation_selected, state.raw_input) {
+                            *state.candidates = navigation_candidates;
+                            *state.selection_index = navigation_selected.index;
+                        }
+                    }
+                }
+
+                let Some(selected) =
+                    Self::select_candidate(state.candidates, *state.selection_index)
+                else {
+                    let _ = backend.move_cursor(Self::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT)?;
+                    if let Some(restored) = state.clause_snapshots.pop() {
+                        *state.preview = restored.preview;
+                        *state.suffix = restored.suffix;
+                        *state.raw_input = restored.raw_input;
+                        *state.raw_hiragana = restored.raw_hiragana;
+                        *state.fixed_prefix = restored.fixed_prefix;
+                        *state.corresponding_count = restored.corresponding_count;
+                        *state.selection_index = restored.selection_index;
+                        *state.current_clause_is_split_derived = restored.is_split_derived;
+                        *state.current_clause_is_direct_split_remainder =
+                            restored.is_direct_split_remainder;
+                        *state.current_clause_has_split_left_neighbor =
+                            restored.has_split_left_neighbor;
+                        *state.current_clause_split_group_id = restored.split_group_id;
+                        *state.candidates = restored.candidates;
+                        return Ok(ClauseActionEffect::applied(true));
+                    }
+                    return Ok(ClauseActionEffect::skipped());
+                };
+
                 *state.current_clause_is_split_derived = false;
                 *state.current_clause_is_direct_split_remainder = false;
                 *state.current_clause_has_split_left_neighbor = false;
@@ -1209,25 +1307,6 @@ impl TextServiceFactory {
                 *state.suffix = selected.sub_text.clone();
                 *state.raw_hiragana = selected.hiragana;
                 return Ok(ClauseActionEffect::applied(true));
-            } else {
-                let _ = backend.move_cursor(Self::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT)?;
-                if let Some(restored) = state.clause_snapshots.pop() {
-                    *state.preview = restored.preview;
-                    *state.suffix = restored.suffix;
-                    *state.raw_input = restored.raw_input;
-                    *state.raw_hiragana = restored.raw_hiragana;
-                    *state.fixed_prefix = restored.fixed_prefix;
-                    *state.corresponding_count = restored.corresponding_count;
-                    *state.selection_index = restored.selection_index;
-                    *state.current_clause_is_split_derived = restored.is_split_derived;
-                    *state.current_clause_is_direct_split_remainder =
-                        restored.is_direct_split_remainder;
-                    *state.current_clause_has_split_left_neighbor =
-                        restored.has_split_left_neighbor;
-                    *state.current_clause_split_group_id = restored.split_group_id;
-                    *state.candidates = restored.candidates;
-                    return Ok(ClauseActionEffect::applied(true));
-                }
             }
 
             Ok(ClauseActionEffect::skipped())
@@ -2199,6 +2278,15 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn commit_enter_actions(composition: &Composition) -> (CompositionState, Vec<ClientAction>) {
+        if Self::is_clause_navigation_active(composition) {
+            (CompositionState::None, vec![ClientAction::EndComposition])
+        } else {
+            Self::commit_current_clause_actions(composition)
+        }
+    }
+
+    #[inline]
     fn commit_first_clause_actions(
         composition: &Composition,
     ) -> (CompositionState, Vec<ClientAction>) {
@@ -2344,6 +2432,14 @@ impl TextServiceFactory {
         }
         actions.push(ClientAction::SetSelection(SetSelectionType::Down));
         actions
+    }
+
+    #[inline]
+    fn clause_navigation_actions(direction: i32) -> Vec<ClientAction> {
+        vec![
+            ClientAction::EnsureClauseNavigationReady,
+            ClientAction::MoveClause(direction),
+        ]
     }
 
     #[inline]
@@ -2519,7 +2615,8 @@ impl TextServiceFactory {
                         Some((CompositionState::Composing, vec![ClientAction::RemoveText]))
                     }
                 }
-                UserAction::Enter | UserAction::CommitAndNextClause => {
+                UserAction::Enter => Some(Self::commit_enter_actions(composition)),
+                UserAction::CommitAndNextClause => {
                     Some(Self::commit_current_clause_actions(composition))
                 }
                 UserAction::CommitFirstClause => {
@@ -2536,11 +2633,11 @@ impl TextServiceFactory {
                 UserAction::Navigation(direction) => match direction {
                     Navigation::Right => Some((
                         CompositionState::Composing,
-                        vec![ClientAction::MoveClause(1)],
+                        Self::clause_navigation_actions(1),
                     )),
                     Navigation::Left => Some((
                         CompositionState::Composing,
-                        vec![ClientAction::MoveClause(-1)],
+                        Self::clause_navigation_actions(-1),
                     )),
                     Navigation::Up => Some((
                         CompositionState::Previewing,
@@ -2669,7 +2766,8 @@ impl TextServiceFactory {
                         Some((CompositionState::Composing, vec![ClientAction::RemoveText]))
                     }
                 }
-                UserAction::Enter | UserAction::CommitAndNextClause => {
+                UserAction::Enter => Some(Self::commit_enter_actions(composition)),
+                UserAction::CommitAndNextClause => {
                     Some(Self::commit_current_clause_actions(composition))
                 }
                 UserAction::CommitFirstClause => {
@@ -2686,11 +2784,11 @@ impl TextServiceFactory {
                 UserAction::Navigation(direction) => match direction {
                     Navigation::Right => Some((
                         CompositionState::Composing,
-                        vec![ClientAction::MoveClause(1)],
+                        Self::clause_navigation_actions(1),
                     )),
                     Navigation::Left => Some((
                         CompositionState::Composing,
-                        vec![ClientAction::MoveClause(-1)],
+                        Self::clause_navigation_actions(-1),
                     )),
                     Navigation::Up => Some((
                         CompositionState::Previewing,
@@ -3271,6 +3369,84 @@ impl TextServiceFactory {
                         ipc_service.set_candidates(candidates.texts.clone())?;
                         ipc_service.set_selection(selection_index)?;
                         self.update_pos()?;
+                    }
+                }
+                ClientAction::EnsureClauseNavigationReady => {
+                    Self::log_clause_action_state(
+                        "before",
+                        action,
+                        &preview,
+                        &suffix,
+                        &raw_input,
+                        &raw_hiragana,
+                        &fixed_prefix,
+                        corresponding_count,
+                        selection_index,
+                        &candidates,
+                        &clause_snapshots,
+                        &future_clause_snapshots,
+                    );
+                    let effect = {
+                        let mut state = ClauseActionStateMut {
+                            preview: &mut preview,
+                            suffix: &mut suffix,
+                            raw_input: &mut raw_input,
+                            raw_hiragana: &mut raw_hiragana,
+                            fixed_prefix: &mut fixed_prefix,
+                            corresponding_count: &mut corresponding_count,
+                            selection_index: &mut selection_index,
+                            candidates: &mut candidates,
+                            clause_snapshots: &mut clause_snapshots,
+                            future_clause_snapshots: &mut future_clause_snapshots,
+                            current_clause_is_split_derived: &mut current_clause_is_split_derived,
+                            current_clause_is_direct_split_remainder:
+                                &mut current_clause_is_direct_split_remainder,
+                            current_clause_has_split_left_neighbor:
+                                &mut current_clause_has_split_left_neighbor,
+                            current_clause_split_group_id: &mut current_clause_split_group_id,
+                            next_split_group_id: &mut next_split_group_id,
+                        };
+                        Self::ensure_clause_navigation_ready(&mut state, &mut ipc_service)?
+                    };
+
+                    if effect.applied {
+                        self.sync_clause_action_ui(
+                            &preview,
+                            &suffix,
+                            &candidates,
+                            selection_index,
+                            &mut ipc_service,
+                            effect.update_pos,
+                        )?;
+                        Self::log_clause_action_state(
+                            "after",
+                            action,
+                            &preview,
+                            &suffix,
+                            &raw_input,
+                            &raw_hiragana,
+                            &fixed_prefix,
+                            corresponding_count,
+                            selection_index,
+                            &candidates,
+                            &clause_snapshots,
+                            &future_clause_snapshots,
+                        );
+                    } else {
+                        Self::log_clause_action_state(
+                            "skip",
+                            action,
+                            &preview,
+                            &suffix,
+                            &raw_input,
+                            &raw_hiragana,
+                            &fixed_prefix,
+                            corresponding_count,
+                            selection_index,
+                            &candidates,
+                            &clause_snapshots,
+                            &future_clause_snapshots,
+                        );
                     }
                 }
                 ClientAction::MoveClause(direction) => {

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -28,6 +28,10 @@ use windows::Win32::{
 };
 
 use anyhow::{Context, Result};
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash as _, Hasher as _},
+};
 
 #[derive(Default, Clone, PartialEq, Debug)]
 pub enum CompositionState {
@@ -162,13 +166,14 @@ impl ClauseActionEffect {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 struct MoveClauseProgressMarker {
-    preview: String,
-    suffix: String,
-    raw_input: String,
-    raw_hiragana: String,
-    fixed_prefix: String,
+    preview_len: usize,
+    suffix_len: usize,
+    raw_input_len: usize,
+    raw_hiragana_len: usize,
+    fixed_prefix_len: usize,
+    text_hash: u64,
     corresponding_count: i32,
     selection_index: i32,
     clause_snapshot_count: usize,
@@ -181,12 +186,20 @@ struct MoveClauseProgressMarker {
 
 impl MoveClauseProgressMarker {
     fn from_state(state: &ClauseActionStateMut<'_>) -> Self {
+        let mut hasher = DefaultHasher::new();
+        state.preview.hash(&mut hasher);
+        state.suffix.hash(&mut hasher);
+        state.raw_input.hash(&mut hasher);
+        state.raw_hiragana.hash(&mut hasher);
+        state.fixed_prefix.hash(&mut hasher);
+
         Self {
-            preview: state.preview.clone(),
-            suffix: state.suffix.clone(),
-            raw_input: state.raw_input.clone(),
-            raw_hiragana: state.raw_hiragana.clone(),
-            fixed_prefix: state.fixed_prefix.clone(),
+            preview_len: state.preview.len(),
+            suffix_len: state.suffix.len(),
+            raw_input_len: state.raw_input.len(),
+            raw_hiragana_len: state.raw_hiragana.len(),
+            fixed_prefix_len: state.fixed_prefix.len(),
+            text_hash: hasher.finish(),
             corresponding_count: *state.corresponding_count,
             selection_index: *state.selection_index,
             clause_snapshot_count: state.clause_snapshots.len(),

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -2592,6 +2592,17 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn should_defer_clause_navigation_ready_sync(actions: &[ClientAction], index: usize) -> bool {
+        matches!(
+            (actions.get(index), actions.get(index + 1)),
+            (
+                Some(ClientAction::EnsureClauseNavigationReady),
+                Some(ClientAction::MoveClause(direction)),
+            ) if *direction == Self::MOVE_CLAUSE_TO_LAST
+        )
+    }
+
+    #[inline]
     fn plan_actions_for_user_action(
         composition: &Composition,
         action: &UserAction,
@@ -3322,7 +3333,7 @@ impl TextServiceFactory {
 
         self.update_context(&preview)?;
 
-        for action in actions {
+        for (action_index, action) in actions.iter().enumerate() {
             match action {
                 ClientAction::StartComposition => {
                     self.start_composition()?;
@@ -3571,6 +3582,26 @@ impl TextServiceFactory {
                     };
 
                     if effect.applied {
+                        let defer_ui_sync =
+                            Self::should_defer_clause_navigation_ready_sync(actions, action_index);
+                        if defer_ui_sync {
+                            Self::log_clause_action_state(
+                                "defer",
+                                action,
+                                &preview,
+                                &suffix,
+                                &raw_input,
+                                &raw_hiragana,
+                                &fixed_prefix,
+                                corresponding_count,
+                                selection_index,
+                                &candidates,
+                                &clause_snapshots,
+                                &future_clause_snapshots,
+                            );
+                            continue;
+                        }
+
                         self.sync_clause_action_ui(
                             &preview,
                             &suffix,

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -664,18 +664,11 @@ impl TextServiceFactory {
         navigation_candidates: &Candidates,
         current_preview: &str,
         fixed_prefix: &str,
-        current_candidates: &Candidates,
         selection_index: i32,
     ) -> Option<CandidateSelection> {
-        let current_selected = Self::select_candidate(current_candidates, selection_index);
-        let target_preview = current_selected
-            .as_ref()
-            .map(|selected| selected.text.as_str())
-            .filter(|text| !text.is_empty())
-            .unwrap_or(current_preview);
-        let target_clause_preview = target_preview
+        let target_clause_preview = current_preview
             .strip_prefix(fixed_prefix)
-            .unwrap_or(target_preview);
+            .unwrap_or(current_preview);
 
         if let Some(index) = (0..navigation_candidates.texts.len()).find(|index| {
             let text = navigation_candidates
@@ -715,6 +708,88 @@ impl TextServiceFactory {
         }
 
         Self::select_candidate(navigation_candidates, selection_index)
+    }
+
+    #[inline]
+    fn split_at_char_count(value: &str, char_count: i32) -> (String, String) {
+        let split_at = char_count.max(0) as usize;
+        let mut prefix = String::new();
+        let mut suffix = String::new();
+
+        for (index, ch) in value.chars().enumerate() {
+            if index < split_at {
+                prefix.push(ch);
+            } else {
+                suffix.push(ch);
+            }
+        }
+
+        (prefix, suffix)
+    }
+
+    #[inline]
+    fn display_override_set_type(
+        current_preview: &str,
+        fixed_prefix: &str,
+        raw_input: &str,
+        raw_hiragana: &str,
+    ) -> Option<SetTextType> {
+        let target_clause_preview = current_preview
+            .strip_prefix(fixed_prefix)
+            .unwrap_or(current_preview);
+        let set_types = [
+            SetTextType::Hiragana,
+            SetTextType::Katakana,
+            SetTextType::HalfKatakana,
+            SetTextType::FullLatin,
+            SetTextType::HalfLatin,
+        ];
+
+        for set_type in set_types {
+            if Self::converted_clause_preview_text(&set_type, raw_input, raw_hiragana)
+                != target_clause_preview
+            {
+                continue;
+            }
+
+            return Some(set_type);
+        }
+
+        None
+    }
+
+    #[inline]
+    fn display_override_split_for_selected_candidate(
+        set_type: &SetTextType,
+        raw_input: &str,
+        raw_hiragana: &str,
+        selected: &CandidateSelection,
+        suffix_raw_input: Option<&str>,
+        suffix_raw_hiragana: Option<&str>,
+    ) -> (String, String) {
+        let (clause_raw_input, suffix_raw_input) = suffix_raw_input
+            .and_then(|suffix| {
+                raw_input
+                    .strip_suffix(suffix)
+                    .map(|prefix| (prefix, suffix))
+            })
+            .map(|(prefix, suffix)| (prefix.to_string(), suffix.to_string()))
+            .unwrap_or_else(|| Self::split_at_char_count(raw_input, selected.corresponding_count));
+        let (clause_raw_hiragana, suffix_raw_hiragana) = suffix_raw_hiragana
+            .and_then(|suffix| {
+                raw_hiragana
+                    .strip_suffix(suffix)
+                    .map(|prefix| (prefix, suffix))
+            })
+            .map(|(prefix, suffix)| (prefix.to_string(), suffix.to_string()))
+            .unwrap_or_else(|| {
+                Self::split_at_char_count(raw_hiragana, selected.corresponding_count)
+            });
+
+        (
+            Self::converted_clause_preview_text(set_type, &clause_raw_input, &clause_raw_hiragana),
+            Self::converted_clause_preview_text(set_type, &suffix_raw_input, &suffix_raw_hiragana),
+        )
     }
 
     #[inline]
@@ -1315,11 +1390,10 @@ impl TextServiceFactory {
         }
 
         let navigation_candidates = backend.move_cursor(0)?;
-        let Some(selected) = Self::select_navigation_candidate_for_current_preview(
+        let Some(mut selected) = Self::select_navigation_candidate_for_current_preview(
             &navigation_candidates,
             state.preview,
             state.fixed_prefix,
-            state.candidates,
             *state.selection_index,
         ) else {
             return Ok(ClauseActionEffect::skipped());
@@ -1328,6 +1402,13 @@ impl TextServiceFactory {
         if !Self::candidate_splits_raw_input(&selected, state.raw_input) {
             return Ok(ClauseActionEffect::skipped());
         }
+
+        let display_override_set_type = Self::display_override_set_type(
+            state.preview,
+            state.fixed_prefix,
+            state.raw_input,
+            state.raw_hiragana,
+        );
 
         *state.candidates = navigation_candidates;
         *state.selection_index = selected.index;
@@ -1340,12 +1421,41 @@ impl TextServiceFactory {
         );
         *state.preview = Self::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
         *state.suffix = display_suffix;
-        *state.raw_hiragana = selected.hiragana;
+        *state.raw_hiragana = selected.hiragana.clone();
         *state.current_clause_is_split_derived = true;
         *state.current_clause_is_direct_split_remainder = false;
         *state.current_clause_has_split_left_neighbor = false;
         *state.current_clause_split_group_id = None;
         Self::rebuild_future_clause_snapshots_from_backend(state, backend)?;
+        if let Some(set_type) = display_override_set_type {
+            let suffix_raw_input = state
+                .future_clause_snapshots
+                .last()
+                .map(|snapshot| snapshot.raw_input.as_str());
+            let suffix_raw_hiragana = state
+                .future_clause_snapshots
+                .last()
+                .map(|snapshot| snapshot.raw_hiragana.as_str());
+            let (converted_text, converted_sub_text) =
+                Self::display_override_split_for_selected_candidate(
+                    &set_type,
+                    state.raw_input,
+                    state.raw_hiragana,
+                    &selected,
+                    suffix_raw_input,
+                    suffix_raw_hiragana,
+                );
+            selected.text = converted_text;
+            selected.sub_text = converted_sub_text;
+            let selected_index = selected.index.max(0) as usize;
+            if let Some(text) = state.candidates.texts.get_mut(selected_index) {
+                *text = selected.text.clone();
+            }
+            if let Some(sub_text) = state.candidates.sub_texts.get_mut(selected_index) {
+                *sub_text = selected.sub_text.clone();
+            }
+            *state.preview = Self::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
+        }
         *state.suffix = Self::sync_current_clause_future_suffix(
             state.candidates,
             *state.selection_index,

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -162,6 +162,44 @@ impl ClauseActionEffect {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MoveClauseProgressMarker {
+    preview: String,
+    suffix: String,
+    raw_input: String,
+    raw_hiragana: String,
+    fixed_prefix: String,
+    corresponding_count: i32,
+    selection_index: i32,
+    clause_snapshot_count: usize,
+    future_clause_snapshot_count: usize,
+    current_clause_is_split_derived: bool,
+    current_clause_is_direct_split_remainder: bool,
+    current_clause_has_split_left_neighbor: bool,
+    current_clause_split_group_id: Option<u64>,
+}
+
+impl MoveClauseProgressMarker {
+    fn from_state(state: &ClauseActionStateMut<'_>) -> Self {
+        Self {
+            preview: state.preview.clone(),
+            suffix: state.suffix.clone(),
+            raw_input: state.raw_input.clone(),
+            raw_hiragana: state.raw_hiragana.clone(),
+            fixed_prefix: state.fixed_prefix.clone(),
+            corresponding_count: *state.corresponding_count,
+            selection_index: *state.selection_index,
+            clause_snapshot_count: state.clause_snapshots.len(),
+            future_clause_snapshot_count: state.future_clause_snapshots.len(),
+            current_clause_is_split_derived: *state.current_clause_is_split_derived,
+            current_clause_is_direct_split_remainder: *state
+                .current_clause_is_direct_split_remainder,
+            current_clause_has_split_left_neighbor: *state.current_clause_has_split_left_neighbor,
+            current_clause_split_group_id: *state.current_clause_split_group_id,
+        }
+    }
+}
+
 impl ITfCompositionSink_Impl for TextServiceFactory_Impl {
     #[macros::anyhow]
     fn OnCompositionTerminated(
@@ -183,6 +221,7 @@ impl TextServiceFactory {
     const MOVE_CURSOR_CLEAR_CLAUSE_SNAPSHOTS: i32 = 125;
     const MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT: i32 = 126;
     const MOVE_CURSOR_POP_CLAUSE_SNAPSHOT: i32 = 127;
+    const MOVE_CLAUSE_TO_LAST: i32 = i32::MAX;
 
     #[inline]
     fn is_ctrl_pressed() -> bool {
@@ -238,11 +277,11 @@ impl TextServiceFactory {
     #[inline]
     fn normalize_direct_symbol_char(c: char) -> char {
         let halfwidth_ascii = Self::to_halfwidth_ascii_char(c);
-        if halfwidth_ascii.is_ascii_punctuation() {
+        if halfwidth_ascii.is_ascii_graphic() || halfwidth_ascii == ' ' {
             return halfwidth_ascii;
         }
 
-        if c.is_ascii_punctuation() {
+        if c.is_ascii_graphic() || c == ' ' {
             return c;
         }
 
@@ -1160,6 +1199,35 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn is_auto_split_derived_clause(is_split_derived: bool, split_group_id: Option<u64>) -> bool {
+        is_split_derived && split_group_id.is_none()
+    }
+
+    #[inline]
+    fn has_auto_split_derived_clause_state(state: &ClauseActionStateMut<'_>) -> bool {
+        Self::is_auto_split_derived_clause(
+            *state.current_clause_is_split_derived,
+            *state.current_clause_split_group_id,
+        ) || state.clause_snapshots.iter().any(|snapshot| {
+            Self::is_auto_split_derived_clause(snapshot.is_split_derived, snapshot.split_group_id)
+        }) || state.future_clause_snapshots.iter().any(|snapshot| {
+            Self::is_auto_split_derived_clause(snapshot.is_split_derived, snapshot.split_group_id)
+        })
+    }
+
+    #[inline]
+    fn has_auto_split_derived_clause(composition: &Composition) -> bool {
+        Self::is_auto_split_derived_clause(
+            composition.current_clause_is_split_derived,
+            composition.current_clause_split_group_id,
+        ) || composition.clause_snapshots.iter().any(|snapshot| {
+            Self::is_auto_split_derived_clause(snapshot.is_split_derived, snapshot.split_group_id)
+        }) || composition.future_clause_snapshots.iter().any(|snapshot| {
+            Self::is_auto_split_derived_clause(snapshot.is_split_derived, snapshot.split_group_id)
+        })
+    }
+
+    #[inline]
     fn ensure_clause_navigation_ready<B: ClauseActionBackend>(
         state: &mut ClauseActionStateMut<'_>,
         backend: &mut B,
@@ -1176,7 +1244,8 @@ impl TextServiceFactory {
         }
 
         let navigation_candidates = backend.move_cursor(0)?;
-        let Some(selected) = Self::select_candidate(&navigation_candidates, 0) else {
+        let Some(selected) = Self::select_candidate(&navigation_candidates, *state.selection_index)
+        else {
             return Ok(ClauseActionEffect::skipped());
         };
 
@@ -1200,6 +1269,13 @@ impl TextServiceFactory {
         *state.current_clause_is_direct_split_remainder = false;
         *state.current_clause_has_split_left_neighbor = false;
         *state.current_clause_split_group_id = None;
+        Self::rebuild_future_clause_snapshots_from_backend(state, backend)?;
+        *state.suffix = Self::sync_current_clause_future_suffix(
+            state.candidates,
+            *state.selection_index,
+            *state.corresponding_count,
+            state.future_clause_snapshots,
+        );
 
         Ok(ClauseActionEffect::applied(true))
     }
@@ -1210,6 +1286,31 @@ impl TextServiceFactory {
         backend: &mut B,
         direction: i32,
     ) -> Result<ClauseActionEffect> {
+        if direction == Self::MOVE_CLAUSE_TO_LAST {
+            let mut applied_any = false;
+            loop {
+                let before = MoveClauseProgressMarker::from_state(state);
+                let effect = Self::apply_move_clause(state, backend, 1)?;
+                if !effect.applied {
+                    break;
+                }
+                let after = MoveClauseProgressMarker::from_state(state);
+                if before == after {
+                    break;
+                }
+                applied_any = true;
+                if state.suffix.is_empty() {
+                    break;
+                }
+            }
+
+            return Ok(if applied_any {
+                ClauseActionEffect::applied(true)
+            } else {
+                ClauseActionEffect::skipped()
+            });
+        }
+
         if direction > 0 {
             if state.suffix.is_empty() {
                 return Ok(ClauseActionEffect::skipped());
@@ -1284,7 +1385,7 @@ impl TextServiceFactory {
                 if state.future_clause_snapshots.is_empty() {
                     let navigation_candidates = backend.move_cursor(0)?;
                     if let Some(navigation_selected) =
-                        Self::select_candidate(&navigation_candidates, 0)
+                        Self::select_candidate(&navigation_candidates, *state.selection_index)
                     {
                         if Self::candidate_splits_raw_input(&navigation_selected, state.raw_input) {
                             *state.candidates = navigation_candidates;
@@ -1385,6 +1486,10 @@ impl TextServiceFactory {
         direction: i32,
     ) -> Result<ClauseActionEffect> {
         if direction == 0 {
+            return Ok(ClauseActionEffect::skipped());
+        }
+
+        if Self::has_auto_split_derived_clause_state(state) {
             return Ok(ClauseActionEffect::skipped());
         }
 
@@ -2013,7 +2118,7 @@ impl TextServiceFactory {
         let mut collected = Vec::new();
 
         loop {
-            let effect = {
+            let (effect, made_progress) = {
                 let mut temp_state = ClauseActionStateMut {
                     preview: &mut temp_preview,
                     suffix: &mut temp_suffix,
@@ -2033,9 +2138,12 @@ impl TextServiceFactory {
                     current_clause_split_group_id: &mut temp_current_clause_split_group_id,
                     next_split_group_id: &mut temp_next_split_group_id,
                 };
-                Self::apply_move_clause(&mut temp_state, backend, 1)?
+                let before = MoveClauseProgressMarker::from_state(&temp_state);
+                let effect = Self::apply_move_clause(&mut temp_state, backend, 1)?;
+                let after = MoveClauseProgressMarker::from_state(&temp_state);
+                (effect, before != after)
             };
-            if !effect.applied {
+            if !effect.applied || !made_progress {
                 break;
             }
 
@@ -2462,11 +2570,22 @@ impl TextServiceFactory {
     }
 
     #[inline]
-    fn clause_navigation_actions(direction: i32) -> Vec<ClientAction> {
-        vec![
-            ClientAction::EnsureClauseNavigationReady,
-            ClientAction::MoveClause(direction),
-        ]
+    fn clause_navigation_actions(composition: &Composition, direction: i32) -> Vec<ClientAction> {
+        if Self::is_clause_navigation_active(composition) || !composition.suffix.is_empty() {
+            return vec![
+                ClientAction::EnsureClauseNavigationReady,
+                ClientAction::MoveClause(direction),
+            ];
+        }
+
+        if direction < 0 {
+            vec![
+                ClientAction::EnsureClauseNavigationReady,
+                ClientAction::MoveClause(Self::MOVE_CLAUSE_TO_LAST),
+            ]
+        } else {
+            vec![ClientAction::EnsureClauseNavigationReady]
+        }
     }
 
     #[inline]
@@ -2649,10 +2768,16 @@ impl TextServiceFactory {
                 UserAction::CommitFirstClause => {
                     Some(Self::commit_first_clause_actions(composition))
                 }
-                UserAction::AdjustClauseBoundary(direction) => Some((
-                    CompositionState::Composing,
-                    vec![ClientAction::AdjustBoundary(*direction)],
-                )),
+                UserAction::AdjustClauseBoundary(direction) => {
+                    if Self::has_auto_split_derived_clause(composition) {
+                        Some((CompositionState::Composing, vec![]))
+                    } else {
+                        Some((
+                            CompositionState::Composing,
+                            vec![ClientAction::AdjustBoundary(*direction)],
+                        ))
+                    }
+                }
                 UserAction::Escape => Some((
                     CompositionState::None,
                     vec![ClientAction::RemoveText, ClientAction::EndComposition],
@@ -2660,11 +2785,11 @@ impl TextServiceFactory {
                 UserAction::Navigation(direction) => match direction {
                     Navigation::Right => Some((
                         CompositionState::Composing,
-                        Self::clause_navigation_actions(1),
+                        Self::clause_navigation_actions(composition, 1),
                     )),
                     Navigation::Left => Some((
                         CompositionState::Composing,
-                        Self::clause_navigation_actions(-1),
+                        Self::clause_navigation_actions(composition, -1),
                     )),
                     Navigation::Up => Some((
                         CompositionState::Previewing,
@@ -2800,10 +2925,16 @@ impl TextServiceFactory {
                 UserAction::CommitFirstClause => {
                     Some(Self::commit_first_clause_actions(composition))
                 }
-                UserAction::AdjustClauseBoundary(direction) => Some((
-                    CompositionState::Previewing,
-                    vec![ClientAction::AdjustBoundary(*direction)],
-                )),
+                UserAction::AdjustClauseBoundary(direction) => {
+                    if Self::has_auto_split_derived_clause(composition) {
+                        Some((CompositionState::Previewing, vec![]))
+                    } else {
+                        Some((
+                            CompositionState::Previewing,
+                            vec![ClientAction::AdjustBoundary(*direction)],
+                        ))
+                    }
+                }
                 UserAction::Escape => Some((
                     CompositionState::None,
                     vec![ClientAction::RemoveText, ClientAction::EndComposition],
@@ -2811,11 +2942,11 @@ impl TextServiceFactory {
                 UserAction::Navigation(direction) => match direction {
                     Navigation::Right => Some((
                         CompositionState::Composing,
-                        Self::clause_navigation_actions(1),
+                        Self::clause_navigation_actions(composition, 1),
                     )),
                     Navigation::Left => Some((
                         CompositionState::Composing,
-                        Self::clause_navigation_actions(-1),
+                        Self::clause_navigation_actions(composition, -1),
                     )),
                     Navigation::Up => Some((
                         CompositionState::Previewing,

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1244,6 +1244,7 @@ impl TextServiceFactory {
         }
 
         let navigation_candidates = backend.move_cursor(0)?;
+        // The full-conversion selection index may be outside this shorter clause list.
         let Some(selected) = Self::select_candidate(&navigation_candidates, *state.selection_index)
         else {
             return Ok(ClauseActionEffect::skipped());

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -2274,6 +2274,9 @@ impl TextServiceFactory {
             .last()
             .map(|snapshot| {
                 server_candidates.hiragana == snapshot.raw_hiragana
+                    || server_candidates
+                        .hiragana
+                        .starts_with(&snapshot.raw_hiragana)
                     || server_candidates.hiragana.ends_with(&snapshot.raw_hiragana)
                     || snapshot.raw_hiragana.ends_with(&server_candidates.hiragana)
             })

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -2603,6 +2603,18 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn deferred_clause_navigation_ready_sync_update_pos(
+        deferred_update_pos: Option<bool>,
+        move_effect: ClauseActionEffect,
+    ) -> Option<bool> {
+        if move_effect.applied {
+            None
+        } else {
+            deferred_update_pos
+        }
+    }
+
+    #[inline]
     fn plan_actions_for_user_action(
         composition: &Composition,
         action: &UserAction,
@@ -3330,6 +3342,7 @@ impl TextServiceFactory {
             .clone()
             .context("ipc_service is None")?;
         let mut transition = transition;
+        let mut deferred_clause_navigation_ready_sync_update_pos = None;
 
         self.update_context(&preview)?;
 
@@ -3585,6 +3598,8 @@ impl TextServiceFactory {
                         let defer_ui_sync =
                             Self::should_defer_clause_navigation_ready_sync(actions, action_index);
                         if defer_ui_sync {
+                            deferred_clause_navigation_ready_sync_update_pos =
+                                Some(effect.update_pos);
                             Self::log_clause_action_state(
                                 "defer",
                                 action,
@@ -3679,6 +3694,11 @@ impl TextServiceFactory {
                         Self::apply_move_clause(&mut state, &mut ipc_service, *direction)?
                     };
 
+                    let deferred_sync_update_pos =
+                        Self::deferred_clause_navigation_ready_sync_update_pos(
+                            deferred_clause_navigation_ready_sync_update_pos.take(),
+                            effect,
+                        );
                     if effect.applied {
                         self.sync_clause_action_ui(
                             &preview,
@@ -3690,6 +3710,29 @@ impl TextServiceFactory {
                         )?;
                         Self::log_clause_action_state(
                             "after",
+                            action,
+                            &preview,
+                            &suffix,
+                            &raw_input,
+                            &raw_hiragana,
+                            &fixed_prefix,
+                            corresponding_count,
+                            selection_index,
+                            &candidates,
+                            &clause_snapshots,
+                            &future_clause_snapshots,
+                        );
+                    } else if let Some(update_pos) = deferred_sync_update_pos {
+                        self.sync_clause_action_ui(
+                            &preview,
+                            &suffix,
+                            &candidates,
+                            selection_index,
+                            &mut ipc_service,
+                            update_pos,
+                        )?;
+                        Self::log_clause_action_state(
+                            "after-deferred",
                             action,
                             &preview,
                             &suffix,

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -660,6 +660,64 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn select_navigation_candidate_for_current_preview(
+        navigation_candidates: &Candidates,
+        current_preview: &str,
+        fixed_prefix: &str,
+        current_candidates: &Candidates,
+        selection_index: i32,
+    ) -> Option<CandidateSelection> {
+        let current_selected = Self::select_candidate(current_candidates, selection_index);
+        let target_preview = current_selected
+            .as_ref()
+            .map(|selected| selected.text.as_str())
+            .filter(|text| !text.is_empty())
+            .unwrap_or(current_preview);
+        let target_clause_preview = target_preview
+            .strip_prefix(fixed_prefix)
+            .unwrap_or(target_preview);
+
+        if let Some(index) = (0..navigation_candidates.texts.len()).find(|index| {
+            let text = navigation_candidates
+                .texts
+                .get(*index)
+                .map(String::as_str)
+                .unwrap_or_default();
+            let sub_text = navigation_candidates
+                .sub_texts
+                .get(*index)
+                .map(String::as_str)
+                .unwrap_or_default();
+
+            target_clause_preview.strip_prefix(text) == Some(sub_text)
+        }) {
+            return Self::select_candidate(navigation_candidates, index as i32);
+        }
+
+        if let Some(index) = navigation_candidates
+            .texts
+            .iter()
+            .enumerate()
+            .filter(|(_, text)| !text.is_empty() && target_clause_preview.starts_with(*text))
+            .max_by_key(|(index, text)| {
+                (
+                    navigation_candidates
+                        .corresponding_count
+                        .get(*index)
+                        .copied()
+                        .unwrap_or(0),
+                    text.len(),
+                )
+            })
+            .map(|(index, _)| index)
+        {
+            return Self::select_candidate(navigation_candidates, index as i32);
+        }
+
+        Self::select_candidate(navigation_candidates, selection_index)
+    }
+
+    #[inline]
     fn candidate_splits_raw_input(selected: &CandidateSelection, raw_input: &str) -> bool {
         selected.corresponding_count > 0
             && selected.corresponding_count < raw_input.chars().count() as i32
@@ -1257,9 +1315,13 @@ impl TextServiceFactory {
         }
 
         let navigation_candidates = backend.move_cursor(0)?;
-        // The full-conversion selection index may be outside this shorter clause list.
-        let Some(selected) = Self::select_candidate(&navigation_candidates, *state.selection_index)
-        else {
+        let Some(selected) = Self::select_navigation_candidate_for_current_preview(
+            &navigation_candidates,
+            state.preview,
+            state.fixed_prefix,
+            state.candidates,
+            *state.selection_index,
+        ) else {
             return Ok(ClauseActionEffect::skipped());
         };
 

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -114,6 +114,89 @@ fn delayed_candidate_window_shows_when_space_opens_preview() {
 }
 
 #[test]
+fn arrow_navigation_prepares_clause_navigation_before_move() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        preview: "いい加減統一しろ".to_string(),
+        raw_input: "iikagentouitusiro".to_string(),
+        raw_hiragana: "いいかげんとういつしろ".to_string(),
+        corresponding_count: 17,
+        ..Composition::default()
+    };
+
+    let (_, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Navigation(Navigation::Right),
+        &InputMode::Kana,
+        false,
+        &AppConfig::default(),
+        false,
+    )
+    .expect("right arrow should navigate clauses");
+
+    assert_eq!(
+        actions,
+        vec![
+            ClientAction::EnsureClauseNavigationReady,
+            ClientAction::MoveClause(1)
+        ]
+    );
+}
+
+#[test]
+fn enter_commits_all_when_clause_navigation_is_active() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        preview: "加減".to_string(),
+        raw_input: "kagentouitu".to_string(),
+        raw_hiragana: "かげんとういつ".to_string(),
+        corresponding_count: 5,
+        future_clause_snapshots: vec![actual_future_snapshot("統一", "", "touitu", "とういつ", 6)],
+        ..Composition::default()
+    };
+
+    let (transition, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Enter,
+        &InputMode::Kana,
+        false,
+        &AppConfig::default(),
+        false,
+    )
+    .expect("enter should commit active clause navigation");
+
+    assert_eq!(transition, CompositionState::None);
+    assert_eq!(actions, vec![ClientAction::EndComposition]);
+}
+
+#[test]
+fn ctrl_down_keeps_current_clause_commit_in_clause_navigation() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        preview: "加減".to_string(),
+        suffix: "統一".to_string(),
+        raw_input: "kagentouitu".to_string(),
+        raw_hiragana: "かげんとういつ".to_string(),
+        corresponding_count: 5,
+        future_clause_snapshots: vec![actual_future_snapshot("統一", "", "touitu", "とういつ", 6)],
+        ..Composition::default()
+    };
+
+    let (transition, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::CommitAndNextClause,
+        &InputMode::Kana,
+        false,
+        &AppConfig::default(),
+        false,
+    )
+    .expect("ctrl+down should commit current clause");
+
+    assert_eq!(transition, CompositionState::Composing);
+    assert_eq!(actions, vec![ClientAction::ShrinkText("".to_string())]);
+}
+
+#[test]
 fn punctuation_commit_defaults_off_and_keeps_existing_append_path() {
     let composition = Composition {
         state: CompositionState::Composing,

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -385,6 +385,26 @@ impl ClauseActionBackend for PreserveSelectionEnsureBackend {
     }
 }
 
+struct ReorderedNavigationEnsureBackend;
+
+impl ClauseActionBackend for ReorderedNavigationEnsureBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        if offset == 0 {
+            return Ok(candidates(
+                &["いい加減", "良い加減", "程良い加減"],
+                &["統一", "統一", "統一"],
+                "いいかげんとういつ",
+                &[7, 7, 7],
+            ));
+        }
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        Ok(candidates(&["統一"], &[""], "とういつ", &[6]))
+    }
+}
+
 #[test]
 fn ensure_clause_navigation_preserves_current_candidate_selection() {
     let mut preview = "良い加減統一".to_string();
@@ -433,6 +453,58 @@ fn ensure_clause_navigation_preserves_current_candidate_selection() {
     assert!(effect.applied);
     assert_eq!(preview, "良い加減");
     assert_eq!(selection_index, 1);
+    assert_eq!(corresponding_count, 7);
+    assert_eq!(suffix, "統一");
+}
+
+#[test]
+fn ensure_clause_navigation_matches_current_preview_before_reusing_index() {
+    let mut preview = "程良い加減統一".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "iikagentouitu".to_string();
+    let mut raw_hiragana = "いいかげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 13;
+    let mut selection_index = 1;
+    let mut current_candidates = candidates(
+        &["いい加減統一", "程良い加減統一"],
+        &["", ""],
+        "いいかげんとういつ",
+        &[13, 13],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = ReorderedNavigationEnsureBackend;
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+        .expect("ensure clause navigation should return");
+
+    assert!(effect.applied);
+    assert_eq!(preview, "程良い加減");
+    assert_eq!(selection_index, 2);
     assert_eq!(corresponding_count, 7);
     assert_eq!(suffix, "統一");
 }

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -138,6 +138,17 @@ fn right_arrow_prepares_clause_navigation_without_initial_move() {
 }
 
 #[test]
+fn initial_left_arrow_defers_clause_navigation_ready_ui_sync_until_last_clause() {
+    let actions = vec![
+        ClientAction::EnsureClauseNavigationReady,
+        ClientAction::MoveClause(TextServiceFactory::MOVE_CLAUSE_TO_LAST),
+    ];
+
+    assert!(TextServiceFactory::should_defer_clause_navigation_ready_sync(&actions, 0));
+    assert!(!TextServiceFactory::should_defer_clause_navigation_ready_sync(&actions, 1));
+}
+
+#[test]
 fn enter_commits_all_when_clause_navigation_is_active() {
     let composition = Composition {
         state: CompositionState::Composing,

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -405,6 +405,29 @@ impl ClauseActionBackend for ReorderedNavigationEnsureBackend {
     }
 }
 
+struct FKeyDisplayEnsureBackend {
+    shrunk: bool,
+}
+
+impl ClauseActionBackend for FKeyDisplayEnsureBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        if offset == 0 && !self.shrunk {
+            return Ok(candidates(
+                &["加減", "下限", "かげん"],
+                &["統一", "統一", "統一"],
+                "かげんとういつ",
+                &[5, 5, 5],
+            ));
+        }
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        self.shrunk = true;
+        Ok(candidates(&["統一"], &[""], "とういつ", &[6]))
+    }
+}
+
 #[test]
 fn ensure_clause_navigation_preserves_current_candidate_selection() {
     let mut preview = "良い加減統一".to_string();
@@ -507,6 +530,60 @@ fn ensure_clause_navigation_matches_current_preview_before_reusing_index() {
     assert_eq!(selection_index, 2);
     assert_eq!(corresponding_count, 7);
     assert_eq!(suffix, "統一");
+}
+
+#[test]
+fn ensure_clause_navigation_preserves_fkey_display_preview() {
+    let mut preview = "カゲントウイツ".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "kagentouitu".to_string();
+    let mut raw_hiragana = "かげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 11;
+    let mut selection_index = 0;
+    let mut current_candidates = candidates(
+        &["加減統一", "下限統一", "かげん統一"],
+        &["", "", ""],
+        "かげんとういつ",
+        &[11, 11, 11],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = FKeyDisplayEnsureBackend { shrunk: false };
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+        .expect("ensure clause navigation should return");
+
+    assert!(effect.applied);
+    assert_eq!(preview, "カゲン");
+    assert_eq!(suffix, "トウイツ");
+    assert_eq!(selection_index, 0);
+    assert_eq!(corresponding_count, 5);
+    assert_eq!(current_candidates.texts[0], "カゲン");
+    assert_eq!(current_candidates.sub_texts[0], "トウイツ");
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -761,6 +761,161 @@ fn move_clause_right_preserves_future_clause_when_server_returns_collapsed_remai
     );
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SingleNBoundaryServerState {
+    Full,
+    BadSuffix,
+}
+
+struct InitialSplitSingleNBoundaryBackend {
+    server: SingleNBoundaryServerState,
+    snapshots: Vec<SingleNBoundaryServerState>,
+}
+
+impl InitialSplitSingleNBoundaryBackend {
+    fn current_candidates(&self) -> Candidates {
+        match self.server {
+            SingleNBoundaryServerState::Full => {
+                candidates(&["いい加減"], &["横溢しろ"], "いいかげんとういつしろ", &[7])
+            }
+            SingleNBoundaryServerState::BadSuffix => {
+                candidates(&["横溢しろ"], &[""], "おういつしろ", &[9])
+            }
+        }
+    }
+}
+
+impl ClauseActionBackend for InitialSplitSingleNBoundaryBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        match offset {
+            value if value == TextServiceFactory::MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT => {
+                self.snapshots.push(self.server);
+            }
+            value if value == TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT => {
+                if let Some(restored) = self.snapshots.pop() {
+                    self.server = restored;
+                }
+            }
+            _ => {}
+        }
+        Ok(self.current_candidates())
+    }
+
+    fn shrink_text(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        assert_eq!(offset, 7);
+        self.server = SingleNBoundaryServerState::BadSuffix;
+        Ok(self.current_candidates())
+    }
+}
+
+#[test]
+fn initial_auto_split_recovers_single_n_suffix_without_reinput() {
+    let mut preview = "いい加減統一しろ".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "iikagentouitusiro".to_string();
+    let mut raw_hiragana = "いいかげんとういつしろ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 17;
+    let mut selection_index = 0;
+    let mut current_candidates = candidates(
+        &["いい加減統一しろ"],
+        &[""],
+        "いいかげんとういつしろ",
+        &[17],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = InitialSplitSingleNBoundaryBackend {
+        server: SingleNBoundaryServerState::Full,
+        snapshots: Vec::new(),
+    };
+
+    {
+        let mut state = ClauseActionStateMut {
+            preview: &mut preview,
+            suffix: &mut suffix,
+            raw_input: &mut raw_input,
+            raw_hiragana: &mut raw_hiragana,
+            fixed_prefix: &mut fixed_prefix,
+            corresponding_count: &mut corresponding_count,
+            selection_index: &mut selection_index,
+            candidates: &mut current_candidates,
+            clause_snapshots: &mut clause_snapshots,
+            future_clause_snapshots: &mut future_clause_snapshots,
+            current_clause_is_split_derived: &mut current_clause_is_split_derived,
+            current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+            current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+            current_clause_split_group_id: &mut current_clause_split_group_id,
+            next_split_group_id: &mut next_split_group_id,
+        };
+        let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+            .expect("clause navigation should prepare");
+        assert!(effect.applied);
+    }
+
+    assert_eq!(backend.server, SingleNBoundaryServerState::Full);
+    assert_eq!(backend.snapshots.len(), 0);
+    assert_eq!(suffix, "統一しろ");
+    assert_eq!(
+        future_clause_snapshots
+            .last()
+            .map(|snapshot| snapshot.selected_text.as_str()),
+        Some("統一しろ")
+    );
+    assert_eq!(
+        future_clause_snapshots
+            .last()
+            .map(|snapshot| snapshot.raw_input.as_str()),
+        Some("touitusiro")
+    );
+    assert_eq!(
+        future_clause_snapshots
+            .last()
+            .map(|snapshot| snapshot.raw_hiragana.as_str()),
+        Some("とういつしろ")
+    );
+
+    {
+        let mut state = ClauseActionStateMut {
+            preview: &mut preview,
+            suffix: &mut suffix,
+            raw_input: &mut raw_input,
+            raw_hiragana: &mut raw_hiragana,
+            fixed_prefix: &mut fixed_prefix,
+            corresponding_count: &mut corresponding_count,
+            selection_index: &mut selection_index,
+            candidates: &mut current_candidates,
+            clause_snapshots: &mut clause_snapshots,
+            future_clause_snapshots: &mut future_clause_snapshots,
+            current_clause_is_split_derived: &mut current_clause_is_split_derived,
+            current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+            current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+            current_clause_split_group_id: &mut current_clause_split_group_id,
+            next_split_group_id: &mut next_split_group_id,
+        };
+        let effect = TextServiceFactory::apply_move_clause(&mut state, &mut backend, 1)
+            .expect("right move should restore the cached suffix");
+        assert!(effect.applied);
+    }
+
+    assert_eq!(suffix, "");
+    assert_eq!(raw_input, "touitusiro");
+    assert_eq!(raw_hiragana, "とういつしろ");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&preview, &fixed_prefix),
+        "統一しろ"
+    );
+    assert_eq!(
+        current_candidates.texts.first().map(String::as_str),
+        Some("統一しろ")
+    );
+}
+
 #[test]
 fn punctuation_commit_defaults_off_and_keeps_existing_append_path() {
     let composition = Composition {

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -365,7 +365,7 @@ fn ensure_clause_navigation_preserves_current_candidate_selection() {
     let mut fixed_prefix = String::new();
     let mut corresponding_count = 13;
     let mut selection_index = 1;
-    let mut candidates = candidates(
+    let mut current_candidates = candidates(
         &["いい加減統一", "良い加減統一"],
         &["", ""],
         "いいかげんとういつ",
@@ -388,7 +388,7 @@ fn ensure_clause_navigation_preserves_current_candidate_selection() {
         fixed_prefix: &mut fixed_prefix,
         corresponding_count: &mut corresponding_count,
         selection_index: &mut selection_index,
-        candidates: &mut candidates,
+        candidates: &mut current_candidates,
         clause_snapshots: &mut clause_snapshots,
         future_clause_snapshots: &mut future_clause_snapshots,
         current_clause_is_split_derived: &mut current_clause_is_split_derived,
@@ -406,6 +406,124 @@ fn ensure_clause_navigation_preserves_current_candidate_selection() {
     assert_eq!(selection_index, 1);
     assert_eq!(corresponding_count, 7);
     assert_eq!(suffix, "統一");
+}
+
+struct MoveRightCollapsedRemainderBackend {
+    moved_left: bool,
+}
+
+impl ClauseActionBackend for MoveRightCollapsedRemainderBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        if offset < 0 {
+            self.moved_left = true;
+        }
+
+        if self.moved_left {
+            return Ok(candidates(
+                &["長い", "永い", "ながい"],
+                &["文節でも複数に分割される"; 3],
+                "ながいぶんせつでもふくすうにぶんかつされる",
+                &[5, 5, 5],
+            ));
+        }
+
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        Ok(candidates(
+            &["長い文節でも複数に分割される"],
+            &[""],
+            "ながいぶんせつでもふくすうにぶんかつされる",
+            &[26],
+        ))
+    }
+}
+
+#[test]
+fn move_clause_right_preserves_future_clause_when_server_returns_collapsed_remainder() {
+    let mut preview = "ある程度".to_string();
+    let mut suffix = "長い文節でも複数に分割される".to_string();
+    let mut raw_input = "aruteidonagaibunsetudemohukusuunibunkatusareru".to_string();
+    let mut raw_hiragana = "あるていどながいぶんせつでもふくすうにぶんかつされる".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 9;
+    let mut selection_index = 0;
+    let mut current_candidates = candidates(
+        &["ある程度"],
+        &["長い文節でも複数に分割される"],
+        "あるていどながいぶんせつでもふくすうにぶんかつされる",
+        &[9],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = vec![
+        actual_future_snapshot(
+            "文節でも",
+            "複数に分割される",
+            "bunsetudemohukusuunibunkatusareru",
+            "ぶんせつでもふくすうにぶんかつされる",
+            11,
+        ),
+        TextServiceFactory::build_future_clause_snapshot(
+            "長い",
+            "文節でも複数に分割される",
+            "nagaibunsetudemohukusuunibunkatusareru",
+            "ながいぶんせつでもふくすうにぶんかつされる",
+            "",
+            5,
+            0,
+            &candidates(
+                &["長い", "永い", "ながい"],
+                &["文節でも複数に分割される"; 3],
+                "ながいぶんせつでもふくすうにぶんかつされる",
+                &[5, 5, 5],
+            ),
+        ),
+    ];
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = MoveRightCollapsedRemainderBackend { moved_left: false };
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::apply_move_clause(&mut state, &mut backend, 1)
+        .expect("right move should return");
+
+    assert!(effect.applied);
+    assert!(backend.moved_left);
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&preview, &fixed_prefix),
+        "長い"
+    );
+    assert_eq!(suffix, "文節でも複数に分割される");
+    assert_eq!(
+        TextServiceFactory::clause_texts_for_log(
+            &preview,
+            &fixed_prefix,
+            &[],
+            &future_clause_snapshots
+        ),
+        "長い / 文節でも"
+    );
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -114,7 +114,7 @@ fn delayed_candidate_window_shows_when_space_opens_preview() {
 }
 
 #[test]
-fn arrow_navigation_prepares_clause_navigation_before_move() {
+fn right_arrow_prepares_clause_navigation_without_initial_move() {
     let composition = Composition {
         state: CompositionState::Composing,
         preview: "いい加減統一しろ".to_string(),
@@ -132,15 +132,9 @@ fn arrow_navigation_prepares_clause_navigation_before_move() {
         &AppConfig::default(),
         false,
     )
-    .expect("right arrow should navigate clauses");
+    .expect("right arrow should prepare clause navigation");
 
-    assert_eq!(
-        actions,
-        vec![
-            ClientAction::EnsureClauseNavigationReady,
-            ClientAction::MoveClause(1)
-        ]
-    );
+    assert_eq!(actions, vec![ClientAction::EnsureClauseNavigationReady]);
 }
 
 #[test]
@@ -194,6 +188,224 @@ fn ctrl_down_keeps_current_clause_commit_in_clause_navigation() {
 
     assert_eq!(transition, CompositionState::Composing);
     assert_eq!(actions, vec![ClientAction::ShrinkText("".to_string())]);
+}
+
+struct NonProgressMoveBackend {
+    shrink_calls: usize,
+}
+
+impl ClauseActionBackend for NonProgressMoveBackend {
+    fn move_cursor(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        self.shrink_calls += 1;
+        assert!(
+            self.shrink_calls <= 1,
+            "MOVE_CLAUSE_TO_LAST retried a non-progressing right move"
+        );
+        Ok(Candidates::default())
+    }
+}
+
+#[test]
+fn move_clause_to_last_stops_when_right_move_makes_no_progress() {
+    let mut preview = "いい加減".to_string();
+    let mut suffix = "統一".to_string();
+    let mut raw_input = "iikagentouitu".to_string();
+    let mut raw_hiragana = "いいかげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 7;
+    let mut selection_index = 0;
+    let mut candidates = candidates(&["いい加減"], &["統一"], "いいかげんとういつ", &[7]);
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = true;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = NonProgressMoveBackend { shrink_calls: 0 };
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::apply_move_clause(
+        &mut state,
+        &mut backend,
+        TextServiceFactory::MOVE_CLAUSE_TO_LAST,
+    )
+    .expect("move to last should return");
+
+    assert!(!effect.applied);
+    assert_eq!(backend.shrink_calls, 1);
+}
+
+struct NonProgressEnsureBackend {
+    move_cursor_zero_calls: usize,
+    shrink_calls: usize,
+}
+
+impl ClauseActionBackend for NonProgressEnsureBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        if offset == 0 {
+            self.move_cursor_zero_calls += 1;
+            if self.move_cursor_zero_calls == 1 {
+                return Ok(candidates(
+                    &["いい加減"],
+                    &["統一"],
+                    "いいかげんとういつ",
+                    &[7],
+                ));
+            }
+        }
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        self.shrink_calls += 1;
+        assert!(
+            self.shrink_calls <= 1,
+            "future snapshot rebuild retried a non-progressing right move"
+        );
+        Ok(Candidates::default())
+    }
+}
+
+#[test]
+fn ensure_clause_navigation_stops_rebuilding_future_on_non_progress_move() {
+    let mut preview = "いい加減統一".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "iikagentouitu".to_string();
+    let mut raw_hiragana = "いいかげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 13;
+    let mut selection_index = 0;
+    let mut candidates = candidates(&["いい加減統一"], &[""], "いいかげんとういつ", &[13]);
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = NonProgressEnsureBackend {
+        move_cursor_zero_calls: 0,
+        shrink_calls: 0,
+    };
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+        .expect("ensure clause navigation should return");
+
+    assert!(effect.applied);
+    assert_eq!(backend.shrink_calls, 1);
+    assert!(future_clause_snapshots.is_empty());
+}
+
+struct PreserveSelectionEnsureBackend;
+
+impl ClauseActionBackend for PreserveSelectionEnsureBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        if offset == 0 {
+            return Ok(candidates(
+                &["いい加減", "良い加減"],
+                &["統一", "統一"],
+                "いいかげんとういつ",
+                &[7, 7],
+            ));
+        }
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        Ok(candidates(&["統一"], &[""], "とういつ", &[6]))
+    }
+}
+
+#[test]
+fn ensure_clause_navigation_preserves_current_candidate_selection() {
+    let mut preview = "良い加減統一".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "iikagentouitu".to_string();
+    let mut raw_hiragana = "いいかげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 13;
+    let mut selection_index = 1;
+    let mut candidates = candidates(
+        &["いい加減統一", "良い加減統一"],
+        &["", ""],
+        "いいかげんとういつ",
+        &[13, 13],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = PreserveSelectionEnsureBackend;
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+        .expect("ensure clause navigation should return");
+
+    assert!(effect.applied);
+    assert_eq!(preview, "良い加減");
+    assert_eq!(selection_index, 1);
+    assert_eq!(corresponding_count, 7);
+    assert_eq!(suffix, "統一");
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    Candidates, ClauseActionBackend, ClauseActionStateMut, ClauseSnapshot, Composition,
-    CompositionState, FutureClauseSnapshot, TextServiceFactory,
+    Candidates, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut, ClauseSnapshot,
+    Composition, CompositionState, FutureClauseSnapshot, TextServiceFactory,
 };
 use crate::engine::{
     client_action::{ClientAction, SetSelectionType, SetTextType},
@@ -146,6 +146,24 @@ fn initial_left_arrow_defers_clause_navigation_ready_ui_sync_until_last_clause()
 
     assert!(TextServiceFactory::should_defer_clause_navigation_ready_sync(&actions, 0));
     assert!(!TextServiceFactory::should_defer_clause_navigation_ready_sync(&actions, 1));
+}
+
+#[test]
+fn skipped_move_to_last_flushes_deferred_clause_navigation_ready_ui_sync() {
+    assert_eq!(
+        TextServiceFactory::deferred_clause_navigation_ready_sync_update_pos(
+            Some(true),
+            ClauseActionEffect::skipped()
+        ),
+        Some(true)
+    );
+    assert_eq!(
+        TextServiceFactory::deferred_clause_navigation_ready_sync_update_pos(
+            Some(true),
+            ClauseActionEffect::applied(true)
+        ),
+        None
+    );
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -437,6 +437,63 @@ fn ensure_clause_navigation_preserves_current_candidate_selection() {
     assert_eq!(suffix, "統一");
 }
 
+#[test]
+fn ensure_clause_navigation_clamps_out_of_range_selection_index() {
+    let mut preview = "程良い加減統一".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "iikagentouitu".to_string();
+    let mut raw_hiragana = "いいかげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 13;
+    let mut selection_index = 3;
+    let mut current_candidates = candidates(
+        &[
+            "いい加減統一",
+            "良い加減統一",
+            "好い加減統一",
+            "程良い加減統一",
+        ],
+        &["", "", "", ""],
+        "いいかげんとういつ",
+        &[13, 13, 13, 13],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = PreserveSelectionEnsureBackend;
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+        .expect("ensure clause navigation should return");
+
+    assert!(effect.applied);
+    assert_eq!(preview, "良い加減");
+    assert_eq!(selection_index, 1);
+    assert_eq!(corresponding_count, 7);
+    assert_eq!(suffix, "統一");
+}
+
 struct MoveRightCollapsedRemainderBackend {
     moved_left: bool,
 }

--- a/crates/client/src/engine/composition/tests/integration_patterns.rs
+++ b/crates/client/src/engine/composition/tests/integration_patterns.rs
@@ -288,13 +288,56 @@ fn clause_integration_fkeys_preserve_display_when_committing_current_clause() {
         );
         assert_eq!(harness_raw_clauses(&harness), "かげん / とういつ");
         assert_eq!(harness_clause_input_lengths(&harness), "5 / 6");
-        assert_eq!(harness.committed_clauses.len(), 1);
-        assert_eq!(
-            TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
-            "統一"
-        );
-        assert_eq!(harness.state, CompositionState::Composing);
+        assert_eq!(harness.committed_clauses.len(), 2);
+        assert!(harness.preview.is_empty());
+        assert!(harness.future_clause_snapshots.is_empty());
+        assert_eq!(harness.state, CompositionState::None);
     }
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_uses_first_clause_for_ju_sequence() {
+    let extra = vec![HarnessUserAction::Right];
+    let (harness, _, history) = run_from_auto_clause_ju(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "準備して / 発表に / 臨む",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+    );
+    assert_eq!(harness_clause_input_lengths(&harness), "9 / 11 / 6");
+    assert_eq!(harness.raw_input, "haxtupyouninozomu");
+    assert_eq!(harness.raw_hiragana, "はっぴょうにのぞむ");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "発表に"
+    );
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_preserves_tyu_sequence_boundary() {
+    let extra = vec![HarnessUserAction::Right];
+    let (harness, _, history) = run_from_auto_clause_tyu(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "注意 / して",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+    );
+    assert_eq!(harness_raw_clauses(&harness), "ちゅうい / して");
+    assert_eq!(harness_clause_input_lengths(&harness), "5 / 4");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "して"
+    );
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests/integration_patterns.rs
+++ b/crates/client/src/engine/composition/tests/integration_patterns.rs
@@ -341,6 +341,30 @@ fn clause_integration_auto_clause_navigation_preserves_tyu_sequence_boundary() {
 }
 
 #[test]
+fn clause_integration_auto_clause_navigation_preserves_realtime_suffix_display() {
+    let extra = vec![HarnessUserAction::Right];
+    let (harness, _, history) = run_from_auto_clause_preserved_suffix(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "ある程度 / 長い / 文節でも複数に分割される",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}\npreview={} fixed_prefix={} suffix={}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+        harness.preview,
+        harness.fixed_prefix,
+        harness.suffix,
+    );
+    assert_eq!(harness.suffix, "文節でも複数に分割される");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "長い"
+    );
+}
+
+#[test]
 fn clause_integration_logged_baseline_f7_keeps_future_display_when_moving_left() {
     let extra = vec![
         HarnessUserAction::Left,

--- a/crates/client/src/engine/composition/tests/integration_patterns.rs
+++ b/crates/client/src/engine/composition/tests/integration_patterns.rs
@@ -310,6 +310,27 @@ fn clause_integration_auto_clause_navigation_uses_first_clause_for_ju_sequence()
         TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
     );
     assert_eq!(harness_clause_input_lengths(&harness), "9 / 11 / 6");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "準備して"
+    );
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_moves_to_second_clause_on_next_right() {
+    let extra = vec![HarnessUserAction::Right, HarnessUserAction::Right];
+    let (harness, _, history) = run_from_auto_clause_ju(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "準備して / 発表に / 臨む",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+    );
+    assert_eq!(harness_clause_input_lengths(&harness), "9 / 11 / 6");
     assert_eq!(harness.raw_input, "haxtupyouninozomu");
     assert_eq!(harness.raw_hiragana, "はっぴょうにのぞむ");
     assert_eq!(
@@ -336,6 +357,28 @@ fn clause_integration_auto_clause_navigation_preserves_tyu_sequence_boundary() {
     assert_eq!(harness_clause_input_lengths(&harness), "5 / 4");
     assert_eq!(
         TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "注意"
+    );
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_moves_tyu_to_second_clause_on_next_right() {
+    let extra = vec![HarnessUserAction::Right, HarnessUserAction::Right];
+    let (harness, _, history) = run_from_auto_clause_tyu(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "注意 / して",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+    );
+    assert_eq!(harness_raw_clauses(&harness), "ちゅうい / して");
+    assert_eq!(harness_clause_input_lengths(&harness), "5 / 4");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
         "して"
     );
 }
@@ -347,7 +390,7 @@ fn clause_integration_auto_clause_navigation_preserves_realtime_suffix_display()
 
     assert_eq!(
         harness_visible_clauses(&harness),
-        "ある程度 / 長い / 文節でも複数に分割される",
+        "ある程度 / 長い / 文節でも / 複数に分割される",
         "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}\npreview={} fixed_prefix={} suffix={}",
         history_string(&history),
         harness_raw_clauses(&harness),
@@ -357,11 +400,48 @@ fn clause_integration_auto_clause_navigation_preserves_realtime_suffix_display()
         harness.fixed_prefix,
         harness.suffix,
     );
-    assert_eq!(harness.suffix, "文節でも複数に分割される");
+    assert_eq!(harness.suffix, "長い文節でも複数に分割される");
     assert_eq!(
         TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
-        "長い"
+        "ある程度"
     );
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_left_starts_at_last_clause() {
+    let extra = vec![HarnessUserAction::Left];
+    let (harness, _, history) = run_from_auto_clause_preserved_suffix(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "ある程度 / 長い / 文節でも / 複数に分割される",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}\npreview={} fixed_prefix={} suffix={}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+        harness.preview,
+        harness.fixed_prefix,
+        harness.suffix,
+    );
+    assert!(harness.suffix.is_empty());
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "複数に分割される"
+    );
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_blocks_shift_arrows_after_auto_split() {
+    let right_extra = vec![HarnessUserAction::Right];
+    let (right_harness, _, _) = run_from_auto_clause_preserved_suffix(&right_extra);
+    assert_adjust_boundary_is_blocked(&right_harness, -1);
+    assert_adjust_boundary_is_blocked(&right_harness, 1);
+
+    let left_extra = vec![HarnessUserAction::Left];
+    let (left_harness, _, _) = run_from_auto_clause_preserved_suffix(&left_extra);
+    assert_adjust_boundary_is_blocked(&left_harness, -1);
+    assert_adjust_boundary_is_blocked(&left_harness, 1);
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests/integration_patterns.rs
+++ b/crates/client/src/engine/composition/tests/integration_patterns.rs
@@ -269,7 +269,7 @@ fn clause_integration_fkeys_preserve_display_when_moving_right() {
 }
 
 #[test]
-fn clause_integration_fkeys_preserve_display_when_committing_current_clause() {
+fn clause_integration_fkeys_commit_all_clauses_when_clause_navigation_is_active() {
     for (set_type, converted_clause) in fkey_cases() {
         let extra = vec![
             HarnessUserAction::SetTextType(set_type),

--- a/crates/client/src/engine/composition/tests/snapshot_restore.rs
+++ b/crates/client/src/engine/composition/tests/snapshot_restore.rs
@@ -216,6 +216,67 @@ fn adjust_boundary_without_existing_future_cache_does_not_capture_initial_split_
 }
 
 #[test]
+fn auto_split_bootstrap_uses_raw_suffix_hint_when_input_count_is_not_kana_count() {
+    let mut future = Vec::new();
+
+    TextServiceFactory::maybe_push_split_future_clause_snapshot(
+        &mut future,
+        "iikagentouitusiro",
+        "いいかげんとういつしろ",
+        7,
+        "とういつしろ",
+        true,
+        Some(1),
+    );
+
+    let snapshot = future
+        .last()
+        .expect("auto split should cache the remaining clause");
+    assert_eq!(snapshot.raw_input, "touitusiro");
+    assert_eq!(snapshot.raw_hiragana, "とういつしろ");
+    assert_eq!(snapshot.clause_preview, "とういつしろ");
+}
+
+#[test]
+fn auto_split_bootstrap_keeps_double_n_suffix_boundary() {
+    let mut future = Vec::new();
+
+    TextServiceFactory::maybe_push_split_future_clause_snapshot(
+        &mut future,
+        "iikagenntouitusiro",
+        "いいかげんとういつしろ",
+        8,
+        "とういつしろ",
+        true,
+        Some(1),
+    );
+
+    let snapshot = future
+        .last()
+        .expect("double-n auto split should cache the same remaining clause");
+    assert_eq!(snapshot.raw_input, "touitusiro");
+    assert_eq!(snapshot.raw_hiragana, "とういつしろ");
+    assert_eq!(snapshot.clause_preview, "とういつしろ");
+}
+
+#[test]
+fn auto_split_bootstrap_does_not_cache_untrusted_display_suffix() {
+    let mut future = Vec::new();
+
+    TextServiceFactory::maybe_push_split_future_clause_snapshot(
+        &mut future,
+        "iikagentouitusiro",
+        "いいかげんとういつしろ",
+        7,
+        "横溢しろ",
+        true,
+        Some(1),
+    );
+
+    assert!(future.is_empty());
+}
+
+#[test]
 fn adjust_boundary_bootstraps_last_clause_split_without_existing_future_cache() {
     let mut future = Vec::new();
 

--- a/crates/client/src/engine/composition/tests/stateful_harness.rs
+++ b/crates/client/src/engine/composition/tests/stateful_harness.rs
@@ -60,6 +60,20 @@ impl SimClause {
 
     fn candidate_texts(&self) -> Vec<String> {
         match (self.uniform_origin_id(), self.raw_hiragana().as_str()) {
+            (None, "じゅんびしてはっぴょうにのぞむ") => {
+                vec!["準備して発表に臨む".to_string()]
+            }
+            (None, "ちゅういして") => vec!["注意して".to_string()],
+            (None, "あるていどながいぶんせつでもふくすうにぶんかつされる") =>
+            {
+                vec!["ある程度長い文節でも複数に分割される".to_string()]
+            }
+            (None, "ながいぶんせつでもふくすうにぶんかつされる") => {
+                vec!["長い文節でも複数に分割される".to_string()]
+            }
+            (None, "ぶんせつでもふくすうにぶんかつされる") => {
+                vec!["文節でも複数に分割される".to_string()]
+            }
             (Some(1), "かげん") => {
                 vec!["加減".to_string(), "下限".to_string(), "かげん".to_string()]
             }
@@ -75,6 +89,25 @@ impl SimClause {
             }
             (Some(7), "ちゅうい") => vec!["注意".to_string(), "ちゅうい".to_string()],
             (Some(8), "して") => vec!["して".to_string()],
+            (Some(9), "あるていど") => vec![
+                "ある程度".to_string(),
+                "有る程度".to_string(),
+                "あるていど".to_string(),
+                "アルテイド".to_string(),
+            ],
+            (Some(10), "ながい") => {
+                vec!["長い".to_string(), "永い".to_string(), "ながい".to_string()]
+            }
+            (Some(11), "ぶんせつでも") => vec![
+                "文節でも".to_string(),
+                "分節でも".to_string(),
+                "ぶんせつでも".to_string(),
+            ],
+            (Some(12), "ふくすうにぶんかつされる") => vec![
+                "複数に分割される".to_string(),
+                "服数に分割される".to_string(),
+                "ふくすうにぶんかつされる".to_string(),
+            ],
             _ => vec![self.raw_hiragana()],
         }
     }
@@ -331,6 +364,41 @@ fn auto_clause_tyu_spec_state() -> SimSpecState {
     }
 }
 
+fn auto_clause_preserved_suffix_spec_state() -> SimSpecState {
+    SimSpecState {
+        committed_clauses: Vec::new(),
+        clauses: vec![clause(vec![
+            unit("あ", "a", "あ", 9),
+            unit("る", "ru", "る", 9),
+            unit("て", "te", "て", 9),
+            unit("い", "i", "い", 9),
+            unit("ど", "do", "ど", 9),
+            unit("な", "na", "な", 10),
+            unit("が", "ga", "が", 10),
+            unit("い", "i", "い", 10),
+            unit("ぶ", "bu", "ぶ", 11),
+            unit("ん", "n", "ん", 11),
+            unit("せ", "se", "せ", 11),
+            unit("つ", "tu", "つ", 11),
+            unit("で", "de", "で", 11),
+            unit("も", "mo", "も", 11),
+            unit("ふ", "fu", "ふ", 12),
+            unit("く", "ku", "く", 12),
+            unit("す", "su", "す", 12),
+            unit("う", "u", "う", 12),
+            unit("に", "ni", "に", 12),
+            unit("ぶ", "bu", "ぶ", 12),
+            unit("ん", "n", "ん", 12),
+            unit("か", "ka", "か", 12),
+            unit("つ", "tu", "つ", 12),
+            unit("さ", "sa", "さ", 12),
+            unit("れ", "re", "れ", 12),
+            unit("る", "ru", "る", 12),
+        ])],
+        current_index: 0,
+    }
+}
+
 fn candidates_owned(
     texts: Vec<String>,
     sub_texts: Vec<String>,
@@ -486,7 +554,15 @@ fn auto_first_clause_candidates(spec: &SimSpecState) -> Option<Candidates> {
         clauses: auto_clauses,
         current_index: 0,
     };
-    Some(candidates_for_clause(&auto_spec, 0))
+    let current = &auto_spec.clauses[0];
+    let texts = current.candidate_texts();
+    let raw_suffix = spec_join_raw_hiragana(&auto_spec.clauses[1..]);
+    Some(candidates_owned(
+        texts.clone(),
+        vec![raw_suffix; texts.len()],
+        spec_join_raw_hiragana(&auto_spec.clauses),
+        vec![current.corresponding_count(); texts.len()],
+    ))
 }
 
 fn split_units_by_offset(units: &[SimUnit], offset: i32) -> Option<(Vec<SimUnit>, Vec<SimUnit>)> {
@@ -1848,6 +1924,21 @@ pub(super) fn run_from_auto_clause_tyu(
     extra_actions: &[HarnessUserAction],
 ) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
     run_from_auto_clause(auto_clause_tyu_spec_state(), extra_actions)
+}
+
+pub(super) fn run_from_auto_clause_preserved_suffix(
+    extra_actions: &[HarnessUserAction],
+) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
+    let (mut harness, mut backend, mut history) =
+        run_to_auto_clause(auto_clause_preserved_suffix_spec_state());
+    assert_harness_matches_spec(&harness, &backend.spec, &history);
+
+    for op in extra_actions {
+        history.push(*op);
+        apply_user_action(&mut harness, &mut backend, *op, &history);
+    }
+
+    (harness, backend, history)
 }
 
 pub(super) fn fkey_cases() -> [(SetTextType, &'static str); 5] {

--- a/crates/client/src/engine/composition/tests/stateful_harness.rs
+++ b/crates/client/src/engine/composition/tests/stateful_harness.rs
@@ -998,6 +998,27 @@ fn harness_as_composition(harness: &ClauseHarness) -> Composition {
     }
 }
 
+pub(super) fn assert_adjust_boundary_is_blocked(harness: &ClauseHarness, direction: i32) {
+    let composition = harness_as_composition(harness);
+    let app_config = AppConfig::default();
+    let Some((transition, actions)) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::AdjustClauseBoundary(direction),
+        &crate::engine::input_mode::InputMode::Kana,
+        true,
+        &app_config,
+        false,
+    ) else {
+        panic!("adjust boundary was not consumed for direction {direction}");
+    };
+
+    assert_eq!(transition, composition.state);
+    assert!(
+        actions.is_empty(),
+        "adjust boundary should be blocked without client actions: direction={direction}, actions={actions:?}"
+    );
+}
+
 fn committed_clause_from_snapshot(
     snapshot: &ClauseSnapshot,
     next_raw_hiragana: Option<&str>,
@@ -1178,6 +1199,15 @@ impl ScenarioBackend {
     fn move_spec_left(&mut self) {
         if self.spec.current_index > 0 {
             self.spec.current_index -= 1;
+        }
+    }
+
+    fn move_spec_to_last(&mut self) {
+        if !self.spec.clauses.is_empty() {
+            self.spec.current_index = self.spec.clauses.len() - 1;
+            if let Some(current) = self.spec.clauses.get_mut(self.spec.current_index) {
+                current.pending_remainder = false;
+            }
         }
     }
 
@@ -1479,6 +1509,11 @@ fn apply_user_action(
         )
     });
 
+    if actions.is_empty() {
+        harness.state = transition;
+        return;
+    }
+
     for action in actions {
         match action {
             ClientAction::EnsureClauseNavigationReady => {
@@ -1550,6 +1585,13 @@ fn apply_user_action(
                     harness.corresponding_count,
                     harness.selection_index,
                 );
+                if direction == TextServiceFactory::MOVE_CLAUSE_TO_LAST {
+                    backend.move_spec_to_last();
+                } else if direction > 0 {
+                    backend.move_spec_right();
+                } else if direction < 0 {
+                    backend.move_spec_left();
+                }
             }
             ClientAction::AdjustBoundary(direction) => {
                 let effect = {
@@ -1821,7 +1863,9 @@ fn apply_user_action(
         }
     }
 
-    backend.apply_expected_user_action(op);
+    if !matches!(op, HarnessUserAction::Left | HarnessUserAction::Right) {
+        backend.apply_expected_user_action(op);
+    }
     harness.state = transition;
 }
 

--- a/crates/client/src/engine/composition/tests/stateful_harness.rs
+++ b/crates/client/src/engine/composition/tests/stateful_harness.rs
@@ -64,6 +64,17 @@ impl SimClause {
                 vec!["加減".to_string(), "下限".to_string(), "かげん".to_string()]
             }
             (Some(2), "とういつ") => vec!["統一".to_string(), "とういつ".to_string()],
+            (Some(4), "じゅんびして") => {
+                vec!["準備して".to_string(), "じゅんびして".to_string()]
+            }
+            (Some(5), "はっぴょうに") => {
+                vec!["発表に".to_string(), "はっぴょうに".to_string()]
+            }
+            (Some(6), "のぞむ") => {
+                vec!["臨む".to_string(), "望む".to_string(), "のぞむ".to_string()]
+            }
+            (Some(7), "ちゅうい") => vec!["注意".to_string(), "ちゅうい".to_string()],
+            (Some(8), "して") => vec!["して".to_string()],
             _ => vec![self.raw_hiragana()],
         }
     }
@@ -284,6 +295,42 @@ fn fkey_two_clause_spec_state() -> SimSpecState {
     }
 }
 
+fn auto_clause_ju_spec_state() -> SimSpecState {
+    SimSpecState {
+        committed_clauses: Vec::new(),
+        clauses: vec![clause(vec![
+            unit("じゅ", "ju", "じゅ", 4),
+            unit("ん", "n", "ん", 4),
+            unit("び", "bi", "び", 4),
+            unit("し", "si", "し", 4),
+            unit("て", "te", "て", 4),
+            unit("は", "ha", "は", 5),
+            unit("っ", "xtu", "っ", 5),
+            unit("ぴょ", "pyo", "ぴょ", 5),
+            unit("う", "u", "う", 5),
+            unit("に", "ni", "に", 5),
+            unit("の", "no", "の", 6),
+            unit("ぞ", "zo", "ぞ", 6),
+            unit("む", "mu", "む", 6),
+        ])],
+        current_index: 0,
+    }
+}
+
+fn auto_clause_tyu_spec_state() -> SimSpecState {
+    SimSpecState {
+        committed_clauses: Vec::new(),
+        clauses: vec![clause(vec![
+            unit("ちゅ", "tyu", "ちゅ", 7),
+            unit("う", "u", "う", 7),
+            unit("い", "i", "い", 7),
+            unit("し", "si", "し", 8),
+            unit("て", "te", "て", 8),
+        ])],
+        current_index: 0,
+    }
+}
+
 fn candidates_owned(
     texts: Vec<String>,
     sub_texts: Vec<String>,
@@ -408,6 +455,38 @@ fn candidates_for_clause(spec: &SimSpecState, clause_index: usize) -> Candidates
         spec_join_raw_hiragana(&spec.clauses[clause_index..]),
         vec![current.corresponding_count(); texts.len()],
     )
+}
+
+fn auto_split_clauses_by_origin(units: &[SimUnit]) -> Vec<SimClause> {
+    let mut clauses: Vec<SimClause> = Vec::new();
+
+    for unit in units.iter().cloned() {
+        if let Some(last) = clauses.last_mut() {
+            if last.uniform_origin_id() == Some(unit.origin_id) {
+                last.units.push(unit);
+                continue;
+            }
+        }
+
+        clauses.push(clause(vec![unit]));
+    }
+
+    clauses
+}
+
+fn auto_first_clause_candidates(spec: &SimSpecState) -> Option<Candidates> {
+    let only_clause = spec.clauses.first()?;
+    let auto_clauses = auto_split_clauses_by_origin(&only_clause.units);
+    if auto_clauses.len() <= 1 {
+        return None;
+    }
+
+    let auto_spec = SimSpecState {
+        committed_clauses: Vec::new(),
+        clauses: auto_clauses,
+        current_index: 0,
+    };
+    Some(candidates_for_clause(&auto_spec, 0))
 }
 
 fn split_units_by_offset(units: &[SimUnit], offset: i32) -> Option<(Vec<SimUnit>, Vec<SimUnit>)> {
@@ -739,7 +818,8 @@ pub(super) fn harness_raw_clauses(harness: &ClauseHarness) -> String {
         return clauses.join(" / ");
     }
 
-    let trailing = harness.suffix.clone();
+    let trailing =
+        TextServiceFactory::current_raw_suffix(&harness.raw_hiragana, harness.corresponding_count);
     let current_raw = harness
         .raw_hiragana
         .strip_suffix(&trailing)
@@ -872,6 +952,21 @@ fn committed_current_clause_from_harness(harness: &ClauseHarness) -> SimCommitte
             &harness.future_clause_snapshots,
         ),
         corresponding_count: harness.corresponding_count,
+    }
+}
+
+fn committed_clause_from_future_snapshot(
+    snapshot: &FutureClauseSnapshot,
+    next_raw_hiragana: Option<&str>,
+) -> SimCommittedClause {
+    SimCommittedClause {
+        display: snapshot.selected_text.clone(),
+        raw_hiragana: TextServiceFactory::clause_raw_preview(
+            &snapshot.raw_hiragana,
+            next_raw_hiragana,
+            snapshot.corresponding_count,
+        ),
+        corresponding_count: snapshot.corresponding_count,
     }
 }
 
@@ -1010,6 +1105,21 @@ impl ScenarioBackend {
         }
     }
 
+    fn ensure_spec_clause_navigation_ready(&mut self) {
+        if self.spec.clauses.len() != 1 || self.spec.current_index != 0 {
+            return;
+        }
+
+        let units = self.spec.clauses[0].units.clone();
+        let auto_clauses = auto_split_clauses_by_origin(&units);
+        if auto_clauses.len() <= 1 {
+            return;
+        }
+
+        self.spec.clauses = auto_clauses;
+        self.spec.current_index = 0;
+    }
+
     fn step_spec_selection(&mut self, delta: i32) {
         let Some(current) = self.spec.clauses.get_mut(self.spec.current_index) else {
             return;
@@ -1021,16 +1131,8 @@ impl ScenarioBackend {
         current.clamp_selection();
     }
 
-    fn commit_spec_current_clause(&mut self) {
-        if self.spec.clauses.is_empty() || self.spec.current_index >= self.spec.clauses.len() {
-            return;
-        }
-
-        let committed = self
-            .spec
-            .clauses
-            .drain(..=self.spec.current_index)
-            .collect::<Vec<_>>();
+    fn commit_spec_all_clauses(&mut self) {
+        let committed = self.spec.clauses.drain(..).collect::<Vec<_>>();
         self.spec
             .committed_clauses
             .extend(committed.into_iter().map(|clause| SimCommittedClause {
@@ -1038,15 +1140,7 @@ impl ScenarioBackend {
                 raw_hiragana: clause.raw_hiragana(),
                 corresponding_count: clause.corresponding_count(),
             }));
-
-        if self.spec.clauses.is_empty() {
-            self.spec.current_index = 0;
-        } else {
-            self.spec.current_index = 0;
-            if let Some(current) = self.spec.clauses.get_mut(0) {
-                current.pending_remainder = false;
-            }
-        }
+        self.spec.current_index = 0;
     }
 
     fn apply_expected_user_action(&mut self, op: HarnessUserAction) {
@@ -1055,7 +1149,7 @@ impl ScenarioBackend {
             HarnessUserAction::Right => self.move_spec_right(),
             HarnessUserAction::ShiftLeft => self.split_spec_left(),
             HarnessUserAction::Space => {}
-            HarnessUserAction::Enter => self.commit_spec_current_clause(),
+            HarnessUserAction::Enter => self.commit_spec_all_clauses(),
             HarnessUserAction::SetTextType(set_type) => {
                 if let Some(current) = self.spec.clauses.get_mut(self.spec.current_index) {
                     current.display_override = Some(set_type);
@@ -1087,6 +1181,8 @@ impl ClauseActionBackend for ScenarioBackend {
             0 => {
                 if self.blocked_boundary {
                     Ok(Candidates::default())
+                } else if let Some(candidates) = auto_first_clause_candidates(&self.server) {
+                    Ok(candidates)
                 } else {
                     Ok(self.current_candidates())
                 }
@@ -1309,6 +1405,30 @@ fn apply_user_action(
 
     for action in actions {
         match action {
+            ClientAction::EnsureClauseNavigationReady => {
+                let mut state = ClauseActionStateMut {
+                    preview: &mut harness.preview,
+                    suffix: &mut harness.suffix,
+                    raw_input: &mut harness.raw_input,
+                    raw_hiragana: &mut harness.raw_hiragana,
+                    fixed_prefix: &mut harness.fixed_prefix,
+                    corresponding_count: &mut harness.corresponding_count,
+                    selection_index: &mut harness.selection_index,
+                    candidates: &mut harness.candidates,
+                    clause_snapshots: &mut harness.clause_snapshots,
+                    future_clause_snapshots: &mut harness.future_clause_snapshots,
+                    current_clause_is_split_derived: &mut harness.current_clause_is_split_derived,
+                    current_clause_is_direct_split_remainder: &mut harness
+                        .current_clause_is_direct_split_remainder,
+                    current_clause_has_split_left_neighbor: &mut harness
+                        .current_clause_has_split_left_neighbor,
+                    current_clause_split_group_id: &mut harness.current_clause_split_group_id,
+                    next_split_group_id: &mut harness.next_split_group_id,
+                };
+                TextServiceFactory::ensure_clause_navigation_ready(&mut state, backend)
+                    .expect("ensure_clause_navigation_ready");
+                backend.ensure_spec_clause_navigation_ready();
+            }
             ClientAction::MoveClause(direction) => {
                 backend.sync_current_selection(harness.selection_index);
                 let effect = {
@@ -1497,6 +1617,22 @@ fn apply_user_action(
                         .committed_clauses
                         .push(committed_current_clause_from_harness(harness));
                 }
+                let ordered_future = harness
+                    .future_clause_snapshots
+                    .iter()
+                    .rev()
+                    .collect::<Vec<_>>();
+                for (index, snapshot) in ordered_future.iter().enumerate() {
+                    let next_raw_hiragana = ordered_future
+                        .get(index + 1)
+                        .map(|next| next.raw_hiragana.as_str());
+                    harness
+                        .committed_clauses
+                        .push(committed_clause_from_future_snapshot(
+                            snapshot,
+                            next_raw_hiragana,
+                        ));
+                }
                 harness.preview.clear();
                 harness.suffix.clear();
                 harness.raw_input.clear();
@@ -1637,6 +1773,15 @@ fn run_to_fkey_baseline() -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAct
     (harness, backend, history)
 }
 
+fn run_to_auto_clause(
+    spec: SimSpecState,
+) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
+    let harness = build_harness_from_spec(&spec, CompositionState::Composing);
+    let backend = ScenarioBackend::new(spec);
+    let history = Vec::new();
+    (harness, backend, history)
+}
+
 pub(super) fn run_from_baseline(
     extra_actions: &[HarnessUserAction],
 ) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
@@ -1675,6 +1820,34 @@ pub(super) fn run_from_fkey_baseline(
     }
 
     (harness, backend, history)
+}
+
+fn run_from_auto_clause(
+    spec: SimSpecState,
+    extra_actions: &[HarnessUserAction],
+) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
+    let (mut harness, mut backend, mut history) = run_to_auto_clause(spec);
+    assert_harness_matches_spec(&harness, &backend.spec, &history);
+
+    for op in extra_actions {
+        history.push(*op);
+        apply_user_action(&mut harness, &mut backend, *op, &history);
+        assert_harness_matches_spec(&harness, &backend.spec, &history);
+    }
+
+    (harness, backend, history)
+}
+
+pub(super) fn run_from_auto_clause_ju(
+    extra_actions: &[HarnessUserAction],
+) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
+    run_from_auto_clause(auto_clause_ju_spec_state(), extra_actions)
+}
+
+pub(super) fn run_from_auto_clause_tyu(
+    extra_actions: &[HarnessUserAction],
+) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
+    run_from_auto_clause(auto_clause_tyu_spec_state(), extra_actions)
 }
 
 pub(super) fn fkey_cases() -> [(SetTextType, &'static str); 5] {

--- a/crates/client/src/engine/full_width.rs
+++ b/crates/client/src/engine/full_width.rs
@@ -108,22 +108,23 @@ static HALF_FULL_AZOOKEY: LazyLock<HashMap<&'static str, &'static str>> = LazyLo
     ])
 });
 
-static HALF_FULL_CONFIGURABLE: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
-    let mut map = HALF_FULL_AZOOKEY.clone();
-    map.extend([
-        ("0", "０"),
-        ("1", "１"),
-        ("2", "２"),
-        ("3", "３"),
-        ("4", "４"),
-        ("5", "５"),
-        ("6", "６"),
-        ("7", "７"),
-        ("8", "８"),
-        ("9", "９"),
-    ]);
-    map
-});
+static HALF_FULL_CONFIGURABLE: LazyLock<HashMap<&'static str, &'static str>> =
+    LazyLock::new(|| {
+        let mut map = HALF_FULL_AZOOKEY.clone();
+        map.extend([
+            ("0", "０"),
+            ("1", "１"),
+            ("2", "２"),
+            ("3", "３"),
+            ("4", "４"),
+            ("5", "５"),
+            ("6", "６"),
+            ("7", "７"),
+            ("8", "８"),
+            ("9", "９"),
+        ]);
+        map
+    });
 
 static SYMBOL_FULLWIDTH_DEFAULTS: LazyLock<HashMap<&'static str, bool>> =
     LazyLock::new(|| HashMap::from(CHARACTER_WIDTH_SYMBOL_DEFAULTS));
@@ -237,7 +238,9 @@ pub fn convert_kana_symbol(
 
             let base = apply_basic_setting(&key, general)
                 .map(str::to_string)
-                .unwrap_or_else(|| legacy_fullwidth_or_half(&key, &character_width.symbol_fullwidth));
+                .unwrap_or_else(|| {
+                    legacy_fullwidth_or_half(&key, &character_width.symbol_fullwidth)
+                });
 
             apply_width_groups_with_source_key(&base, &key, groups)
         })
@@ -302,7 +305,9 @@ fn legacy_fullwidth_or_half(key: &str, symbol_fullwidth: &HashMap<String, bool>)
 }
 
 fn apply_width_groups(text: &str, groups: &CharacterWidthGroups) -> String {
-    text.chars().map(|c| apply_width_group_char(c, groups)).collect()
+    text.chars()
+        .map(|c| apply_width_group_char(c, groups))
+        .collect()
 }
 
 fn apply_width_groups_with_source_key(
@@ -565,6 +570,9 @@ mod tests {
         let mut config = default_character_width();
         config.groups.hash_group = WidthMode::Full;
 
-        assert_eq!(convert_kana_symbol("ˆ", &GeneralConfig::default(), &config, &[]), "＾");
+        assert_eq!(
+            convert_kana_symbol("ˆ", &GeneralConfig::default(), &config, &[]),
+            "＾"
+        );
     }
 }

--- a/crates/client/src/engine/user_action.rs
+++ b/crates/client/src/engine/user_action.rs
@@ -165,14 +165,14 @@ impl TryFrom<usize> for UserAction {
             0x77 => UserAction::Function(Function::Eight), // VK_F8
             0x78 => UserAction::Function(Function::Nine), // VK_F9
             0x79 => UserAction::Function(Function::Ten), // VK_F10
-            0x6A => UserAction::NumpadSymbol('*'), // VK_MULTIPLY
-            0x6B => UserAction::NumpadSymbol('+'), // VK_ADD
-            0x6C => UserAction::NumpadSymbol(','), // VK_SEPARATOR
-            0x6D => UserAction::NumpadSymbol('-'), // VK_SUBTRACT
-            0x6E => UserAction::NumpadSymbol('.'), // VK_DECIMAL
-            0x6F => UserAction::NumpadSymbol('/'), // VK_DIVIDE
-            0x16 => UserAction::InputModeOn,  // VK_IME_ON
-            0x1A => UserAction::InputModeOff, // VK_IME_OFF
+            0x6A => UserAction::NumpadSymbol('*'),       // VK_MULTIPLY
+            0x6B => UserAction::NumpadSymbol('+'),       // VK_ADD
+            0x6C => UserAction::NumpadSymbol(','),       // VK_SEPARATOR
+            0x6D => UserAction::NumpadSymbol('-'),       // VK_SUBTRACT
+            0x6E => UserAction::NumpadSymbol('.'),       // VK_DECIMAL
+            0x6F => UserAction::NumpadSymbol('/'),       // VK_DIVIDE
+            0x16 => UserAction::InputModeOn,             // VK_IME_ON
+            0x1A => UserAction::InputModeOff,            // VK_IME_OFF
 
             0xF3 | 0xF4 => UserAction::ToggleInputMode, // Zenkaku/Hankaku
 

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -374,6 +374,53 @@ private func clampedCorrespondingCount(
     )
 }
 
+@MainActor func cursorPrefixCandidateResults(
+    mainResults: [Candidate],
+    firstClauseResults: [Candidate],
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText,
+    previewHiragana: String
+) -> [Candidate] {
+    guard let firstClauseCandidate = firstClauseResults.first else {
+        return mainResults
+    }
+
+    let firstClauseCorrespondingCount = resolveCandidateCompositionForDisplay(
+        originalComposingText: originalComposingText,
+        previewComposingText: previewComposingText,
+        candidateComposingCount: firstClauseCandidate.composingCount
+    ).correspondingCount
+
+    var seenTexts = Set<String>()
+    var results: [Candidate] = []
+
+    func appendIfNeeded(_ candidate: Candidate) {
+        let text = constructCandidateString(candidate: candidate, hiragana: previewHiragana)
+        guard seenTexts.insert(text).inserted else {
+            return
+        }
+        results.append(candidate)
+    }
+
+    for candidate in firstClauseResults {
+        appendIfNeeded(candidate)
+    }
+
+    for candidate in mainResults {
+        let correspondingCount = resolveCandidateCompositionForDisplay(
+            originalComposingText: originalComposingText,
+            previewComposingText: previewComposingText,
+            candidateComposingCount: candidate.composingCount
+        ).correspondingCount
+        guard correspondingCount == firstClauseCorrespondingCount else {
+            continue
+        }
+        appendIfNeeded(candidate)
+    }
+
+    return results
+}
+
 @MainActor func getOptions(context: String = "") -> ConvertRequestOptions {
     getOptions(
         context: context,
@@ -831,7 +878,13 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
     let requestStart = ProcessInfo.processInfo.systemUptime
     let converted = converter.requestCandidates(previewPrefixComposingText, options: options)
     let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
-    let cursorPrefixResults = converted.firstClauseResults.isEmpty ? converted.mainResults : converted.firstClauseResults
+    let cursorPrefixResults = cursorPrefixCandidateResults(
+        mainResults: converted.mainResults,
+        firstClauseResults: converted.firstClauseResults,
+        originalComposingText: prefixComposingText,
+        previewComposingText: previewPrefixComposingText,
+        previewHiragana: previewPrefixHiragana
+    )
     serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(cursorPrefixResults.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) elapsed_ms=\(requestMs)")
     var result: [FFICandidate] = []
 

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -831,12 +831,13 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
     let requestStart = ProcessInfo.processInfo.systemUptime
     let converted = converter.requestCandidates(previewPrefixComposingText, options: options)
     let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
-    serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(converted.mainResults.count) elapsed_ms=\(requestMs)")
+    let cursorPrefixResults = converted.firstClauseResults.isEmpty ? converted.mainResults : converted.firstClauseResults
+    serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(cursorPrefixResults.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) elapsed_ms=\(requestMs)")
     var result: [FFICandidate] = []
 
-    for i in 0..<converted.mainResults.count {
-        let candidate = converted.mainResults[i]
-        serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)/\(converted.mainResults.count)] start")
+    for i in 0..<cursorPrefixResults.count {
+        let candidate = cursorPrefixResults[i]
+        serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)/\(cursorPrefixResults.count)] start")
 
         let text = strdup(constructCandidateString(candidate: candidate, hiragana: previewPrefixHiragana))
         serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)] textReady")
@@ -850,7 +851,7 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
         debugLogResolvedCorrespondingCount(
             scope: "GetComposedTextForCursorPrefix",
             candidateIndex: i,
-            candidateTotal: converted.mainResults.count,
+            candidateTotal: cursorPrefixResults.count,
             candidateComposingCount: candidate.composingCount,
             resolvedCorrespondingCount: correspondingCount,
             inputCount: prefixComposingText.input.count,

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -377,19 +377,18 @@ private func clampedCorrespondingCount(
 @MainActor func cursorPrefixCandidateResults(
     mainResults: [Candidate],
     firstClauseResults: [Candidate],
+    exactClauseResults: [Candidate] = [],
     originalComposingText: ComposingText,
     previewComposingText: ComposingText,
     previewHiragana: String
 ) -> [Candidate] {
-    guard let firstClauseCandidate = firstClauseResults.first else {
+    guard let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
+        firstClauseResults: firstClauseResults,
+        originalComposingText: originalComposingText,
+        previewComposingText: previewComposingText
+    ) else {
         return mainResults
     }
-
-    let firstClauseCorrespondingCount = resolveCandidateCompositionForDisplay(
-        originalComposingText: originalComposingText,
-        previewComposingText: previewComposingText,
-        candidateComposingCount: firstClauseCandidate.composingCount
-    ).correspondingCount
 
     var seenTexts = Set<String>()
     var results: [Candidate] = []
@@ -402,23 +401,68 @@ private func clampedCorrespondingCount(
         results.append(candidate)
     }
 
-    for candidate in firstClauseResults {
-        appendIfNeeded(candidate)
-    }
-
-    for candidate in mainResults {
+    func matchesFirstClauseBoundary(_ candidate: Candidate) -> Bool {
         let correspondingCount = resolveCandidateCompositionForDisplay(
             originalComposingText: originalComposingText,
             previewComposingText: previewComposingText,
             candidateComposingCount: candidate.composingCount
         ).correspondingCount
-        guard correspondingCount == firstClauseCorrespondingCount else {
+        return correspondingCount == firstClauseCorrespondingCount
+    }
+
+    for candidate in firstClauseResults {
+        guard matchesFirstClauseBoundary(candidate) else {
+            continue
+        }
+        appendIfNeeded(candidate)
+    }
+
+    for candidate in mainResults {
+        guard matchesFirstClauseBoundary(candidate) else {
+            continue
+        }
+        appendIfNeeded(candidate)
+    }
+
+    for candidate in exactClauseResults {
+        guard matchesFirstClauseBoundary(candidate) else {
             continue
         }
         appendIfNeeded(candidate)
     }
 
     return results
+}
+
+@MainActor func cursorPrefixFirstClauseCorrespondingCount(
+    firstClauseResults: [Candidate],
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText
+) -> Int? {
+    firstClauseResults
+        .map {
+            resolveCandidateCompositionForDisplay(
+                originalComposingText: originalComposingText,
+                previewComposingText: previewComposingText,
+                candidateComposingCount: $0.composingCount
+            ).correspondingCount
+        }
+        .max()
+}
+
+@MainActor func makeCursorPrefixExactClauseComposingText(
+    prefixComposingText: ComposingText,
+    correspondingCount: Int
+) -> ComposingText {
+    var clauseComposingText = ComposingText()
+    let count = clampedCorrespondingCount(
+        composingText: prefixComposingText,
+        rawCount: correspondingCount
+    )
+    clauseComposingText.insertAtCursorPosition(
+        Array(prefixComposingText.input.prefix(count))
+    )
+    return clauseComposingText
 }
 
 @MainActor func getOptions(context: String = "") -> ConvertRequestOptions {
@@ -878,14 +922,44 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
     let requestStart = ProcessInfo.processInfo.systemUptime
     let converted = converter.requestCandidates(previewPrefixComposingText, options: options)
     let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
-    let cursorPrefixResults = cursorPrefixCandidateResults(
+    let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
+        firstClauseResults: converted.firstClauseResults,
+        originalComposingText: prefixComposingText,
+        previewComposingText: previewPrefixComposingText
+    )
+    let preliminaryCursorPrefixResults = cursorPrefixCandidateResults(
         mainResults: converted.mainResults,
         firstClauseResults: converted.firstClauseResults,
         originalComposingText: prefixComposingText,
         previewComposingText: previewPrefixComposingText,
         previewHiragana: previewPrefixHiragana
     )
-    serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(cursorPrefixResults.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) elapsed_ms=\(requestMs)")
+    let shouldRequestExactClauseResults = preliminaryCursorPrefixResults.count < 5
+    var exactClauseResults: [Candidate] = []
+    if let firstClauseCorrespondingCount, shouldRequestExactClauseResults {
+        let exactClauseComposingText = makeCursorPrefixExactClauseComposingText(
+            prefixComposingText: prefixComposingText,
+            correspondingCount: firstClauseCorrespondingCount
+        )
+        let exactClausePreviewState = makeCandidatePreviewComposingText(
+            from: exactClauseComposingText
+        )
+        exactClauseResults = converter.requestCandidates(
+            exactClausePreviewState.composingText,
+            options: options
+        ).mainResults
+    }
+    let cursorPrefixResults = exactClauseResults.isEmpty
+        ? preliminaryCursorPrefixResults
+        : cursorPrefixCandidateResults(
+            mainResults: converted.mainResults,
+            firstClauseResults: converted.firstClauseResults,
+            exactClauseResults: exactClauseResults,
+            originalComposingText: prefixComposingText,
+            previewComposingText: previewPrefixComposingText,
+            previewHiragana: previewPrefixHiragana
+        )
+    serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(cursorPrefixResults.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) exactClauseCandidateCount=\(exactClauseResults.count) elapsed_ms=\(requestMs)")
     var result: [FFICandidate] = []
 
     for i in 0..<cursorPrefixResults.count {

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -1044,7 +1044,8 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
         let resolvedCandidate = resolveCandidateCompositionForDisplay(
             originalComposingText: prefixComposingText,
             previewComposingText: previewPrefixComposingText,
-            candidateComposingCount: candidate.composingCount
+            candidateComposingCount: candidate.composingCount,
+            resolutionCache: &cursorPrefixResolutionCache
         )
         let correspondingCount = resolvedCandidate.correspondingCount
         debugLogResolvedCorrespondingCount(

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -35,6 +35,8 @@ private let fallbackDictionaryURL: URL = {
 let maxUserDictionaryEntryCount = 50
 let minInputCountForZenzaiCandidates = 4
 let minHiraganaCountForZenzaiCandidates = 2
+// Request exact-clause supplements only when boundary-matched candidates are sparse.
+let cursorPrefixExactClauseSupplementCandidateThreshold = 5
 let serverLogFileName = "server.log"
 
 private enum ServerLogLevel: Int {
@@ -358,6 +360,28 @@ private func clampedCorrespondingCount(
     )
 }
 
+typealias CandidateDisplayResolution = (correspondingCount: Int, remainingConvertTarget: String)
+
+@MainActor func resolveCandidateCompositionForDisplay(
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText,
+    candidateComposingCount: ComposingCount,
+    resolutionCache: inout [String: CandidateDisplayResolution]
+) -> CandidateDisplayResolution {
+    let cacheKey = String(describing: candidateComposingCount)
+    if let cached = resolutionCache[cacheKey] {
+        return cached
+    }
+
+    let resolved = resolveCandidateCompositionForDisplay(
+        originalComposingText: originalComposingText,
+        previewComposingText: previewComposingText,
+        candidateComposingCount: candidateComposingCount
+    )
+    resolutionCache[cacheKey] = resolved
+    return resolved
+}
+
 @MainActor private func debugLogResolvedCorrespondingCount(
     scope: String,
     candidateIndex: Int,
@@ -382,11 +406,36 @@ private func clampedCorrespondingCount(
     previewComposingText: ComposingText,
     previewHiragana: String
 ) -> [Candidate] {
-    guard let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
+    var resolutionCache: [String: CandidateDisplayResolution] = [:]
+    let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
         firstClauseResults: firstClauseResults,
         originalComposingText: originalComposingText,
-        previewComposingText: previewComposingText
-    ) else {
+        previewComposingText: previewComposingText,
+        resolutionCache: &resolutionCache
+    )
+    return cursorPrefixCandidateResults(
+        mainResults: mainResults,
+        firstClauseResults: firstClauseResults,
+        exactClauseResults: exactClauseResults,
+        firstClauseCorrespondingCount: firstClauseCorrespondingCount,
+        originalComposingText: originalComposingText,
+        previewComposingText: previewComposingText,
+        previewHiragana: previewHiragana,
+        resolutionCache: &resolutionCache
+    )
+}
+
+@MainActor func cursorPrefixCandidateResults(
+    mainResults: [Candidate],
+    firstClauseResults: [Candidate],
+    exactClauseResults: [Candidate] = [],
+    firstClauseCorrespondingCount: Int?,
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText,
+    previewHiragana: String,
+    resolutionCache: inout [String: CandidateDisplayResolution]
+) -> [Candidate] {
+    guard let firstClauseCorrespondingCount else {
         return mainResults
     }
 
@@ -405,7 +454,8 @@ private func clampedCorrespondingCount(
         let correspondingCount = resolveCandidateCompositionForDisplay(
             originalComposingText: originalComposingText,
             previewComposingText: previewComposingText,
-            candidateComposingCount: candidate.composingCount
+            candidateComposingCount: candidate.composingCount,
+            resolutionCache: &resolutionCache
         ).correspondingCount
         return correspondingCount == firstClauseCorrespondingCount
     }
@@ -439,12 +489,28 @@ private func clampedCorrespondingCount(
     originalComposingText: ComposingText,
     previewComposingText: ComposingText
 ) -> Int? {
+    var resolutionCache: [String: CandidateDisplayResolution] = [:]
+    return cursorPrefixFirstClauseCorrespondingCount(
+        firstClauseResults: firstClauseResults,
+        originalComposingText: originalComposingText,
+        previewComposingText: previewComposingText,
+        resolutionCache: &resolutionCache
+    )
+}
+
+@MainActor func cursorPrefixFirstClauseCorrespondingCount(
+    firstClauseResults: [Candidate],
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText,
+    resolutionCache: inout [String: CandidateDisplayResolution]
+) -> Int? {
     firstClauseResults
         .map {
             resolveCandidateCompositionForDisplay(
                 originalComposingText: originalComposingText,
                 previewComposingText: previewComposingText,
-                candidateComposingCount: $0.composingCount
+                candidateComposingCount: $0.composingCount,
+                resolutionCache: &resolutionCache
             ).correspondingCount
         }
         .max()
@@ -922,19 +988,23 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
     let requestStart = ProcessInfo.processInfo.systemUptime
     let converted = converter.requestCandidates(previewPrefixComposingText, options: options)
     let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
+    var cursorPrefixResolutionCache: [String: CandidateDisplayResolution] = [:]
     let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
         firstClauseResults: converted.firstClauseResults,
         originalComposingText: prefixComposingText,
-        previewComposingText: previewPrefixComposingText
+        previewComposingText: previewPrefixComposingText,
+        resolutionCache: &cursorPrefixResolutionCache
     )
     let preliminaryCursorPrefixResults = cursorPrefixCandidateResults(
         mainResults: converted.mainResults,
         firstClauseResults: converted.firstClauseResults,
+        firstClauseCorrespondingCount: firstClauseCorrespondingCount,
         originalComposingText: prefixComposingText,
         previewComposingText: previewPrefixComposingText,
-        previewHiragana: previewPrefixHiragana
+        previewHiragana: previewPrefixHiragana,
+        resolutionCache: &cursorPrefixResolutionCache
     )
-    let shouldRequestExactClauseResults = preliminaryCursorPrefixResults.count < 5
+    let shouldRequestExactClauseResults = preliminaryCursorPrefixResults.count < cursorPrefixExactClauseSupplementCandidateThreshold
     var exactClauseResults: [Candidate] = []
     if let firstClauseCorrespondingCount, shouldRequestExactClauseResults {
         let exactClauseComposingText = makeCursorPrefixExactClauseComposingText(
@@ -955,9 +1025,11 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
             mainResults: converted.mainResults,
             firstClauseResults: converted.firstClauseResults,
             exactClauseResults: exactClauseResults,
+            firstClauseCorrespondingCount: firstClauseCorrespondingCount,
             originalComposingText: prefixComposingText,
             previewComposingText: previewPrefixComposingText,
-            previewHiragana: previewPrefixHiragana
+            previewHiragana: previewPrefixHiragana,
+            resolutionCache: &cursorPrefixResolutionCache
         )
     serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(cursorPrefixResults.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) exactClauseCandidateCount=\(exactClauseResults.count) elapsed_ms=\(requestMs)")
     var result: [FFICandidate] = []

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -362,6 +362,11 @@ private func clampedCorrespondingCount(
 
 typealias CandidateDisplayResolution = (correspondingCount: Int, remainingConvertTarget: String)
 
+struct CursorPrefixCandidateResult {
+    let candidate: Candidate
+    let displayText: String
+}
+
 @MainActor func resolveCandidateCompositionForDisplay(
     originalComposingText: ComposingText,
     previewComposingText: ComposingText,
@@ -406,6 +411,24 @@ typealias CandidateDisplayResolution = (correspondingCount: Int, remainingConver
     previewComposingText: ComposingText,
     previewHiragana: String
 ) -> [Candidate] {
+    cursorPrefixCandidateDisplayResults(
+        mainResults: mainResults,
+        firstClauseResults: firstClauseResults,
+        exactClauseResults: exactClauseResults,
+        originalComposingText: originalComposingText,
+        previewComposingText: previewComposingText,
+        previewHiragana: previewHiragana
+    ).map(\.candidate)
+}
+
+@MainActor func cursorPrefixCandidateDisplayResults(
+    mainResults: [Candidate],
+    firstClauseResults: [Candidate],
+    exactClauseResults: [Candidate] = [],
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText,
+    previewHiragana: String
+) -> [CursorPrefixCandidateResult] {
     var resolutionCache: [String: CandidateDisplayResolution] = [:]
     let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
         firstClauseResults: firstClauseResults,
@@ -413,7 +436,7 @@ typealias CandidateDisplayResolution = (correspondingCount: Int, remainingConver
         previewComposingText: previewComposingText,
         resolutionCache: &resolutionCache
     )
-    return cursorPrefixCandidateResults(
+    return cursorPrefixCandidateDisplayResults(
         mainResults: mainResults,
         firstClauseResults: firstClauseResults,
         exactClauseResults: exactClauseResults,
@@ -425,7 +448,7 @@ typealias CandidateDisplayResolution = (correspondingCount: Int, remainingConver
     )
 }
 
-@MainActor func cursorPrefixCandidateResults(
+@MainActor func cursorPrefixCandidateDisplayResults(
     mainResults: [Candidate],
     firstClauseResults: [Candidate],
     exactClauseResults: [Candidate] = [],
@@ -434,20 +457,25 @@ typealias CandidateDisplayResolution = (correspondingCount: Int, remainingConver
     previewComposingText: ComposingText,
     previewHiragana: String,
     resolutionCache: inout [String: CandidateDisplayResolution]
-) -> [Candidate] {
+) -> [CursorPrefixCandidateResult] {
     guard let firstClauseCorrespondingCount else {
-        return mainResults
+        return mainResults.map {
+            CursorPrefixCandidateResult(
+                candidate: $0,
+                displayText: constructCandidateString(candidate: $0, hiragana: previewHiragana)
+            )
+        }
     }
 
     var seenTexts = Set<String>()
-    var results: [Candidate] = []
+    var results: [CursorPrefixCandidateResult] = []
 
     func appendIfNeeded(_ candidate: Candidate) {
         let text = constructCandidateString(candidate: candidate, hiragana: previewHiragana)
         guard seenTexts.insert(text).inserted else {
             return
         }
-        results.append(candidate)
+        results.append(CursorPrefixCandidateResult(candidate: candidate, displayText: text))
     }
 
     func matchesFirstClauseBoundary(_ candidate: Candidate) -> Bool {
@@ -987,7 +1015,6 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
     serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates begin useZenzai=\(useZenzai) syntheticEndOfText=\(previewState.syntheticEndOfText)")
     let requestStart = ProcessInfo.processInfo.systemUptime
     let converted = converter.requestCandidates(previewPrefixComposingText, options: options)
-    let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
     var cursorPrefixResolutionCache: [String: CandidateDisplayResolution] = [:]
     let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
         firstClauseResults: converted.firstClauseResults,
@@ -995,7 +1022,7 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
         previewComposingText: previewPrefixComposingText,
         resolutionCache: &cursorPrefixResolutionCache
     )
-    let preliminaryCursorPrefixResults = cursorPrefixCandidateResults(
+    let preliminaryCursorPrefixResults = cursorPrefixCandidateDisplayResults(
         mainResults: converted.mainResults,
         firstClauseResults: converted.firstClauseResults,
         firstClauseCorrespondingCount: firstClauseCorrespondingCount,
@@ -1021,7 +1048,7 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
     }
     let cursorPrefixResults = exactClauseResults.isEmpty
         ? preliminaryCursorPrefixResults
-        : cursorPrefixCandidateResults(
+        : cursorPrefixCandidateDisplayResults(
             mainResults: converted.mainResults,
             firstClauseResults: converted.firstClauseResults,
             exactClauseResults: exactClauseResults,
@@ -1031,14 +1058,16 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
             previewHiragana: previewPrefixHiragana,
             resolutionCache: &cursorPrefixResolutionCache
         )
+    let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
     serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(cursorPrefixResults.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) exactClauseCandidateCount=\(exactClauseResults.count) elapsed_ms=\(requestMs)")
     var result: [FFICandidate] = []
 
     for i in 0..<cursorPrefixResults.count {
-        let candidate = cursorPrefixResults[i]
+        let cursorPrefixResult = cursorPrefixResults[i]
+        let candidate = cursorPrefixResult.candidate
         serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)/\(cursorPrefixResults.count)] start")
 
-        let text = strdup(constructCandidateString(candidate: candidate, hiragana: previewPrefixHiragana))
+        let text = strdup(cursorPrefixResult.displayText)
         serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)] textReady")
         let hiragana = strdup(previewPrefixHiragana + suffixAfterCursor)
         let resolvedCandidate = resolveCandidateCompositionForDisplay(

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -55,6 +55,28 @@ private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions 
     )
 }
 
+private func testCandidate(
+    word: String,
+    ruby: String,
+    composingCount: ComposingCount
+) -> Candidate {
+    Candidate(
+        text: word,
+        value: -1,
+        composingCount: composingCount,
+        lastMid: MIDData.一般.mid,
+        data: [
+            DicdataElement(
+                word: word,
+                ruby: ruby,
+                cid: CIDData.一般名詞.cid,
+                mid: MIDData.一般.mid,
+                value: -1
+            )
+        ]
+    )
+}
+
 @Test func supportsNextInputCarryForTsuRules() async throws {
     let map = tableMap([
         row("tt", "っ", "t"),
@@ -417,4 +439,51 @@ private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions 
 
     #expect(preview.syntheticEndOfText == false)
     #expect(preview.composingText.convertTarget == "q")
+}
+
+@Test func cursorPrefixCandidatesSupplementFirstClauseWithMainResultsForSameBoundary() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("aruteidonagai", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let firstClause = testCandidate(
+            word: "ある程度",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        let hiragana = testCandidate(
+            word: "あるていど",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        let katakana = testCandidate(
+            word: "アルテイド",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        let fullSentence = Candidate(
+            text: "ある程度長い",
+            value: -1,
+            composingCount: .inputCount(13),
+            lastMid: MIDData.一般.mid,
+            data: [
+                DicdataElement(
+                    word: "ある程度長い",
+                    ruby: "あるていどながい",
+                    cid: CIDData.一般名詞.cid,
+                    mid: MIDData.一般.mid,
+                    value: -1
+                )
+            ]
+        )
+        return cursorPrefixCandidateResults(
+            mainResults: [fullSentence, hiragana, katakana],
+            firstClauseResults: [firstClause],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map { constructCandidateString(candidate: $0, hiragana: preview.convertTarget) }
+    }
+
+    #expect(resultTexts == ["ある程度", "あるていど", "アルテイド"])
 }

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -487,3 +487,182 @@ private func testCandidate(
 
     #expect(resultTexts == ["ある程度", "あるていど", "アルテイド"])
 }
+
+@Test func cursorPrefixCandidatesDropFirstClauseResultsForDifferentBoundary() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("iikagentouitusiro", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let firstClause = testCandidate(
+            word: "いい加減",
+            ruby: "いいかげん",
+            composingCount: .inputCount(7)
+        )
+        let tooShort = testCandidate(
+            word: "いい",
+            ruby: "いい",
+            composingCount: .inputCount(2)
+        )
+        let hiragana = testCandidate(
+            word: "いいかげん",
+            ruby: "いいかげん",
+            composingCount: .inputCount(7)
+        )
+        return cursorPrefixCandidateResults(
+            mainResults: [],
+            firstClauseResults: [firstClause, tooShort, hiragana],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map { constructCandidateString(candidate: $0, hiragana: preview.convertTarget) }
+    }
+
+    #expect(resultTexts == ["いい加減", "いいかげん"])
+}
+
+@Test func cursorPrefixCandidatesUseLongestFirstClauseBoundaryWhenShorterCandidateRanksFirst() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("iikagentouitusiro", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let tooShort = testCandidate(
+            word: "いい",
+            ruby: "いい",
+            composingCount: .inputCount(2)
+        )
+        let firstClause = testCandidate(
+            word: "いい加減",
+            ruby: "いいかげん",
+            composingCount: .inputCount(7)
+        )
+        let hiragana = testCandidate(
+            word: "いいかげん",
+            ruby: "いいかげん",
+            composingCount: .inputCount(7)
+        )
+        return cursorPrefixCandidateResults(
+            mainResults: [],
+            firstClauseResults: [tooShort, firstClause, hiragana],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map { constructCandidateString(candidate: $0, hiragana: preview.convertTarget) }
+    }
+
+    #expect(resultTexts == ["いい加減", "いいかげん"])
+}
+
+@Test func cursorPrefixCandidatesSupplementWithExactClauseResultsWhenMainResultsLackSameBoundary() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("aruteidonagaibunsetsudemo", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let firstClause = testCandidate(
+            word: "ある程度",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        let fullSentence = Candidate(
+            text: "ある程度長い文節でも",
+            value: -1,
+            composingCount: .inputCount(25),
+            lastMid: MIDData.一般.mid,
+            data: [
+                DicdataElement(
+                    word: "ある程度長い文節でも",
+                    ruby: "あるていどながいぶんせつでも",
+                    cid: CIDData.一般名詞.cid,
+                    mid: MIDData.一般.mid,
+                    value: -1
+                )
+            ]
+        )
+        let hiragana = testCandidate(
+            word: "あるていど",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        let katakana = testCandidate(
+            word: "アルテイド",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        return cursorPrefixCandidateResults(
+            mainResults: [fullSentence],
+            firstClauseResults: [firstClause],
+            exactClauseResults: [hiragana, katakana],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map { constructCandidateString(candidate: $0, hiragana: preview.convertTarget) }
+    }
+
+    #expect(resultTexts == ["ある程度", "あるていど", "アルテイド"])
+}
+
+@Test func cursorPrefixCandidatesSupplementParticleClauseWithExactClauseResults() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("bunsetsudemofukusuunibunkatsusareru", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let firstClause = testCandidate(
+            word: "文節でも",
+            ruby: "ぶんせつでも",
+            composingCount: .inputCount(12)
+        )
+        let alternative = testCandidate(
+            word: "分節でも",
+            ruby: "ぶんせつでも",
+            composingCount: .inputCount(12)
+        )
+        let hiragana = testCandidate(
+            word: "ぶんせつでも",
+            ruby: "ぶんせつでも",
+            composingCount: .inputCount(12)
+        )
+        let katakana = testCandidate(
+            word: "ブンセツデモ",
+            ruby: "ぶんせつでも",
+            composingCount: .inputCount(12)
+        )
+        let fullSentence = Candidate(
+            text: "文節でも複数に分割される",
+            value: -1,
+            composingCount: .inputCount(35),
+            lastMid: MIDData.一般.mid,
+            data: [
+                DicdataElement(
+                    word: "文節でも複数に分割される",
+                    ruby: "ぶんせつでもふくすうにぶんかつされる",
+                    cid: CIDData.一般名詞.cid,
+                    mid: MIDData.一般.mid,
+                    value: -1
+                )
+            ]
+        )
+        return cursorPrefixCandidateResults(
+            mainResults: [fullSentence],
+            firstClauseResults: [firstClause, alternative],
+            exactClauseResults: [firstClause, alternative, hiragana, katakana],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map { constructCandidateString(candidate: $0, hiragana: preview.convertTarget) }
+    }
+
+    #expect(resultTexts == ["文節でも", "分節でも", "ぶんせつでも", "ブンセツデモ"])
+}
+
+@Test func cursorPrefixExactClauseComposingTextPreservesSelectedClauseInput() async throws {
+    let clause = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("aruteidonagaibunsetsudemo", inputStyle: .roman2kana)
+        return makeCursorPrefixExactClauseComposingText(
+            prefixComposingText: source,
+            correspondingCount: 8
+        )
+    }
+
+    #expect(clause.convertTarget == "あるていど")
+    #expect(clause.input.count == 8)
+}


### PR DESCRIPTION
## Summary
- Re-rolled the auto clause navigation fix from the parent of `42bd03d`, dropping the broken `42bd03d` / `e2610fa` approach.
- Fixes the single-n auto-split boundary case where `iikagentouitusiro` could split as `いい加減 / 横溢しろ` instead of `いい加減 / 統一しろ`.
- Keeps the boundary fix on the Rust client snapshot/suffix restoration path; no new Swift server FFI, no raw suffix re-input path.
- Addresses follow-up review feedback in the existing Swift cursor-prefix path by reusing constructed display text and logging elapsed time across exact-clause supplementation.

## Root Cause
The auto split code was treating a server `corresponding_count` as though it could be used directly against the hiragana string. At a single-n romaji boundary, that let the remaining clause suffix be reinterpreted incorrectly and cached as a broken future snapshot.

## Changes
- Prefer existing matching future snapshots and trusted display/raw suffix hints when rebuilding future clause snapshots.
- Avoid caching conservative snapshots when the suffix cannot be trusted.
- Recover the single-n boundary case without clearing/appending server composition state.
- Add regression coverage for both `iikagentouitusiro` and `iikagenntouitusiro`, plus conservative snapshot behavior.
- Reuse cursor-prefix display strings instead of reconstructing them again while building FFI candidates.
- Measure cursor-prefix elapsed time after optional exact-clause supplementation.

## Verification
- `bash .local/vm_test_client_composition.sh feature/issue-32-auto-clause-navigation-reroll initial_auto_split_recovers_single_n_suffix_without_reinput skip`
- `bash .local/vm_test_client_composition.sh feature/issue-32-auto-clause-navigation-reroll clause_integration_matches_spec_for_histories_up_to_depth_eight skip`
- `bash .local/vm_test_client_composition.sh feature/issue-32-auto-clause-navigation-reroll composition skip` (`89 passed`)
- `git diff --check`
- `bash .local/vm_build_master.sh feature/issue-32-auto-clause-navigation-reroll`
- `bash .local/vm_stage_for_manual_test.sh latest` (installer exit code `0`)

## Artifacts
- Installer: `/home/batao9/workspaces/azooKey-Windows/.local/artifacts/azookey-setup-feature_issue-32-auto-clause-navigation-reroll-20260516-215200.exe`
- Install log: `/home/batao9/workspaces/azooKey-Windows/.local/logs/win11-install-20260516-223352.log`