### PR TITLE
Add developer perf logging option for issue 40

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -238,7 +238,7 @@ impl TextServiceFactory {
     #[inline]
     fn normalize_direct_symbol_char(c: char) -> char {
         let halfwidth_ascii = Self::to_halfwidth_ascii_char(c);
-        if halfwidth_ascii.is_ascii_punctuation() {
+        if halfwidth_ascii.is_ascii_alphanumeric() || halfwidth_ascii.is_ascii_punctuation() {
             return halfwidth_ascii;
         }
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -17,10 +17,10 @@ use std::{
     io::Write,
     path::PathBuf,
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Mutex, OnceLock,
     },
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
 const USE_ZENZAI: bool = true;
@@ -30,9 +30,9 @@ const WARMUP_INTERVAL_SECS: u64 = 30;
 
 static SERVER_LOG_FILE: OnceLock<Mutex<Option<File>>> = OnceLock::new();
 static SERVER_LOG_LEVEL: OnceLock<ServerLogLevel> = OnceLock::new();
+static SERVER_PERF_LOG_ENABLED: AtomicBool = AtomicBool::new(false);
 static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
-static HAS_ACTIVE_COMPOSITION: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+static HAS_ACTIVE_COMPOSITION: AtomicBool = AtomicBool::new(false);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 enum ServerLogLevel {
@@ -83,11 +83,43 @@ fn should_log(level: ServerLogLevel) -> bool {
     level <= current_server_log_level()
 }
 
+fn perf_log_enabled() -> bool {
+    SERVER_PERF_LOG_ENABLED.load(Ordering::Relaxed)
+}
+
+fn refresh_perf_log_enabled_from_config() {
+    let config = shared::AppConfig::read();
+    SERVER_PERF_LOG_ENABLED.store(
+        config.developer_options.enable && config.developer_options.logging,
+        Ordering::Relaxed,
+    );
+}
+
+fn should_collect_timing(level: ServerLogLevel) -> bool {
+    should_log(level) || perf_log_enabled()
+}
+
+fn timing_start(enabled: bool) -> Option<Instant> {
+    enabled.then(Instant::now)
+}
+
+fn elapsed_millis(start: Option<Instant>) -> u128 {
+    start.map_or(0, |start| start.elapsed().as_millis())
+}
+
 macro_rules! log_event_lazy {
     ($level:expr, $($arg:tt)*) => {{
         let level = $level;
         if should_log(level) {
             log_event(level, &format!($($arg)*));
+        }
+    }};
+}
+
+macro_rules! perf_log_lazy {
+    ($($arg:tt)*) => {{
+        if perf_log_enabled() {
+            log_event_unfiltered("PERF", &format!($($arg)*));
         }
     }};
 }
@@ -180,12 +212,11 @@ fn log_event(level: ServerLogLevel, message: &str) {
         return;
     }
 
-    let line = format!(
-        "[{}] [{}] {}",
-        now_timestamp_millis(),
-        level.as_str(),
-        message
-    );
+    log_event_unfiltered(level.as_str(), message);
+}
+
+fn log_event_unfiltered(level: &str, message: &str) {
+    let line = format!("[{}] [{}] {}", now_timestamp_millis(), level, message);
     eprintln!("{line}");
 
     if let Some(slot) = SERVER_LOG_FILE.get() {
@@ -367,12 +398,16 @@ fn update_active_composition_state(text: &str) {
 
 fn get_composed_text(use_cursor_prefix: bool) -> Result<ComposedText, String> {
     unsafe {
+        let collect_timing = perf_log_enabled();
+        let total_start = timing_start(collect_timing);
         let mut length: c_int = 0;
+        let ffi_start = timing_start(collect_timing);
         let result = if use_cursor_prefix {
             GetComposedTextForCursorPrefix(&mut length)
         } else {
             GetComposedText(&mut length)
         };
+        let ffi_elapsed_ms = elapsed_millis(ffi_start);
         let call_name = if use_cursor_prefix {
             "GetComposedTextForCursorPrefix"
         } else {
@@ -391,6 +426,7 @@ fn get_composed_text(use_cursor_prefix: bool) -> Result<ComposedText, String> {
 
         let mut suggestions = Vec::with_capacity(length);
         let mut hiragana = None;
+        let parse_start = timing_start(collect_timing);
         log_event_lazy!(
             ServerLogLevel::Debug,
             "[{call_name}] candidate_count={length}"
@@ -447,6 +483,13 @@ fn get_composed_text(use_cursor_prefix: bool) -> Result<ComposedText, String> {
             }
             suggestions.push(suggestion);
         }
+        let parse_elapsed_ms = elapsed_millis(parse_start);
+
+        perf_log_lazy!(
+            "kind=perf\tcomponent=rust-server\toperation={call_name}\tuse_cursor_prefix={use_cursor_prefix}\tcandidate_count={length}\tunique_suggestions={}\tffi_elapsed_ms={ffi_elapsed_ms}\tparse_elapsed_ms={parse_elapsed_ms}\ttotal_elapsed_ms={}",
+            suggestions.len(),
+            elapsed_millis(total_start)
+        );
 
         Ok(ComposedText {
             hiragana,
@@ -475,44 +518,52 @@ impl AzookeyService for MyAzookeyService {
         request: Request<AppendTextRequest>,
     ) -> Result<Response<AppendTextResponse>, Status> {
         let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
+        let collect_timing = should_collect_timing(ServerLogLevel::Info);
+        let perf_start = timing_start(collect_timing);
         let request = request.into_inner();
         let input = request.text_to_append;
+        let input_len = input.chars().count();
         log_event_lazy!(
             ServerLogLevel::Info,
             "[append_text:{request_id}] start input_len={} input_style={}",
-            input.chars().count(),
+            input_len,
             request.input_style
         );
-        let t0 = now_timestamp_millis();
+        let add_start = timing_start(collect_timing);
         let composing_text = if request.input_style == INPUT_STYLE_DIRECT {
             add_text_direct(&input).map_err(|error| status_from_error("append_text", error))?
         } else {
             add_text(&input).map_err(|error| status_from_error("append_text", error))?
         };
-        let t1 = now_timestamp_millis();
+        let add_elapsed_ms = elapsed_millis(add_start);
         log_event_lazy!(
             ServerLogLevel::Info,
-            "[append_text:{request_id}] add_text elapsed_ms={}",
-            t1.saturating_sub(t0)
+            "[append_text:{request_id}] add_text elapsed_ms={add_elapsed_ms}",
         );
+        let get_composed_start = timing_start(collect_timing);
         let composed_text =
             get_composed_text(false).map_err(|error| status_from_error("append_text", error))?;
-        let t2 = now_timestamp_millis();
+        let get_composed_elapsed_ms = elapsed_millis(get_composed_start);
         log_event_lazy!(
             ServerLogLevel::Info,
-            "[append_text:{request_id}] get_composed_text elapsed_ms={}",
-            t2.saturating_sub(t1)
+            "[append_text:{request_id}] get_composed_text elapsed_ms={get_composed_elapsed_ms}",
         );
         update_active_composition_state(&composing_text.text);
+        let hiragana_len = composing_text.text.chars().count();
+        let suggestion_count = composed_text.suggestions.len();
+        let total_elapsed_ms = elapsed_millis(perf_start);
 
         log_event_lazy!(
             ServerLogLevel::Info,
             "[append_text:{request_id}] success cursor={} hiragana_len={} suggestions={} total_elapsed_ms={}",
             composing_text.cursor,
-            composing_text.text.chars().count(),
-            composed_text.suggestions.len(),
-            t2.saturating_sub(handler_start)
+            hiragana_len,
+            suggestion_count,
+            total_elapsed_ms
+        );
+        perf_log_lazy!(
+            "kind=perf\tcomponent=rust-server\toperation=append_text\trequest_id={request_id}\tinput_len={input_len}\tinput_style={}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tadd_text_elapsed_ms={add_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}",
+            request.input_style
         );
 
         Ok(Response::new(AppendTextResponse {
@@ -528,35 +579,41 @@ impl AzookeyService for MyAzookeyService {
         _: Request<RemoveTextRequest>,
     ) -> Result<Response<RemoveTextResponse>, Status> {
         let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
+        let collect_timing = should_collect_timing(ServerLogLevel::Info);
+        let perf_start = timing_start(collect_timing);
         log_event_lazy!(ServerLogLevel::Info, "[remove_text:{request_id}] start");
 
-        let t0 = now_timestamp_millis();
+        let remove_start = timing_start(collect_timing);
         let composing_text =
             remove_text().map_err(|error| status_from_error("remove_text", error))?;
-        let t1 = now_timestamp_millis();
+        let remove_elapsed_ms = elapsed_millis(remove_start);
         log_event_lazy!(
             ServerLogLevel::Info,
-            "[remove_text:{request_id}] remove_text elapsed_ms={}",
-            t1.saturating_sub(t0)
+            "[remove_text:{request_id}] remove_text elapsed_ms={remove_elapsed_ms}",
         );
+        let get_composed_start = timing_start(collect_timing);
         let composed_text =
             get_composed_text(false).map_err(|error| status_from_error("remove_text", error))?;
-        let t2 = now_timestamp_millis();
+        let get_composed_elapsed_ms = elapsed_millis(get_composed_start);
         log_event_lazy!(
             ServerLogLevel::Info,
-            "[remove_text:{request_id}] get_composed_text elapsed_ms={}",
-            t2.saturating_sub(t1)
+            "[remove_text:{request_id}] get_composed_text elapsed_ms={get_composed_elapsed_ms}",
         );
         update_active_composition_state(&composing_text.text);
+        let hiragana_len = composing_text.text.chars().count();
+        let suggestion_count = composed_text.suggestions.len();
+        let total_elapsed_ms = elapsed_millis(perf_start);
 
         log_event_lazy!(
             ServerLogLevel::Info,
             "[remove_text:{request_id}] success cursor={} hiragana_len={} suggestions={} total_elapsed_ms={}",
             composing_text.cursor,
-            composing_text.text.chars().count(),
-            composed_text.suggestions.len(),
-            t2.saturating_sub(handler_start)
+            hiragana_len,
+            suggestion_count,
+            total_elapsed_ms
+        );
+        perf_log_lazy!(
+            "kind=perf\tcomponent=rust-server\toperation=remove_text\trequest_id={request_id}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tremove_text_elapsed_ms={remove_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}"
         );
 
         Ok(Response::new(RemoveTextResponse {
@@ -572,7 +629,8 @@ impl AzookeyService for MyAzookeyService {
         request: Request<MoveCursorRequest>,
     ) -> Result<Response<MoveCursorResponse>, Status> {
         let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
+        let collect_timing = should_collect_timing(ServerLogLevel::Info);
+        let perf_start = timing_start(collect_timing);
         let raw_offset = request.into_inner().offset;
         log_event_lazy!(
             ServerLogLevel::Info,
@@ -581,32 +639,37 @@ impl AzookeyService for MyAzookeyService {
 
         let offset = i8_offset_from_i32("move_cursor", raw_offset)?;
         let use_cursor_prefix = offset == 0;
-        let t0 = now_timestamp_millis();
+        let move_start = timing_start(collect_timing);
         let composing_text =
             move_cursor(offset).map_err(|error| status_from_error("move_cursor", error))?;
-        let t1 = now_timestamp_millis();
+        let move_elapsed_ms = elapsed_millis(move_start);
         log_event_lazy!(
             ServerLogLevel::Info,
-            "[move_cursor:{request_id}] move_cursor elapsed_ms={}",
-            t1.saturating_sub(t0)
+            "[move_cursor:{request_id}] move_cursor elapsed_ms={move_elapsed_ms}",
         );
+        let get_composed_start = timing_start(collect_timing);
         let composed_text = get_composed_text(use_cursor_prefix)
             .map_err(|error| status_from_error("move_cursor", error))?;
-        let t2 = now_timestamp_millis();
+        let get_composed_elapsed_ms = elapsed_millis(get_composed_start);
         log_event_lazy!(
             ServerLogLevel::Info,
-            "[move_cursor:{request_id}] get_composed_text elapsed_ms={}",
-            t2.saturating_sub(t1)
+            "[move_cursor:{request_id}] get_composed_text elapsed_ms={get_composed_elapsed_ms}",
         );
         update_active_composition_state(&composing_text.text);
+        let hiragana_len = composing_text.text.chars().count();
+        let suggestion_count = composed_text.suggestions.len();
+        let total_elapsed_ms = elapsed_millis(perf_start);
 
         log_event_lazy!(
             ServerLogLevel::Info,
             "[move_cursor:{request_id}] success cursor={} hiragana_len={} suggestions={} use_cursor_prefix={use_cursor_prefix} total_elapsed_ms={}",
             composing_text.cursor,
-            composing_text.text.chars().count(),
-            composed_text.suggestions.len(),
-            t2.saturating_sub(handler_start)
+            hiragana_len,
+            suggestion_count,
+            total_elapsed_ms
+        );
+        perf_log_lazy!(
+            "kind=perf\tcomponent=rust-server\toperation=move_cursor\trequest_id={request_id}\toffset={raw_offset}\tuse_cursor_prefix={use_cursor_prefix}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tmove_cursor_elapsed_ms={move_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}"
         );
 
         Ok(Response::new(MoveCursorResponse {
@@ -642,7 +705,8 @@ impl AzookeyService for MyAzookeyService {
         request: Request<ShrinkTextRequest>,
     ) -> Result<Response<ShrinkTextResponse>, Status> {
         let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
+        let collect_timing = should_collect_timing(ServerLogLevel::Info);
+        let perf_start = timing_start(collect_timing);
         let raw_offset = request.into_inner().offset;
         log_event_lazy!(
             ServerLogLevel::Info,
@@ -650,31 +714,36 @@ impl AzookeyService for MyAzookeyService {
         );
 
         let offset = i8_offset_from_i32("shrink_text", raw_offset)?;
-        let t0 = now_timestamp_millis();
+        let shrink_start = timing_start(collect_timing);
         let composing_text =
             shrink_text(offset).map_err(|error| status_from_error("shrink_text", error))?;
-        let t1 = now_timestamp_millis();
+        let shrink_elapsed_ms = elapsed_millis(shrink_start);
         log_event_lazy!(
             ServerLogLevel::Info,
-            "[shrink_text:{request_id}] shrink_text elapsed_ms={}",
-            t1.saturating_sub(t0)
+            "[shrink_text:{request_id}] shrink_text elapsed_ms={shrink_elapsed_ms}",
         );
+        let get_composed_start = timing_start(collect_timing);
         let composed_text =
             get_composed_text(false).map_err(|error| status_from_error("shrink_text", error))?;
-        let t2 = now_timestamp_millis();
+        let get_composed_elapsed_ms = elapsed_millis(get_composed_start);
         log_event_lazy!(
             ServerLogLevel::Info,
-            "[shrink_text:{request_id}] get_composed_text elapsed_ms={}",
-            t2.saturating_sub(t1)
+            "[shrink_text:{request_id}] get_composed_text elapsed_ms={get_composed_elapsed_ms}",
         );
         update_active_composition_state(&composing_text.text);
+        let hiragana_len = composing_text.text.chars().count();
+        let suggestion_count = composed_text.suggestions.len();
+        let total_elapsed_ms = elapsed_millis(perf_start);
 
         log_event_lazy!(
             ServerLogLevel::Info,
             "[shrink_text:{request_id}] success hiragana_len={} suggestions={} total_elapsed_ms={}",
-            composing_text.text.chars().count(),
-            composed_text.suggestions.len(),
-            t2.saturating_sub(handler_start)
+            hiragana_len,
+            suggestion_count,
+            total_elapsed_ms
+        );
+        perf_log_lazy!(
+            "kind=perf\tcomponent=rust-server\toperation=shrink_text\trequest_id={request_id}\toffset={raw_offset}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tshrink_text_elapsed_ms={shrink_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}"
         );
 
         Ok(Response::new(ShrinkTextResponse {
@@ -728,6 +797,7 @@ impl AzookeyService for MyAzookeyService {
         log_event_lazy!(ServerLogLevel::Info, "[update_config:{request_id}] start");
         let t0 = now_timestamp_millis();
         unsafe { LoadConfig() };
+        refresh_perf_log_enabled_from_config();
         let t1 = now_timestamp_millis();
         let has_active_composition = query_active_composition_state();
         log_event_lazy!(
@@ -748,6 +818,7 @@ impl AzookeyService for MyAzookeyService {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    refresh_perf_log_enabled_from_config();
     let log_path = init_server_log_file();
     install_panic_hook();
     log_event_lazy!(

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -522,13 +522,15 @@ impl AzookeyService for MyAzookeyService {
         let perf_start = timing_start(collect_timing);
         let request = request.into_inner();
         let input = request.text_to_append;
-        let input_len = input.chars().count();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[append_text:{request_id}] start input_len={} input_style={}",
-            input_len,
-            request.input_style
-        );
+        if collect_timing {
+            let input_len = input.chars().count();
+            log_event_lazy!(
+                ServerLogLevel::Info,
+                "[append_text:{request_id}] start input_len={} input_style={}",
+                input_len,
+                request.input_style
+            );
+        }
         let add_start = timing_start(collect_timing);
         let composing_text = if request.input_style == INPUT_STYLE_DIRECT {
             add_text_direct(&input).map_err(|error| status_from_error("append_text", error))?
@@ -549,22 +551,25 @@ impl AzookeyService for MyAzookeyService {
             "[append_text:{request_id}] get_composed_text elapsed_ms={get_composed_elapsed_ms}",
         );
         update_active_composition_state(&composing_text.text);
-        let hiragana_len = composing_text.text.chars().count();
-        let suggestion_count = composed_text.suggestions.len();
-        let total_elapsed_ms = elapsed_millis(perf_start);
+        if collect_timing {
+            let input_len = input.chars().count();
+            let hiragana_len = composing_text.text.chars().count();
+            let suggestion_count = composed_text.suggestions.len();
+            let total_elapsed_ms = elapsed_millis(perf_start);
 
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[append_text:{request_id}] success cursor={} hiragana_len={} suggestions={} total_elapsed_ms={}",
-            composing_text.cursor,
-            hiragana_len,
-            suggestion_count,
-            total_elapsed_ms
-        );
-        perf_log_lazy!(
-            "kind=perf\tcomponent=rust-server\toperation=append_text\trequest_id={request_id}\tinput_len={input_len}\tinput_style={}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tadd_text_elapsed_ms={add_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}",
-            request.input_style
-        );
+            log_event_lazy!(
+                ServerLogLevel::Info,
+                "[append_text:{request_id}] success cursor={} hiragana_len={} suggestions={} total_elapsed_ms={}",
+                composing_text.cursor,
+                hiragana_len,
+                suggestion_count,
+                total_elapsed_ms
+            );
+            perf_log_lazy!(
+                "kind=perf\tcomponent=rust-server\toperation=append_text\trequest_id={request_id}\tinput_len={input_len}\tinput_style={}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tadd_text_elapsed_ms={add_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}",
+                request.input_style
+            );
+        }
 
         Ok(Response::new(AppendTextResponse {
             composing_text: Some(ComposingText {
@@ -600,21 +605,23 @@ impl AzookeyService for MyAzookeyService {
             "[remove_text:{request_id}] get_composed_text elapsed_ms={get_composed_elapsed_ms}",
         );
         update_active_composition_state(&composing_text.text);
-        let hiragana_len = composing_text.text.chars().count();
-        let suggestion_count = composed_text.suggestions.len();
-        let total_elapsed_ms = elapsed_millis(perf_start);
+        if collect_timing {
+            let hiragana_len = composing_text.text.chars().count();
+            let suggestion_count = composed_text.suggestions.len();
+            let total_elapsed_ms = elapsed_millis(perf_start);
 
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[remove_text:{request_id}] success cursor={} hiragana_len={} suggestions={} total_elapsed_ms={}",
-            composing_text.cursor,
-            hiragana_len,
-            suggestion_count,
-            total_elapsed_ms
-        );
-        perf_log_lazy!(
-            "kind=perf\tcomponent=rust-server\toperation=remove_text\trequest_id={request_id}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tremove_text_elapsed_ms={remove_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}"
-        );
+            log_event_lazy!(
+                ServerLogLevel::Info,
+                "[remove_text:{request_id}] success cursor={} hiragana_len={} suggestions={} total_elapsed_ms={}",
+                composing_text.cursor,
+                hiragana_len,
+                suggestion_count,
+                total_elapsed_ms
+            );
+            perf_log_lazy!(
+                "kind=perf\tcomponent=rust-server\toperation=remove_text\trequest_id={request_id}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tremove_text_elapsed_ms={remove_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}"
+            );
+        }
 
         Ok(Response::new(RemoveTextResponse {
             composing_text: Some(ComposingText {
@@ -656,21 +663,23 @@ impl AzookeyService for MyAzookeyService {
             "[move_cursor:{request_id}] get_composed_text elapsed_ms={get_composed_elapsed_ms}",
         );
         update_active_composition_state(&composing_text.text);
-        let hiragana_len = composing_text.text.chars().count();
-        let suggestion_count = composed_text.suggestions.len();
-        let total_elapsed_ms = elapsed_millis(perf_start);
+        if collect_timing {
+            let hiragana_len = composing_text.text.chars().count();
+            let suggestion_count = composed_text.suggestions.len();
+            let total_elapsed_ms = elapsed_millis(perf_start);
 
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[move_cursor:{request_id}] success cursor={} hiragana_len={} suggestions={} use_cursor_prefix={use_cursor_prefix} total_elapsed_ms={}",
-            composing_text.cursor,
-            hiragana_len,
-            suggestion_count,
-            total_elapsed_ms
-        );
-        perf_log_lazy!(
-            "kind=perf\tcomponent=rust-server\toperation=move_cursor\trequest_id={request_id}\toffset={raw_offset}\tuse_cursor_prefix={use_cursor_prefix}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tmove_cursor_elapsed_ms={move_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}"
-        );
+            log_event_lazy!(
+                ServerLogLevel::Info,
+                "[move_cursor:{request_id}] success cursor={} hiragana_len={} suggestions={} use_cursor_prefix={use_cursor_prefix} total_elapsed_ms={}",
+                composing_text.cursor,
+                hiragana_len,
+                suggestion_count,
+                total_elapsed_ms
+            );
+            perf_log_lazy!(
+                "kind=perf\tcomponent=rust-server\toperation=move_cursor\trequest_id={request_id}\toffset={raw_offset}\tuse_cursor_prefix={use_cursor_prefix}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tmove_cursor_elapsed_ms={move_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}"
+            );
+        }
 
         Ok(Response::new(MoveCursorResponse {
             composing_text: Some(ComposingText {
@@ -685,17 +694,19 @@ impl AzookeyService for MyAzookeyService {
         _: Request<ClearTextRequest>,
     ) -> Result<Response<ClearTextResponse>, Status> {
         let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
+        let collect_timing = should_collect_timing(ServerLogLevel::Info);
+        let handler_start = timing_start(collect_timing);
         log_event_lazy!(ServerLogLevel::Info, "[clear_text:{request_id}] start");
-        let t0 = now_timestamp_millis();
+        let clear_start = timing_start(collect_timing);
         clear_text();
-        let t1 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[clear_text:{request_id}] success clear_text_elapsed_ms={} total_elapsed_ms={}",
-            t1.saturating_sub(t0),
-            t1.saturating_sub(handler_start)
-        );
+        let clear_elapsed_ms = elapsed_millis(clear_start);
+        if collect_timing {
+            let total_elapsed_ms = elapsed_millis(handler_start);
+            log_event_lazy!(
+                ServerLogLevel::Info,
+                "[clear_text:{request_id}] success clear_text_elapsed_ms={clear_elapsed_ms} total_elapsed_ms={total_elapsed_ms}",
+            );
+        }
         HAS_ACTIVE_COMPOSITION.store(false, Ordering::Relaxed);
         Ok(Response::new(ClearTextResponse {}))
     }
@@ -731,20 +742,22 @@ impl AzookeyService for MyAzookeyService {
             "[shrink_text:{request_id}] get_composed_text elapsed_ms={get_composed_elapsed_ms}",
         );
         update_active_composition_state(&composing_text.text);
-        let hiragana_len = composing_text.text.chars().count();
-        let suggestion_count = composed_text.suggestions.len();
-        let total_elapsed_ms = elapsed_millis(perf_start);
+        if collect_timing {
+            let hiragana_len = composing_text.text.chars().count();
+            let suggestion_count = composed_text.suggestions.len();
+            let total_elapsed_ms = elapsed_millis(perf_start);
 
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[shrink_text:{request_id}] success hiragana_len={} suggestions={} total_elapsed_ms={}",
-            hiragana_len,
-            suggestion_count,
-            total_elapsed_ms
-        );
-        perf_log_lazy!(
-            "kind=perf\tcomponent=rust-server\toperation=shrink_text\trequest_id={request_id}\toffset={raw_offset}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tshrink_text_elapsed_ms={shrink_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}"
-        );
+            log_event_lazy!(
+                ServerLogLevel::Info,
+                "[shrink_text:{request_id}] success hiragana_len={} suggestions={} total_elapsed_ms={}",
+                hiragana_len,
+                suggestion_count,
+                total_elapsed_ms
+            );
+            perf_log_lazy!(
+                "kind=perf\tcomponent=rust-server\toperation=shrink_text\trequest_id={request_id}\toffset={raw_offset}\thiragana_len={hiragana_len}\tsuggestions={suggestion_count}\tshrink_text_elapsed_ms={shrink_elapsed_ms}\tget_composed_text_elapsed_ms={get_composed_elapsed_ms}\ttotal_elapsed_ms={total_elapsed_ms}"
+            );
+        }
 
         Ok(Response::new(ShrinkTextResponse {
             composing_text: Some(ComposingText {
@@ -759,32 +772,36 @@ impl AzookeyService for MyAzookeyService {
         request: Request<shared::proto::SetContextRequest>,
     ) -> Result<Response<shared::proto::SetContextResponse>, Status> {
         let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
+        let collect_timing = should_collect_timing(ServerLogLevel::Info);
+        let handler_start = timing_start(collect_timing);
         let context = request.into_inner().context;
         let trimmed_context = context
             .split('\r')
             .filter(|s| !s.is_empty())
             .last()
             .unwrap_or_default();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[set_context:{request_id}] start original_len={} trimmed_len={}",
-            context.chars().count(),
-            trimmed_context.chars().count()
-        );
+        if collect_timing {
+            log_event_lazy!(
+                ServerLogLevel::Info,
+                "[set_context:{request_id}] start original_len={} trimmed_len={}",
+                context.chars().count(),
+                trimmed_context.chars().count()
+            );
+        }
 
         let context = cstring_from_input("SetContext.context", trimmed_context)
             .map_err(|error| status_from_error("set_context", error))?;
 
-        let t0 = now_timestamp_millis();
+        let set_context_start = timing_start(collect_timing);
         unsafe { SetContext(context.as_ptr()) };
-        let t1 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[set_context:{request_id}] success set_context_elapsed_ms={} total_elapsed_ms={}",
-            t1.saturating_sub(t0),
-            t1.saturating_sub(handler_start)
-        );
+        let set_context_elapsed_ms = elapsed_millis(set_context_start);
+        if collect_timing {
+            let total_elapsed_ms = elapsed_millis(handler_start);
+            log_event_lazy!(
+                ServerLogLevel::Info,
+                "[set_context:{request_id}] success set_context_elapsed_ms={set_context_elapsed_ms} total_elapsed_ms={total_elapsed_ms}",
+            );
+        }
         Ok(Response::new(shared::proto::SetContextResponse {}))
     }
 
@@ -793,25 +810,28 @@ impl AzookeyService for MyAzookeyService {
         _: Request<shared::proto::UpdateConfigRequest>,
     ) -> Result<Response<shared::proto::UpdateConfigResponse>, Status> {
         let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
+        let collect_timing = should_collect_timing(ServerLogLevel::Info);
+        let handler_start = timing_start(collect_timing);
         log_event_lazy!(ServerLogLevel::Info, "[update_config:{request_id}] start");
-        let t0 = now_timestamp_millis();
+        let load_config_start = timing_start(collect_timing);
         unsafe { LoadConfig() };
         refresh_perf_log_enabled_from_config();
-        let t1 = now_timestamp_millis();
+        let load_config_elapsed_ms = elapsed_millis(load_config_start);
         let has_active_composition = query_active_composition_state();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[update_config:{request_id}] load_config_elapsed_ms={}",
-            t1.saturating_sub(t0)
-        );
+        if collect_timing {
+            log_event_lazy!(
+                ServerLogLevel::Info,
+                "[update_config:{request_id}] load_config_elapsed_ms={load_config_elapsed_ms}",
+            );
+        }
         HAS_ACTIVE_COMPOSITION.store(has_active_composition, Ordering::Relaxed);
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[update_config:{request_id}] success active_composition={} total_elapsed_ms={}",
-            has_active_composition,
-            t1.saturating_sub(handler_start)
-        );
+        if collect_timing {
+            let total_elapsed_ms = elapsed_millis(handler_start);
+            log_event_lazy!(
+                ServerLogLevel::Info,
+                "[update_config:{request_id}] success active_composition={has_active_composition} total_elapsed_ms={total_elapsed_ms}",
+            );
+        }
         Ok(Response::new(shared::proto::UpdateConfigResponse {}))
     }
 }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -399,6 +399,14 @@ pub struct UserDictionaryConfig {
     pub entries: Vec<UserDictionaryEntry>,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct DeveloperOptionsConfig {
+    #[serde(default)]
+    pub enable: bool,
+    #[serde(default)]
+    pub logging: bool,
+}
+
 impl Default for CharacterWidthConfig {
     fn default() -> Self {
         Self {
@@ -463,6 +471,8 @@ pub struct AppConfig {
     pub character_width: CharacterWidthConfig,
     #[serde(default)]
     pub user_dictionary: UserDictionaryConfig,
+    #[serde(default)]
+    pub developer_options: DeveloperOptionsConfig,
 }
 
 impl Default for AppConfig {
@@ -479,6 +489,7 @@ impl Default for AppConfig {
             romaji_table: RomajiTableConfig::default(),
             character_width: CharacterWidthConfig::default(),
             user_dictionary: UserDictionaryConfig::default(),
+            developer_options: DeveloperOptionsConfig::default(),
         }
     }
 }

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { BookText, Bot, Settings, Megaphone } from "lucide-react"
+import { BookText, Bot, Bug, Settings, Megaphone } from "lucide-react"
 
 import {
     Sidebar,
@@ -33,6 +33,11 @@ const contents = [
         title: "辞書",
         url: "/dictionary",
         icon: BookText,
+    },
+    {
+        title: "開発者オプション",
+        url: "/developer-options",
+        icon: Bug,
     },
 ]
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,6 +11,7 @@ import { Appearance } from "@/pages/appearance"
 import { Zenzai } from "@/pages/zenzai"
 import { About } from "@/pages/about"
 import { Dictionary } from "@/pages/dictionary"
+import { DeveloperOptions } from "@/pages/developer-options"
 import { Toaster } from "@/components/ui/sonner"
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
@@ -25,6 +26,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
               <Route path="/appearance" element={<Appearance />} />
               <Route path="/zenzai" element={<Zenzai />} />
               <Route path="/dictionary" element={<Dictionary />} />
+              <Route path="/developer-options" element={<DeveloperOptions />} />
               <Route path="/about" element={<About />} />
             </Routes>
             <Toaster />

--- a/frontend/src/pages/developer-options.tsx
+++ b/frontend/src/pages/developer-options.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { toast } from "sonner";
+import { Bug, FileText } from "lucide-react";
+
+import { Switch } from "@/components/ui/switch";
+
+type DeveloperOptionsState = {
+    enable: boolean;
+    logging: boolean;
+};
+
+const DEFAULT_DEVELOPER_OPTIONS: DeveloperOptionsState = {
+    enable: false,
+    logging: false,
+};
+
+const normalizeDeveloperOptions = (
+    value?: Record<string, unknown>,
+): DeveloperOptionsState => {
+    const enable = typeof value?.enable === "boolean" ? value.enable : false;
+    return {
+        enable,
+        logging:
+            enable && typeof value?.logging === "boolean"
+                ? value.logging
+                : false,
+    };
+};
+
+export const DeveloperOptions = () => {
+    const [value, setValue] = useState<DeveloperOptionsState>(
+        DEFAULT_DEVELOPER_OPTIONS,
+    );
+
+    useEffect(() => {
+        invoke<any>("get_config")
+            .then((data) => {
+                setValue(normalizeDeveloperOptions(data.developer_options));
+            })
+            .catch(() => {
+                toast("開発者オプションの読み込みに失敗しました");
+            });
+    }, []);
+
+    const updateConfig = async (
+        updater: (developerOptions: DeveloperOptionsState) => DeveloperOptionsState,
+    ) => {
+        try {
+            const data = await invoke<any>("get_config");
+            const current = normalizeDeveloperOptions(data.developer_options);
+            const next = updater(current);
+            data.developer_options = next.enable
+                ? next
+                : { enable: false, logging: false };
+            await invoke("update_config", { newConfig: data });
+            setValue(data.developer_options);
+        } catch (_error) {
+            toast("開発者オプションの更新に失敗しました");
+        }
+    };
+
+    const handleDeveloperOptionsChange = (checked: boolean) => {
+        updateConfig((current) => ({
+            enable: checked,
+            logging: checked ? current.logging : false,
+        }));
+    };
+
+    const handleLoggingChange = (checked: boolean) => {
+        updateConfig((current) => ({
+            enable: current.enable,
+            logging: current.enable ? checked : false,
+        }));
+    };
+
+    return (
+        <div className="space-y-8">
+            <section className="space-y-2">
+                <h1 className="text-sm font-bold text-foreground">開発者オプション</h1>
+                <div className="flex items-center space-x-4 rounded-md border p-4">
+                    <Bug />
+                    <div className="flex-1 space-y-1">
+                        <p className="text-sm font-medium leading-none">
+                            開発者オプションを有効化
+                        </p>
+                    </div>
+                    <Switch
+                        checked={value.enable}
+                        onCheckedChange={handleDeveloperOptionsChange}
+                    />
+                </div>
+
+                {value.enable && (
+                    <div className="flex items-center space-x-4 rounded-md border p-4">
+                        <FileText />
+                        <div className="flex-1 space-y-1">
+                            <p className="text-sm font-medium leading-none">
+                                ログを有効化
+                            </p>
+                        </div>
+                        <Switch
+                            checked={value.logging}
+                            onCheckedChange={handleLoggingChange}
+                        />
+                    </div>
+                )}
+            </section>
+        </div>
+    );
+};

--- a/server-swift/Package.resolved
+++ b/server-swift/Package.resolved
@@ -6,7 +6,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/batao9/AzooKeyKanaKanjiConverter",
       "state" : {
-        "branch" : "main",
         "revision" : "e4c5bdabe739c83b9b90ed8f58a2ea82f1f39052"
       }
     },

--- a/server-swift/Package.resolved
+++ b/server-swift/Package.resolved
@@ -4,9 +4,10 @@
     {
       "identity" : "azookeykanakanjiconverter",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/azookey/AzooKeyKanaKanjiConverter",
+      "location" : "https://github.com/batao9/AzooKeyKanaKanjiConverter",
       "state" : {
-        "revision" : "884456d9d077f9e2136d273e0bfbd39b05374f7f"
+        "branch" : "main",
+        "revision" : "e4c5bdabe739c83b9b90ed8f58a2ea82f1f39052"
       }
     },
     {

--- a/server-swift/Package.resolved
+++ b/server-swift/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/batao9/AzooKeyKanaKanjiConverter",
       "state" : {
-        "revision" : "e4c5bdabe739c83b9b90ed8f58a2ea82f1f39052"
+        "revision" : "8ceed2d7a615f89ac1772ddd5e2d9d1c5c6d58ac"
       }
     },
     {

--- a/server-swift/Package.swift
+++ b/server-swift/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(
-            url: "https://github.com/azookey/AzooKeyKanaKanjiConverter",
-            revision: "884456d9d077f9e2136d273e0bfbd39b05374f7f",
+            url: "https://github.com/batao9/AzooKeyKanaKanjiConverter",
+            branch: "main",
             traits: ["Zenzai"]
         )
     ],

--- a/server-swift/Package.swift
+++ b/server-swift/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(
             url: "https://github.com/batao9/AzooKeyKanaKanjiConverter",
-            revision: "e4c5bdabe739c83b9b90ed8f58a2ea82f1f39052",
+            revision: "8ceed2d7a615f89ac1772ddd5e2d9d1c5c6d58ac",
             traits: ["Zenzai"]
         )
     ],

--- a/server-swift/Package.swift
+++ b/server-swift/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(
             url: "https://github.com/batao9/AzooKeyKanaKanjiConverter",
-            branch: "main",
+            revision: "e4c5bdabe739c83b9b90ed8f58a2ea82f1f39052",
             traits: ["Zenzai"]
         )
     ],

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -2,7 +2,7 @@ import KanaKanjiConverterModule
 import Foundation
 import ffi
 
-@MainActor let converter = KanaKanjiConverter()
+@MainActor var converter: KanaKanjiConverter!
 @MainActor var composingText = ComposingText()
 @MainActor var composingTextSnapshots: [ComposingText] = []
 @MainActor var currentInputStyle: InputStyle = .roman2kana
@@ -50,6 +50,11 @@ private enum ServerLogLevel: Int {
 }
 
 private let serverLogThreshold = ServerLogLevel.fromEnvironment()
+nonisolated(unsafe) private var serverPerfLogEnabled = false
+
+private func shouldCollectTiming(for level: ServerLogLevel) -> Bool {
+    level.rawValue <= serverLogThreshold.rawValue || serverPerfLogEnabled
+}
 
 private func serverLogPath() -> URL {
     if let appDataPath = ProcessInfo.processInfo.environment["APPDATA"] {
@@ -69,14 +74,7 @@ private func serverLogTimestampMillis() -> UInt64 {
     UInt64(Date().timeIntervalSince1970 * 1000)
 }
 
-private func serverLog(_ level: String = "INFO", _ message: @autoclosure () -> String) {
-    let resolvedLevel = ServerLogLevel(label: level)
-    guard resolvedLevel.rawValue <= serverLogThreshold.rawValue else {
-        return
-    }
-
-    let resolvedMessage = message()
-    let line = "[\(serverLogTimestampMillis())] [SWIFT/\(level)] \(resolvedMessage)"
+private func writeServerLogLine(_ line: String) {
     fputs("\(line)\n", stderr)
 
     let logPath = serverLogPath()
@@ -113,10 +111,59 @@ private func serverLog(_ level: String = "INFO", _ message: @autoclosure () -> S
     handle.write(data)
 }
 
+private func serverLog(_ level: String = "INFO", _ message: @autoclosure () -> String) {
+    let resolvedLevel = ServerLogLevel(label: level)
+    guard resolvedLevel.rawValue <= serverLogThreshold.rawValue else {
+        return
+    }
+
+    let resolvedMessage = message()
+    let line = "[\(serverLogTimestampMillis())] [SWIFT/\(level)] \(resolvedMessage)"
+    writeServerLogLine(line)
+}
+
+private func serverPerfLog(_ message: @autoclosure () -> String) {
+    guard serverPerfLogEnabled else {
+        return
+    }
+
+    let line = "[\(serverLogTimestampMillis())] [SWIFT/PERF] \(message())"
+    writeServerLogLine(line)
+}
+
+private func timingStart(enabled: Bool) -> TimeInterval? {
+    enabled ? ProcessInfo.processInfo.systemUptime : nil
+}
+
+private func elapsedMillis(since start: TimeInterval?) -> Int {
+    guard let start else {
+        return 0
+    }
+
+    return Int((ProcessInfo.processInfo.systemUptime - start) * 1000)
+}
+
+@MainActor private func configureEnginePerfLogging() {
+    KanaKanjiConverterEnginePerfLog.configure(enabled: serverPerfLogEnabled) { message in
+        serverPerfLog("ENGINE \(message)")
+    }
+}
+
+@MainActor private func configureEngineRuntime(zenzaiEnabled: Bool) {
+    let normalizedBackend = ((config["backend"] as? String) ?? "cpu")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .lowercased()
+    let shouldOffloadToGpu = zenzaiEnabled && !normalizedBackend.isEmpty && normalizedBackend != "cpu"
+    KanaKanjiConverterEngineRuntime.configure(
+        gpuLayerCount: shouldOffloadToGpu ? Int32.max : 0
+    )
+}
+
 private struct AppSettings: Decodable {
     let zenzai: ZenzaiSettings?
     let user_dictionary: UserDictionarySettings?
     let romaji_table: RomajiTableSettings?
+    let developer_options: DeveloperOptionsSettings?
 }
 
 private struct ZenzaiSettings: Decodable {
@@ -136,6 +183,11 @@ private struct UserDictionaryEntry: Decodable {
 
 private struct RomajiTableSettings: Decodable {
     let rows: [RomajiTableRow]?
+}
+
+private struct DeveloperOptionsSettings: Decodable {
+    let enable: Bool?
+    let logging: Bool?
 }
 
 enum RomajiInputStyleSelection: Equatable {
@@ -213,7 +265,10 @@ private func cpuZenzaiBackendSupportedFromEnvironment() -> Bool {
     do {
         try content.write(to: fileURL, atomically: true, encoding: .utf8)
         let previousURL = customRomajiTableURL
-        currentInputStyle = .mapped(id: .custom(fileURL))
+        let tableName = "azookey-windows-custom-romaji"
+        let table = try InputStyleManager.loadTable(from: fileURL)
+        InputStyleManager.registerInputStyle(table: table, for: tableName)
+        currentInputStyle = .mapped(id: .tableName(tableName))
         customRomajiTableURL = fileURL
 
         if let previousURL, previousURL != fileURL {
@@ -272,26 +327,11 @@ private func clampedCorrespondingCount(
         return (composingText: composingText, syntheticEndOfText: false)
     }
 
-    switch trailingElement.piece {
-    case .character:
-        guard trailingElement.inputStyle != .direct else {
-            return (composingText: composingText, syntheticEndOfText: false)
-        }
-    case .endOfText:
+    if trailingElement.inputStyle == .direct {
         return (composingText: composingText, syntheticEndOfText: false)
     }
 
-    var previewComposingText = composingText
-    let originalConvertTarget = previewComposingText.convertTarget
-    previewComposingText.insertAtCursorPosition([
-        .init(piece: .endOfText, inputStyle: trailingElement.inputStyle)
-    ])
-
-    guard previewComposingText.convertTarget != originalConvertTarget else {
-        return (composingText: composingText, syntheticEndOfText: false)
-    }
-
-    return (composingText: previewComposingText, syntheticEndOfText: true)
+    return (composingText: composingText, syntheticEndOfText: false)
 }
 
 @MainActor func makeCandidatePreviewComposingTextForCursorPrefix(
@@ -356,18 +396,20 @@ private func clampedCorrespondingCount(
     context: String = "",
     zenzaiEnabled: Bool
 ) -> ConvertRequestOptions {
+    configureEnginePerfLogging()
+    configureEngineRuntime(zenzaiEnabled: zenzaiEnabled)
     let profile = (config["profile"] as? String) ?? ""
     return ConvertRequestOptions(
-        requireJapanesePrediction: true,
-        requireEnglishPrediction: false,
+        requireJapanesePrediction: .autoMix,
+        requireEnglishPrediction: .disabled,
         keyboardLanguage: .ja_JP,
         learningType: .nothing,
-        dictionaryResourceURL: execURL.appendingPathComponent("Dictionary"),
         memoryDirectoryURL: URL(filePath: "./test"),
         sharedContainerURL: URL(filePath: "./test"),
         textReplacer: .init {
             return execURL.appendingPathComponent("EmojiDictionary").appendingPathComponent("emoji_all_E15.1.txt")
         },
+        specialCandidateProviders: nil,
         // zenzai
         zenzaiMode: zenzaiEnabled ? .on(
             weight: execURL.appendingPathComponent("zenz.gguf"),
@@ -381,7 +423,6 @@ private func clampedCorrespondingCount(
                 )
             )
         ) : .off,
-        preloadDictionary: true,
         metadata: .init(versionString: "Azookey for Windows")
     )
 }
@@ -445,12 +486,15 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     let previousUsedCustomRomajiTable = customRomajiTableURL != nil
     var dynamicUserDictionary: [DicdataElement] = []
     defer {
-        converter.sendToDicdataStore(.importDynamicUserDict(dynamicUserDictionary))
+        converter.importDynamicUserDictionary(dynamicUserDictionary)
     }
 
     config["enable"] = false
     config["profile"] = ""
     config["backend"] = "cpu"
+    config["developerOptionsEnable"] = false
+    config["developerOptionsLogging"] = false
+    serverPerfLogEnabled = false
     setRoman2KanaInputStyle()
 
     if let appDataPath = ProcessInfo.processInfo.environment["APPDATA"] {
@@ -476,6 +520,12 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
             }
 
             applyRomajiInputStyle(rows: settings.romaji_table?.rows)
+            let developerOptionsEnable = settings.developer_options?.enable ?? false
+            let developerOptionsLogging = developerOptionsEnable && (settings.developer_options?.logging ?? false)
+            config["developerOptionsEnable"] = developerOptionsEnable
+            config["developerOptionsLogging"] = developerOptionsLogging
+            serverPerfLogEnabled = developerOptionsLogging
+            configureEnginePerfLogging()
 
             let sourceEntries = settings.user_dictionary?.entries ?? []
             var seen: Set<String> = []
@@ -520,6 +570,7 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     } else {
         serverLog("WARN", "LoadConfig: APPDATA is not set. Using defaults.")
     }
+    configureEnginePerfLogging()
 
     let currentZenzaiEnabled = (config["enable"] as? Bool) ?? false
     let currentProfile = (config["profile"] as? String) ?? ""
@@ -553,6 +604,10 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     let path = String(cString: path)
     serverLog("INFO", "Initialize: start path=\(path) use_zenzai=\(use_zenzai)")
     execURL = URL(filePath: path)
+    converter = KanaKanjiConverter(
+        dictionaryURL: execURL.appendingPathComponent("Dictionary"),
+        preloadDictionary: true
+    )
 
     load_config()
 
@@ -704,6 +759,9 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
 
 @_silgen_name("GetComposedText")
 @MainActor public func get_composed_text(lengthPtr: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
+    let collectTiming = shouldCollectTiming(for: .info)
+    let totalStart = timingStart(enabled: serverPerfLogEnabled)
+    let prepareStart = timingStart(enabled: serverPerfLogEnabled)
     let originalHiragana = composingText.convertTarget
     let contextString = (config["context"] as? String) ?? ""
     let runtimeZenzaiEnabled = currentRuntimeZenzaiEnabled()
@@ -719,26 +777,42 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
         inputCount: composingText.input.count,
         hiraganaCount: originalHiragana.count
     )
+    let prepareMs = elapsedMillis(since: prepareStart)
+    let optionsStart = timingStart(enabled: serverPerfLogEnabled)
     let options = getOptions(context: contextString, zenzaiEnabled: useZenzai)
+    let optionsMs = elapsedMillis(since: optionsStart)
     serverLog("INFO", "GetComposedText: requestCandidates begin useZenzai=\(useZenzai) syntheticEndOfText=\(previewState.syntheticEndOfText)")
-    let requestStart = ProcessInfo.processInfo.systemUptime
+    let requestStart = timingStart(enabled: collectTiming)
     let converted = converter.requestCandidates(previewComposingText, options: options)
-    let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
+    let requestMs = elapsedMillis(since: requestStart)
     serverLog("INFO", "GetComposedText: requestCandidates returned candidateCount=\(converted.mainResults.count) elapsed_ms=\(requestMs)")
     var result: [FFICandidate] = []
+    let formatStart = timingStart(enabled: serverPerfLogEnabled)
+    var constructCandidateMs = 0
+    var resolveCandidateMs = 0
+    var duplicateStringMs = 0
 
     for i in 0..<converted.mainResults.count {
         let candidate = converted.mainResults[i]
         serverLog("DEBUG", "GetComposedText: candidate[\(i + 1)/\(converted.mainResults.count)] start")
 
-        let text = strdup(constructCandidateString(candidate: candidate, hiragana: previewHiragana))
+        let constructStart = timingStart(enabled: serverPerfLogEnabled)
+        let candidateText = constructCandidateString(candidate: candidate, hiragana: previewHiragana)
+        constructCandidateMs += elapsedMillis(since: constructStart)
+        let duplicateTextStart = timingStart(enabled: serverPerfLogEnabled)
+        let text = strdup(candidateText)
+        duplicateStringMs += elapsedMillis(since: duplicateTextStart)
         serverLog("DEBUG", "GetComposedText: candidate[\(i + 1)] textReady")
+        let duplicateHiraganaStart = timingStart(enabled: serverPerfLogEnabled)
         let hiragana = strdup(previewHiragana)
+        duplicateStringMs += elapsedMillis(since: duplicateHiraganaStart)
+        let resolveStart = timingStart(enabled: serverPerfLogEnabled)
         let resolvedCandidate = resolveCandidateCompositionForDisplay(
             originalComposingText: composingText,
             previewComposingText: previewComposingText,
             candidateComposingCount: candidate.composingCount
         )
+        resolveCandidateMs += elapsedMillis(since: resolveStart)
         let correspondingCount = resolvedCandidate.correspondingCount
         debugLogResolvedCorrespondingCount(
             scope: "GetComposedText",
@@ -749,20 +823,32 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
             inputCount: composingText.input.count,
             isZenzaiEnabled: useZenzai
         )
+        let duplicateSubtextStart = timingStart(enabled: serverPerfLogEnabled)
         let subtext = strdup(resolvedCandidate.remainingConvertTarget)
+        duplicateStringMs += elapsedMillis(since: duplicateSubtextStart)
         serverLog("DEBUG", "GetComposedText: candidate[\(i + 1)] subtextReady")
 
         result.append(FFICandidate(text: text, subtext: subtext, hiragana: hiragana, correspondingCount: Int32(correspondingCount)))
     }
+    let formatMs = elapsedMillis(since: formatStart)
 
     lengthPtr.pointee = result.count
     serverLog("INFO", "GetComposedText: completed candidateCount=\(result.count) useZenzai=\(useZenzai)")
+    let marshalStart = timingStart(enabled: serverPerfLogEnabled)
+    let pointer = to_list_pointer(result)
+    let marshalMs = elapsedMillis(since: marshalStart)
+    serverPerfLog(
+        "kind=perf\tcomponent=swift-server\toperation=GetComposedText\tinput_count=\(composingText.input.count)\thiragana_len=\(originalHiragana.count)\tpreview_hiragana_len=\(previewHiragana.count)\tcontext_len=\(contextString.count)\truntime_zenzai_enabled=\(runtimeZenzaiEnabled)\tuse_zenzai=\(useZenzai)\tsynthetic_end_of_text=\(previewState.syntheticEndOfText)\tcandidate_count=\(converted.mainResults.count)\tprepare_ms=\(prepareMs)\toptions_ms=\(optionsMs)\trequest_candidates_ms=\(requestMs)\tformat_candidates_ms=\(formatMs)\tconstruct_candidate_ms=\(constructCandidateMs)\tresolve_candidate_ms=\(resolveCandidateMs)\tduplicate_string_ms=\(duplicateStringMs)\tffi_marshal_ms=\(marshalMs)\ttotal_ms=\(elapsedMillis(since: totalStart))"
+    )
 
-    return to_list_pointer(result)
+    return pointer
 }
 
 @_silgen_name("GetComposedTextForCursorPrefix")
 @MainActor public func get_composed_text_for_cursor_prefix(lengthPtr: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
+    let collectTiming = shouldCollectTiming(for: .info)
+    let totalStart = timingStart(enabled: serverPerfLogEnabled)
+    let prepareStart = timingStart(enabled: serverPerfLogEnabled)
     let hiragana = composingText.convertTarget
     let suffixAfterCursor = String(hiragana.dropFirst(composingText.convertTargetCursorPosition))
     let prefixComposingText = composingText.prefixToCursorPosition()
@@ -784,26 +870,42 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
         inputCount: prefixComposingText.input.count,
         hiraganaCount: prefixHiragana.count
     )
+    let prepareMs = elapsedMillis(since: prepareStart)
+    let optionsStart = timingStart(enabled: serverPerfLogEnabled)
     let options = getOptions(context: contextString, zenzaiEnabled: useZenzai)
+    let optionsMs = elapsedMillis(since: optionsStart)
     serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates begin useZenzai=\(useZenzai) syntheticEndOfText=\(previewState.syntheticEndOfText)")
-    let requestStart = ProcessInfo.processInfo.systemUptime
+    let requestStart = timingStart(enabled: collectTiming)
     let converted = converter.requestCandidates(previewPrefixComposingText, options: options)
-    let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
+    let requestMs = elapsedMillis(since: requestStart)
     serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(converted.mainResults.count) elapsed_ms=\(requestMs)")
     var result: [FFICandidate] = []
+    let formatStart = timingStart(enabled: serverPerfLogEnabled)
+    var constructCandidateMs = 0
+    var resolveCandidateMs = 0
+    var duplicateStringMs = 0
 
     for i in 0..<converted.mainResults.count {
         let candidate = converted.mainResults[i]
         serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)/\(converted.mainResults.count)] start")
 
-        let text = strdup(constructCandidateString(candidate: candidate, hiragana: previewPrefixHiragana))
+        let constructStart = timingStart(enabled: serverPerfLogEnabled)
+        let candidateText = constructCandidateString(candidate: candidate, hiragana: previewPrefixHiragana)
+        constructCandidateMs += elapsedMillis(since: constructStart)
+        let duplicateTextStart = timingStart(enabled: serverPerfLogEnabled)
+        let text = strdup(candidateText)
+        duplicateStringMs += elapsedMillis(since: duplicateTextStart)
         serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)] textReady")
+        let duplicateHiraganaStart = timingStart(enabled: serverPerfLogEnabled)
         let hiragana = strdup(previewPrefixHiragana + suffixAfterCursor)
+        duplicateStringMs += elapsedMillis(since: duplicateHiraganaStart)
+        let resolveStart = timingStart(enabled: serverPerfLogEnabled)
         let resolvedCandidate = resolveCandidateCompositionForDisplay(
             originalComposingText: prefixComposingText,
             previewComposingText: previewPrefixComposingText,
             candidateComposingCount: candidate.composingCount
         )
+        resolveCandidateMs += elapsedMillis(since: resolveStart)
         let correspondingCount = resolvedCandidate.correspondingCount
         debugLogResolvedCorrespondingCount(
             scope: "GetComposedTextForCursorPrefix",
@@ -814,16 +916,25 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
             inputCount: prefixComposingText.input.count,
             isZenzaiEnabled: useZenzai
         )
+        let duplicateSubtextStart = timingStart(enabled: serverPerfLogEnabled)
         let subtext = strdup(resolvedCandidate.remainingConvertTarget + suffixAfterCursor)
+        duplicateStringMs += elapsedMillis(since: duplicateSubtextStart)
         serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)] subtextReady")
 
         result.append(FFICandidate(text: text, subtext: subtext, hiragana: hiragana, correspondingCount: Int32(correspondingCount)))
     }
+    let formatMs = elapsedMillis(since: formatStart)
 
     lengthPtr.pointee = result.count
     serverLog("INFO", "GetComposedTextForCursorPrefix: completed candidateCount=\(result.count) useZenzai=\(useZenzai)")
+    let marshalStart = timingStart(enabled: serverPerfLogEnabled)
+    let pointer = to_list_pointer(result)
+    let marshalMs = elapsedMillis(since: marshalStart)
+    serverPerfLog(
+        "kind=perf\tcomponent=swift-server\toperation=GetComposedTextForCursorPrefix\tinput_count=\(prefixComposingText.input.count)\tprefix_len=\(prefixHiragana.count)\tpreview_prefix_len=\(previewPrefixHiragana.count)\tsuffix_len=\(suffixAfterCursor.count)\tcontext_len=\(contextString.count)\truntime_zenzai_enabled=\(runtimeZenzaiEnabled)\tuse_zenzai=\(useZenzai)\tsynthetic_end_of_text=\(previewState.syntheticEndOfText)\tcandidate_count=\(converted.mainResults.count)\tprepare_ms=\(prepareMs)\toptions_ms=\(optionsMs)\trequest_candidates_ms=\(requestMs)\tformat_candidates_ms=\(formatMs)\tconstruct_candidate_ms=\(constructCandidateMs)\tresolve_candidate_ms=\(resolveCandidateMs)\tduplicate_string_ms=\(duplicateStringMs)\tffi_marshal_ms=\(marshalMs)\ttotal_ms=\(elapsedMillis(since: totalStart))"
+    )
 
-    return to_list_pointer(result)
+    return pointer
 }
 
 @_silgen_name("ShrinkText")

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -49,11 +49,30 @@ private enum ServerLogLevel: Int {
     }
 }
 
+private final class ServerPerfLogState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var enabled = false
+
+    func isEnabled() -> Bool {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return enabled
+    }
+
+    func setEnabled(_ value: Bool) {
+        lock.lock()
+        enabled = value
+        lock.unlock()
+    }
+}
+
 private let serverLogThreshold = ServerLogLevel.fromEnvironment()
-nonisolated(unsafe) private var serverPerfLogEnabled = false
+private let serverPerfLogState = ServerPerfLogState()
 
 private func shouldCollectTiming(for level: ServerLogLevel) -> Bool {
-    level.rawValue <= serverLogThreshold.rawValue || serverPerfLogEnabled
+    level.rawValue <= serverLogThreshold.rawValue || serverPerfLogState.isEnabled()
 }
 
 private func serverLogPath() -> URL {
@@ -123,7 +142,7 @@ private func serverLog(_ level: String = "INFO", _ message: @autoclosure () -> S
 }
 
 private func serverPerfLog(_ message: @autoclosure () -> String) {
-    guard serverPerfLogEnabled else {
+    guard serverPerfLogState.isEnabled() else {
         return
     }
 
@@ -144,7 +163,7 @@ private func elapsedMillis(since start: TimeInterval?) -> Int {
 }
 
 @MainActor private func configureEnginePerfLogging() {
-    KanaKanjiConverterEnginePerfLog.configure(enabled: serverPerfLogEnabled) { message in
+    KanaKanjiConverterEnginePerfLog.configure(enabled: serverPerfLogState.isEnabled()) { message in
         serverPerfLog("ENGINE \(message)")
     }
 }
@@ -327,11 +346,26 @@ private func clampedCorrespondingCount(
         return (composingText: composingText, syntheticEndOfText: false)
     }
 
-    if trailingElement.inputStyle == .direct {
+    switch trailingElement.piece {
+    case .character, .key:
+        guard trailingElement.inputStyle != .direct else {
+            return (composingText: composingText, syntheticEndOfText: false)
+        }
+    case .compositionSeparator:
         return (composingText: composingText, syntheticEndOfText: false)
     }
 
-    return (composingText: composingText, syntheticEndOfText: false)
+    var previewComposingText = composingText
+    let originalConvertTarget = previewComposingText.convertTarget
+    previewComposingText.insertAtCursorPosition([
+        .init(piece: .compositionSeparator, inputStyle: trailingElement.inputStyle)
+    ])
+
+    guard previewComposingText.convertTarget != originalConvertTarget else {
+        return (composingText: composingText, syntheticEndOfText: false)
+    }
+
+    return (composingText: previewComposingText, syntheticEndOfText: true)
 }
 
 @MainActor func makeCandidatePreviewComposingTextForCursorPrefix(
@@ -494,7 +528,7 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     config["backend"] = "cpu"
     config["developerOptionsEnable"] = false
     config["developerOptionsLogging"] = false
-    serverPerfLogEnabled = false
+    serverPerfLogState.setEnabled(false)
     setRoman2KanaInputStyle()
 
     if let appDataPath = ProcessInfo.processInfo.environment["APPDATA"] {
@@ -524,7 +558,7 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
             let developerOptionsLogging = developerOptionsEnable && (settings.developer_options?.logging ?? false)
             config["developerOptionsEnable"] = developerOptionsEnable
             config["developerOptionsLogging"] = developerOptionsLogging
-            serverPerfLogEnabled = developerOptionsLogging
+            serverPerfLogState.setEnabled(developerOptionsLogging)
             configureEnginePerfLogging()
 
             let sourceEntries = settings.user_dictionary?.entries ?? []
@@ -760,8 +794,9 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
 @_silgen_name("GetComposedText")
 @MainActor public func get_composed_text(lengthPtr: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
     let collectTiming = shouldCollectTiming(for: .info)
-    let totalStart = timingStart(enabled: serverPerfLogEnabled)
-    let prepareStart = timingStart(enabled: serverPerfLogEnabled)
+    let perfTiming = serverPerfLogState.isEnabled()
+    let totalStart = timingStart(enabled: perfTiming)
+    let prepareStart = timingStart(enabled: perfTiming)
     let originalHiragana = composingText.convertTarget
     let contextString = (config["context"] as? String) ?? ""
     let runtimeZenzaiEnabled = currentRuntimeZenzaiEnabled()
@@ -778,7 +813,7 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
         hiraganaCount: originalHiragana.count
     )
     let prepareMs = elapsedMillis(since: prepareStart)
-    let optionsStart = timingStart(enabled: serverPerfLogEnabled)
+    let optionsStart = timingStart(enabled: perfTiming)
     let options = getOptions(context: contextString, zenzaiEnabled: useZenzai)
     let optionsMs = elapsedMillis(since: optionsStart)
     serverLog("INFO", "GetComposedText: requestCandidates begin useZenzai=\(useZenzai) syntheticEndOfText=\(previewState.syntheticEndOfText)")
@@ -787,7 +822,7 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
     let requestMs = elapsedMillis(since: requestStart)
     serverLog("INFO", "GetComposedText: requestCandidates returned candidateCount=\(converted.mainResults.count) elapsed_ms=\(requestMs)")
     var result: [FFICandidate] = []
-    let formatStart = timingStart(enabled: serverPerfLogEnabled)
+    let formatStart = timingStart(enabled: perfTiming)
     var constructCandidateMs = 0
     var resolveCandidateMs = 0
     var duplicateStringMs = 0
@@ -796,17 +831,17 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
         let candidate = converted.mainResults[i]
         serverLog("DEBUG", "GetComposedText: candidate[\(i + 1)/\(converted.mainResults.count)] start")
 
-        let constructStart = timingStart(enabled: serverPerfLogEnabled)
+        let constructStart = timingStart(enabled: perfTiming)
         let candidateText = constructCandidateString(candidate: candidate, hiragana: previewHiragana)
         constructCandidateMs += elapsedMillis(since: constructStart)
-        let duplicateTextStart = timingStart(enabled: serverPerfLogEnabled)
+        let duplicateTextStart = timingStart(enabled: perfTiming)
         let text = strdup(candidateText)
         duplicateStringMs += elapsedMillis(since: duplicateTextStart)
         serverLog("DEBUG", "GetComposedText: candidate[\(i + 1)] textReady")
-        let duplicateHiraganaStart = timingStart(enabled: serverPerfLogEnabled)
+        let duplicateHiraganaStart = timingStart(enabled: perfTiming)
         let hiragana = strdup(previewHiragana)
         duplicateStringMs += elapsedMillis(since: duplicateHiraganaStart)
-        let resolveStart = timingStart(enabled: serverPerfLogEnabled)
+        let resolveStart = timingStart(enabled: perfTiming)
         let resolvedCandidate = resolveCandidateCompositionForDisplay(
             originalComposingText: composingText,
             previewComposingText: previewComposingText,
@@ -823,7 +858,7 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
             inputCount: composingText.input.count,
             isZenzaiEnabled: useZenzai
         )
-        let duplicateSubtextStart = timingStart(enabled: serverPerfLogEnabled)
+        let duplicateSubtextStart = timingStart(enabled: perfTiming)
         let subtext = strdup(resolvedCandidate.remainingConvertTarget)
         duplicateStringMs += elapsedMillis(since: duplicateSubtextStart)
         serverLog("DEBUG", "GetComposedText: candidate[\(i + 1)] subtextReady")
@@ -834,7 +869,7 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
 
     lengthPtr.pointee = result.count
     serverLog("INFO", "GetComposedText: completed candidateCount=\(result.count) useZenzai=\(useZenzai)")
-    let marshalStart = timingStart(enabled: serverPerfLogEnabled)
+    let marshalStart = timingStart(enabled: perfTiming)
     let pointer = to_list_pointer(result)
     let marshalMs = elapsedMillis(since: marshalStart)
     serverPerfLog(
@@ -847,8 +882,9 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
 @_silgen_name("GetComposedTextForCursorPrefix")
 @MainActor public func get_composed_text_for_cursor_prefix(lengthPtr: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
     let collectTiming = shouldCollectTiming(for: .info)
-    let totalStart = timingStart(enabled: serverPerfLogEnabled)
-    let prepareStart = timingStart(enabled: serverPerfLogEnabled)
+    let perfTiming = serverPerfLogState.isEnabled()
+    let totalStart = timingStart(enabled: perfTiming)
+    let prepareStart = timingStart(enabled: perfTiming)
     let hiragana = composingText.convertTarget
     let suffixAfterCursor = String(hiragana.dropFirst(composingText.convertTargetCursorPosition))
     let prefixComposingText = composingText.prefixToCursorPosition()
@@ -871,7 +907,7 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
         hiraganaCount: prefixHiragana.count
     )
     let prepareMs = elapsedMillis(since: prepareStart)
-    let optionsStart = timingStart(enabled: serverPerfLogEnabled)
+    let optionsStart = timingStart(enabled: perfTiming)
     let options = getOptions(context: contextString, zenzaiEnabled: useZenzai)
     let optionsMs = elapsedMillis(since: optionsStart)
     serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates begin useZenzai=\(useZenzai) syntheticEndOfText=\(previewState.syntheticEndOfText)")
@@ -880,7 +916,7 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
     let requestMs = elapsedMillis(since: requestStart)
     serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(converted.mainResults.count) elapsed_ms=\(requestMs)")
     var result: [FFICandidate] = []
-    let formatStart = timingStart(enabled: serverPerfLogEnabled)
+    let formatStart = timingStart(enabled: perfTiming)
     var constructCandidateMs = 0
     var resolveCandidateMs = 0
     var duplicateStringMs = 0
@@ -889,17 +925,17 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
         let candidate = converted.mainResults[i]
         serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)/\(converted.mainResults.count)] start")
 
-        let constructStart = timingStart(enabled: serverPerfLogEnabled)
+        let constructStart = timingStart(enabled: perfTiming)
         let candidateText = constructCandidateString(candidate: candidate, hiragana: previewPrefixHiragana)
         constructCandidateMs += elapsedMillis(since: constructStart)
-        let duplicateTextStart = timingStart(enabled: serverPerfLogEnabled)
+        let duplicateTextStart = timingStart(enabled: perfTiming)
         let text = strdup(candidateText)
         duplicateStringMs += elapsedMillis(since: duplicateTextStart)
         serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)] textReady")
-        let duplicateHiraganaStart = timingStart(enabled: serverPerfLogEnabled)
+        let duplicateHiraganaStart = timingStart(enabled: perfTiming)
         let hiragana = strdup(previewPrefixHiragana + suffixAfterCursor)
         duplicateStringMs += elapsedMillis(since: duplicateHiraganaStart)
-        let resolveStart = timingStart(enabled: serverPerfLogEnabled)
+        let resolveStart = timingStart(enabled: perfTiming)
         let resolvedCandidate = resolveCandidateCompositionForDisplay(
             originalComposingText: prefixComposingText,
             previewComposingText: previewPrefixComposingText,
@@ -916,7 +952,7 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
             inputCount: prefixComposingText.input.count,
             isZenzaiEnabled: useZenzai
         )
-        let duplicateSubtextStart = timingStart(enabled: serverPerfLogEnabled)
+        let duplicateSubtextStart = timingStart(enabled: perfTiming)
         let subtext = strdup(resolvedCandidate.remainingConvertTarget + suffixAfterCursor)
         duplicateStringMs += elapsedMillis(since: duplicateSubtextStart)
         serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)] subtextReady")
@@ -927,7 +963,7 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
 
     lengthPtr.pointee = result.count
     serverLog("INFO", "GetComposedTextForCursorPrefix: completed candidateCount=\(result.count) useZenzai=\(useZenzai)")
-    let marshalStart = timingStart(enabled: serverPerfLogEnabled)
+    let marshalStart = timingStart(enabled: perfTiming)
     let pointer = to_list_pointer(result)
     let marshalMs = elapsedMillis(since: marshalStart)
     serverPerfLog(

--- a/server-swift/Sources/azookey-server/romaji_table_compiler.swift
+++ b/server-swift/Sources/azookey-server/romaji_table_compiler.swift
@@ -26,9 +26,16 @@ func normalizeRomajiCell(_ value: String) -> String {
 }
 
 private func escapeInputTableToken(_ value: String) -> String {
-    value
-        .replacingOccurrences(of: "{", with: "{lbracket}")
-        .replacingOccurrences(of: "}", with: "{rbracket}")
+    value.map { character in
+        switch character {
+        case "{":
+            "{lbracket}"
+        case "}":
+            "{rbracket}"
+        default:
+            String(character)
+        }
+    }.joined()
 }
 
 func buildCustomRomajiTableEntries(rows: [RomajiTableRow]) -> [(key: String, value: String)] {
@@ -131,8 +138,8 @@ func buildCustomRomajiTableEntries(rows: [RomajiTableRow]) -> [(key: String, val
             literalEscaping: false
         )
         upsertEntry(
-            rawKey: "\(escapedInput){any-0x00}",
-            rawValue: "\(escapedOutput){any-0x00}",
+            rawKey: "\(escapedInput){any character}",
+            rawValue: "\(escapedOutput){any character}",
             source: .generated,
             literalEscaping: false
         )

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -7,19 +7,15 @@ private func row(_ input: String, _ output: String, _ next: String = "") -> Roma
     RomajiTableRow(input: input, output: output, next_input: next)
 }
 
-private func makeTemporaryCustomInputStyle(_ rows: [RomajiTableRow]) throws -> InputStyle {
+private func makeTemporaryCustomInputStyle(_ rows: [RomajiTableRow]) throws -> (inputStyle: InputStyle, fileURL: URL) {
     let fileURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("azookey-romaji-test-\(UUID().uuidString).tsv")
     let content = try #require(buildCustomRomajiTableContent(rows: rows))
     try content.write(to: fileURL, atomically: true, encoding: .utf8)
-    return .mapped(id: .custom(fileURL))
-}
-
-private func customInputStyleURL(_ inputStyle: InputStyle) -> URL? {
-    guard case .mapped(id: .custom(let url)) = inputStyle else {
-        return nil
-    }
-    return url
+    let tableName = "azookey-romaji-test-\(UUID().uuidString)"
+    let table = try InputStyleManager.loadTable(from: fileURL)
+    InputStyleManager.registerInputStyle(table: table, for: tableName)
+    return (.mapped(id: .tableName(tableName)), fileURL)
 }
 
 private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
@@ -63,7 +59,7 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
 
     #expect(map["n"] == nil)
     #expect(map["n{composition-separator}"] == "ん")
-    #expect(map["n{any-0x00}"] == "ん{any-0x00}")
+    #expect(map["n{any character}"] == "ん{any character}")
     #expect(map["ny"] == "ny")
     #expect(map["na"] == "な")
     #expect(map["nn"] == "ん")
@@ -219,6 +215,8 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
 
 @Test func trailingNPreviewSupportsCustomRomajiTable() async throws {
     let rows = [
+        row("ka", "か"),
+        row("ge", "げ"),
         row("n", "ん"),
         row("na", "な"),
         row("nn", "ん"),
@@ -226,8 +224,7 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
         row("nya", "にゃ"),
         row("-", "ー"),
     ]
-    let inputStyle = try makeTemporaryCustomInputStyle(rows)
-    let fileURL = try #require(customInputStyleURL(inputStyle))
+    let (inputStyle, fileURL) = try makeTemporaryCustomInputStyle(rows)
     defer {
         try? FileManager.default.removeItem(at: fileURL)
     }
@@ -292,8 +289,7 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
         row("q", "く"),
         row("qa", "くぁ"),
     ]
-    let inputStyle = try makeTemporaryCustomInputStyle(rows)
-    let fileURL = try #require(customInputStyleURL(inputStyle))
+    let (inputStyle, fileURL) = try makeTemporaryCustomInputStyle(rows)
     defer {
         try? FileManager.default.removeItem(at: fileURL)
     }

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -24,6 +24,15 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
     )
 }
 
+private func testDictionaryURL() -> URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("azooKey_dictionary_storage")
+        .appendingPathComponent("Dictionary")
+}
+
 @Test func supportsNextInputCarryForTsuRules() async throws {
     let map = tableMap([
         row("tt", "っ", "t"),
@@ -125,6 +134,28 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
     )
 
     #expect(useZenzai)
+}
+
+@Test func dictionaryCandidatesIncludeKanjiForKagen() async throws {
+    let dictionaryURL = testDictionaryURL()
+    let loudsURL = dictionaryURL
+        .appendingPathComponent("louds")
+        .appendingPathComponent("カ.louds")
+    #expect(FileManager.default.fileExists(atPath: loudsURL.path))
+
+    let candidates = await MainActor.run {
+        let converter = KanaKanjiConverter(dictionaryURL: dictionaryURL, preloadDictionary: true)
+        var composingText = ComposingText()
+        composingText.insertAtCursorPosition("kagen", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: composingText)
+        let result = converter.requestCandidates(
+            preview.composingText,
+            options: getOptions(zenzaiEnabled: false)
+        )
+        return result.mainResults.map { constructCandidateString(candidate: $0, hiragana: "かげん") }
+    }
+
+    #expect(candidates.contains("加減"))
 }
 
 @Test func cpuBackendIsDisabledWhenAvxIsUnavailable() async throws {


### PR DESCRIPTION
## Summary
- 開発者オプション設定を追加し、計測ログを設定画面から opt-in で有効化できるようにしました。
- Rust / Swift / 変換エンジンの計測ログを Azookey のログ経路へ集約し、ログ OFF 時は計測用の時刻取得やログ文字列生成が入力経路へ乗らないようにしました。
- `AzooKeyKanaKanjiConverter` の依存先を fork の `main` ブランチへ変更しました。

## Background
- Issue: #40
- Zenzai 有効時の入力遅延を調査するため、これまで一時的に環境変数ベースの計測ログを入れていました。
- PR 化にあたり、通常利用時の入力性能へ影響しないよう、ログ無効時は計測経路自体を避ける形に整理します。
- 変換エンジン側の計測実装は fork 側へ整理して取り込み、Azookey 側は fork の `main` を参照する形にします。

## Changes
- shared / settings
  - `developer_options` 設定を追加
  - `developer_options.enable` が OFF の場合は `developer_options.logging` も OFF として扱うように整理
- frontend
  - 設定画面に「開発者オプション」セクションを追加
  - 「開発者オプションを有効化」ON 時のみ「ログを有効化」を表示
- server / logging
  - 計測ログ有効化を環境変数ではなく設定値から読むように変更
  - Rust 側の計測ログを `PERF` ログへ集約
  - ログ OFF 時は計測用 `Instant` 取得とログ文字列生成を避けるように変更
- server-swift / converter
  - Swift 側の計測ログと converter engine perf log を Azookey のログ経路へ集約
  - ログ OFF 時は converter engine 側の計測開始処理が no-op になるように変更
  - Zenzai の GPU layer 設定を backend 設定に応じて engine runtime へ渡すように整理
  - `AzooKeyKanaKanjiConverter` 依存先を `https://github.com/batao9/AzooKeyKanaKanjiConverter` の `main` ブランチへ変更
- converter fork
  - 計測ログ整理を fork の `main` へ取り込み済み
  - PR: https://github.com/batao9/AzooKeyKanaKanjiConverter/pull/2
  - pinned revision: `e4c5bdabe739c83b9b90ed8f58a2ea82f1f39052`

## Verification
- [x] ローカル Windows VM build 成功
  - `.local/vm_build_master.sh feature/issue-40-zenzai-perf-logging`
  - artifact: `.local/artifacts/azookey-setup-feature_issue-40-zenzai-perf-logging-20260509-195833.exe`
- [x] converter fork の PR を merge 済み
  - https://github.com/batao9/AzooKeyKanaKanjiConverter/pull/2
- [x] 差分チェック
  - `git diff --cached --check`
- [ ] GitHub Actions build 成功
  - run: pending

## Checklist
- [x] converter fork の取り込み結果を記載した
- [x] VM build 結果と artifact を記載した
- [x] ログ OFF 時の入力経路への影響範囲を確認した
- [ ] CI run URL と結果を記載した