### PR TITLE
chore(release): prepare v0.1.0-batao.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0-batao.1",
+  "version": "0.1.0-batao.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0-batao.1",
+      "version": "0.1.0-batao.2",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-dialog": "^1.1.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0-batao.1",
+  "version": "0.1.0-batao.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Azookey",
-  "version": "0.1.0-batao.1",
+  "version": "0.1.0-batao.2",
   "identifier": "com.azookey.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/frontend/src/pages/general.tsx
+++ b/frontend/src/pages/general.tsx
@@ -474,7 +474,7 @@ export const General = () => {
                     <div className="flex items-center space-x-4 rounded-md border p-4">
                         <RefreshCcw />
                         <div className="flex-1 space-y-1">
-                            <p className="text-sm font-medium leading-none">v0.1.0-batao.1</p>
+                            <p className="text-sm font-medium leading-none">v0.1.0-batao.2</p>
                         </div>
                         <Button variant="secondary">
                             <a

--- a/installer/Installer.iss
+++ b/installer/Installer.iss
@@ -3,7 +3,7 @@
 #include "CodeDependencies.iss"
 
 #define MyAppName "Azookey"
-#define MyAppVersion "0.1.0-batao.1"
+#define MyAppVersion "0.1.0-batao.2"
 #define MyAppPublisher "batao9"
 #define MyAppURL "https://github.com/batao9/azooKey-Windows/"
 
@@ -43,7 +43,7 @@ Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Source: "../build/azookey_windows.dll"; DestDir: "{app}"; DestName: "azookey.dll"; Flags: ignoreversion regserver 64bit
 Source: "../build/x86/azookey_windows.dll"; DestDir: "{app}"; DestName: "azookey32.dll"; Flags: ignoreversion regserver 32bit
 Source: "../build/*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "../target/release/bundle/nsis/Azookey_0.1.0-batao.1_x64-setup.exe"; Flags: dontcopy noencryption
+Source: "../target/release/bundle/nsis/Azookey_0.1.0-batao.2_x64-setup.exe"; Flags: dontcopy noencryption
 Source: "./Azookey Startup.xml"; Flags: dontcopy noencryption
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
@@ -65,10 +65,10 @@ Filename: "schtasks"; \
 [Code]
 function InitializeSetup: Boolean;
 begin
-  ExtractTemporaryFile('Azookey_0.1.0-batao.1_x64-setup.exe');
+  ExtractTemporaryFile('Azookey_0.1.0-batao.2_x64-setup.exe');
   Dependency_AddVC2015To2022x64;
   Dependency_AddVC2015To2022x86;
-  Dependency_Add('Azookey_0.1.0-batao.1_x64-setup.exe',
+  Dependency_Add('Azookey_0.1.0-batao.2_x64-setup.exe',
     '/S',
     'Azookey',
     '', '', True, False);


### PR DESCRIPTION
## Summary
- release 向けにアプリ版数を `0.1.0-batao.2` へ更新
- 設定画面のバージョン表示を `v0.1.0-batao.2` に更新
- Inno Setup が内包する NSIS installer 名を `0.1.0-batao.2` 向けに更新

## Background
- Issue: N/A
- `v0.1.0-batao.2` として fork 版の次回リリースを作成するため、アプリ内表示と installer の version / bundle 参照を揃えます。

## Changes
- frontend / tauri
  - app version を `0.1.0-batao.2` に更新
  - 設定画面のバージョン表示を `v0.1.0-batao.2` に更新
- installer
  - Inno Setup の version と内包する NSIS installer 名を `0.1.0-batao.2` に更新

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/25506095921
- [x] VM build 成功
  - `.local/vm_build_master.sh feature/release-v0.1.0-batao.2`
  - artifact: `.local/artifacts/azookey-setup-feature_release-v0.1.0-batao.2-20260508-000121.exe`
- [x] 設定値確認
  - `frontend/src-tauri/tauri.conf.json` の version が `0.1.0-batao.2` であることを確認
  - `installer/Installer.iss` が `Azookey_0.1.0-batao.2_x64-setup.exe` を参照することを確認

## Checklist
- [x] CI run URL と結果を記載した
- [x] 影響範囲を確認した