### PR TITLE
fix(server): integrate clean zenzai converter

### DIFF
--- a/server-swift/Package.resolved
+++ b/server-swift/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/batao9/AzooKeyKanaKanjiConverter",
       "state" : {
-        "revision" : "4684ff9bd6784901e1b4314f3cb08208a6468143"
+        "revision" : "56268957b81b004ca8231ffc3491a4af684d0e20"
       }
     },
     {

--- a/server-swift/Package.resolved
+++ b/server-swift/Package.resolved
@@ -4,9 +4,9 @@
     {
       "identity" : "azookeykanakanjiconverter",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/azookey/AzooKeyKanaKanjiConverter",
+      "location" : "https://github.com/batao9/AzooKeyKanaKanjiConverter",
       "state" : {
-        "revision" : "884456d9d077f9e2136d273e0bfbd39b05374f7f"
+        "revision" : "fecb061e4955dbbad87acaa47ef470a0558c51fe"
       }
     },
     {

--- a/server-swift/Package.resolved
+++ b/server-swift/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/batao9/AzooKeyKanaKanjiConverter",
       "state" : {
-        "revision" : "8d6fd109e5598fdc17f9d0253e416d4b42d6711a"
+        "revision" : "8a44bb5d1d3d7c68fc1869820412c5971bc7dc2d"
       }
     },
     {

--- a/server-swift/Package.resolved
+++ b/server-swift/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/batao9/AzooKeyKanaKanjiConverter",
       "state" : {
-        "revision" : "8a44bb5d1d3d7c68fc1869820412c5971bc7dc2d"
+        "revision" : "4684ff9bd6784901e1b4314f3cb08208a6468143"
       }
     },
     {

--- a/server-swift/Package.resolved
+++ b/server-swift/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/batao9/AzooKeyKanaKanjiConverter",
       "state" : {
-        "revision" : "fecb061e4955dbbad87acaa47ef470a0558c51fe"
+        "revision" : "8d6fd109e5598fdc17f9d0253e416d4b42d6711a"
       }
     },
     {

--- a/server-swift/Package.swift
+++ b/server-swift/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(
             url: "https://github.com/batao9/AzooKeyKanaKanjiConverter",
-            revision: "8a44bb5d1d3d7c68fc1869820412c5971bc7dc2d",
+            revision: "4684ff9bd6784901e1b4314f3cb08208a6468143",
             traits: ["Zenzai"]
         )
     ],

--- a/server-swift/Package.swift
+++ b/server-swift/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(
-            url: "https://github.com/azookey/AzooKeyKanaKanjiConverter",
-            revision: "884456d9d077f9e2136d273e0bfbd39b05374f7f",
+            url: "https://github.com/batao9/AzooKeyKanaKanjiConverter",
+            revision: "fecb061e4955dbbad87acaa47ef470a0558c51fe",
             traits: ["Zenzai"]
         )
     ],

--- a/server-swift/Package.swift
+++ b/server-swift/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(
             url: "https://github.com/batao9/AzooKeyKanaKanjiConverter",
-            revision: "fecb061e4955dbbad87acaa47ef470a0558c51fe",
+            revision: "8d6fd109e5598fdc17f9d0253e416d4b42d6711a",
             traits: ["Zenzai"]
         )
     ],

--- a/server-swift/Package.swift
+++ b/server-swift/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(
             url: "https://github.com/batao9/AzooKeyKanaKanjiConverter",
-            revision: "8d6fd109e5598fdc17f9d0253e416d4b42d6711a",
+            revision: "8a44bb5d1d3d7c68fc1869820412c5971bc7dc2d",
             traits: ["Zenzai"]
         )
     ],

--- a/server-swift/Package.swift
+++ b/server-swift/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(
             url: "https://github.com/batao9/AzooKeyKanaKanjiConverter",
-            revision: "4684ff9bd6784901e1b4314f3cb08208a6468143",
+            revision: "56268957b81b004ca8231ffc3491a4af684d0e20",
             traits: ["Zenzai"]
         )
     ],

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -2,8 +2,12 @@ import KanaKanjiConverterModule
 import Foundation
 import ffi
 
+private let fallbackDictionaryURL = URL(fileURLWithPath: "/dev/null")
+
+@MainActor var converterDictionaryURL = fallbackDictionaryURL
+@MainActor var converterPreloadDictionary = false
 @MainActor var converter = KanaKanjiConverter(
-    dictionaryURL: URL(fileURLWithPath: "/dev/null"),
+    dictionaryURL: fallbackDictionaryURL,
     preloadDictionary: false
 )
 @MainActor var composingText = ComposingText()
@@ -116,10 +120,21 @@ private func serverLog(_ level: String = "INFO", _ message: @autoclosure () -> S
     handle.write(data)
 }
 
-@MainActor private func configureEngineRuntime(zenzaiEnabled: Bool) {
-    let normalizedBackend = ((config["backend"] as? String) ?? "cpu")
+@MainActor private func rebuildConverter() {
+    converter = KanaKanjiConverter(
+        dictionaryURL: converterDictionaryURL,
+        preloadDictionary: converterPreloadDictionary
+    )
+}
+
+func normalizedZenzaiBackend(_ backend: String?) -> String {
+    (backend ?? "cpu")
         .trimmingCharacters(in: .whitespacesAndNewlines)
         .lowercased()
+}
+
+@MainActor private func configureEngineRuntime(zenzaiEnabled: Bool) {
+    let normalizedBackend = normalizedZenzaiBackend(config["backend"] as? String)
     let shouldOffloadToGpu = zenzaiEnabled && !normalizedBackend.isEmpty && normalizedBackend != "cpu"
     KanaKanjiConverterEngineRuntime.configure(
         gpuLayerCount: shouldOffloadToGpu ? Int32.max : 0
@@ -189,9 +204,7 @@ func effectiveZenzaiRuntimeEnabled(
         return false
     }
 
-    let normalizedBackend = (backend ?? "cpu")
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-        .lowercased()
+    let normalizedBackend = normalizedZenzaiBackend(backend)
 
     if normalizedBackend.isEmpty || normalizedBackend == "cpu" {
         return cpuBackendSupported
@@ -375,7 +388,7 @@ private func clampedCorrespondingCount(
     configureEngineRuntime(zenzaiEnabled: zenzaiEnabled)
     let profile = (config["profile"] as? String) ?? ""
     return ConvertRequestOptions(
-        requireJapanesePrediction: .manualMix,
+        requireJapanesePrediction: .disabled,
         requireEnglishPrediction: .disabled,
         keyboardLanguage: .ja_JP,
         learningType: .nothing,
@@ -546,11 +559,17 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
         cpuBackendSupported: cpuZenzaiBackendSupportedFromEnvironment()
     )
     let currentUsedCustomRomajiTable = customRomajiTableURL != nil
+    let backendChanged = normalizedZenzaiBackend(previousBackend) != normalizedZenzaiBackend(currentBackend)
     if previousEffectiveZenzaiEnabled != currentEffectiveZenzaiEnabled
         || previousProfile != currentProfile
+        || backendChanged
         || previousUsedCustomRomajiTable != currentUsedCustomRomajiTable
     {
-        converter.stopComposition()
+        if backendChanged {
+            rebuildConverter()
+        } else {
+            converter.stopComposition()
+        }
         composingText = ComposingText()
         composingTextSnapshots.removeAll()
     }
@@ -569,10 +588,9 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     let path = String(cString: path)
     serverLog("INFO", "Initialize: start path=\(path) use_zenzai=\(use_zenzai)")
     execURL = URL(filePath: path)
-    converter = KanaKanjiConverter(
-        dictionaryURL: execURL.appendingPathComponent("Dictionary"),
-        preloadDictionary: true
-    )
+    converterDictionaryURL = execURL.appendingPathComponent("Dictionary")
+    converterPreloadDictionary = true
+    rebuildConverter()
 
     load_config()
 

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -375,7 +375,7 @@ private func clampedCorrespondingCount(
     configureEngineRuntime(zenzaiEnabled: zenzaiEnabled)
     let profile = (config["profile"] as? String) ?? ""
     return ConvertRequestOptions(
-        requireJapanesePrediction: .autoMix,
+        requireJapanesePrediction: .manualMix,
         requireEnglishPrediction: .disabled,
         keyboardLanguage: .ja_JP,
         learningType: .nothing,

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -2,7 +2,18 @@ import KanaKanjiConverterModule
 import Foundation
 import ffi
 
-private let fallbackDictionaryURL = URL(fileURLWithPath: "/dev/null")
+private let fallbackDictionaryURL: URL = {
+    let temporaryDirectory = FileManager.default.temporaryDirectory
+    let url = temporaryDirectory
+        .appendingPathComponent("Azookey")
+        .appendingPathComponent("FallbackDictionary", isDirectory: true)
+    do {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    } catch {
+        return temporaryDirectory
+    }
+}()
 
 @MainActor var converterDictionaryURL = fallbackDictionaryURL
 @MainActor var converterPreloadDictionary = false
@@ -13,7 +24,7 @@ private let fallbackDictionaryURL = URL(fileURLWithPath: "/dev/null")
 @MainActor var composingText = ComposingText()
 @MainActor var composingTextSnapshots: [ComposingText] = []
 @MainActor var currentInputStyle: InputStyle = .roman2kana
-@MainActor var customRomajiTableURL: URL?
+@MainActor var customRomajiTableEnabled = false
 
 @MainActor var execURL = URL(filePath: "")
 @MainActor var config: [String : Any] = [
@@ -219,12 +230,7 @@ private func cpuZenzaiBackendSupportedFromEnvironment() -> Bool {
 
 @MainActor private func setRoman2KanaInputStyle() {
     currentInputStyle = .roman2kana
-
-    if let existing = customRomajiTableURL {
-        try? FileManager.default.removeItem(at: existing)
-    }
-
-    customRomajiTableURL = nil
+    customRomajiTableEnabled = false
 }
 
 @MainActor private func setCustomRomajiInputStyle(rows: [RomajiTableRow]?) {
@@ -238,16 +244,14 @@ private func cpuZenzaiBackendSupportedFromEnvironment() -> Bool {
 
     do {
         try content.write(to: fileURL, atomically: true, encoding: .utf8)
-        let previousURL = customRomajiTableURL
+        defer {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
         let tableName = "azookey-windows-custom-romaji"
         let table = try InputStyleManager.loadTable(from: fileURL)
         InputStyleManager.registerInputStyle(table: table, for: tableName)
         currentInputStyle = .mapped(id: .tableName(tableName))
-        customRomajiTableURL = fileURL
-
-        if let previousURL, previousURL != fileURL {
-            try? FileManager.default.removeItem(at: previousURL)
-        }
+        customRomajiTableEnabled = true
     } catch {
         serverLog("ERROR", "Failed to apply custom romaji table: \(error)")
         setRoman2KanaInputStyle()
@@ -471,7 +475,7 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
         backend: previousBackend,
         cpuBackendSupported: cpuZenzaiBackendSupportedFromEnvironment()
     )
-    let previousUsedCustomRomajiTable = customRomajiTableURL != nil
+    let previousUsedCustomRomajiTable = customRomajiTableEnabled
     var dynamicUserDictionary: [DicdataElement] = []
     defer {
         converter.importDynamicUserDictionary(dynamicUserDictionary)
@@ -558,7 +562,7 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
         backend: currentBackend,
         cpuBackendSupported: cpuZenzaiBackendSupportedFromEnvironment()
     )
-    let currentUsedCustomRomajiTable = customRomajiTableURL != nil
+    let currentUsedCustomRomajiTable = customRomajiTableEnabled
     let backendChanged = normalizedZenzaiBackend(previousBackend) != normalizedZenzaiBackend(currentBackend)
     if previousEffectiveZenzaiEnabled != currentEffectiveZenzaiEnabled
         || previousProfile != currentProfile

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -2,7 +2,10 @@ import KanaKanjiConverterModule
 import Foundation
 import ffi
 
-@MainActor let converter = KanaKanjiConverter()
+@MainActor var converter = KanaKanjiConverter(
+    dictionaryURL: URL(fileURLWithPath: "/dev/null"),
+    preloadDictionary: false
+)
 @MainActor var composingText = ComposingText()
 @MainActor var composingTextSnapshots: [ComposingText] = []
 @MainActor var currentInputStyle: InputStyle = .roman2kana
@@ -113,6 +116,16 @@ private func serverLog(_ level: String = "INFO", _ message: @autoclosure () -> S
     handle.write(data)
 }
 
+@MainActor private func configureEngineRuntime(zenzaiEnabled: Bool) {
+    let normalizedBackend = ((config["backend"] as? String) ?? "cpu")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .lowercased()
+    let shouldOffloadToGpu = zenzaiEnabled && !normalizedBackend.isEmpty && normalizedBackend != "cpu"
+    KanaKanjiConverterEngineRuntime.configure(
+        gpuLayerCount: shouldOffloadToGpu ? Int32.max : 0
+    )
+}
+
 private struct AppSettings: Decodable {
     let zenzai: ZenzaiSettings?
     let user_dictionary: UserDictionarySettings?
@@ -213,7 +226,10 @@ private func cpuZenzaiBackendSupportedFromEnvironment() -> Bool {
     do {
         try content.write(to: fileURL, atomically: true, encoding: .utf8)
         let previousURL = customRomajiTableURL
-        currentInputStyle = .mapped(id: .custom(fileURL))
+        let tableName = "azookey-windows-custom-romaji"
+        let table = try InputStyleManager.loadTable(from: fileURL)
+        InputStyleManager.registerInputStyle(table: table, for: tableName)
+        currentInputStyle = .mapped(id: .tableName(tableName))
         customRomajiTableURL = fileURL
 
         if let previousURL, previousURL != fileURL {
@@ -273,18 +289,18 @@ private func clampedCorrespondingCount(
     }
 
     switch trailingElement.piece {
-    case .character:
+    case .character, .key:
         guard trailingElement.inputStyle != .direct else {
             return (composingText: composingText, syntheticEndOfText: false)
         }
-    case .endOfText:
+    case .compositionSeparator:
         return (composingText: composingText, syntheticEndOfText: false)
     }
 
     var previewComposingText = composingText
     let originalConvertTarget = previewComposingText.convertTarget
     previewComposingText.insertAtCursorPosition([
-        .init(piece: .endOfText, inputStyle: trailingElement.inputStyle)
+        .init(piece: .compositionSeparator, inputStyle: trailingElement.inputStyle)
     ])
 
     guard previewComposingText.convertTarget != originalConvertTarget else {
@@ -356,18 +372,19 @@ private func clampedCorrespondingCount(
     context: String = "",
     zenzaiEnabled: Bool
 ) -> ConvertRequestOptions {
+    configureEngineRuntime(zenzaiEnabled: zenzaiEnabled)
     let profile = (config["profile"] as? String) ?? ""
     return ConvertRequestOptions(
-        requireJapanesePrediction: true,
-        requireEnglishPrediction: false,
+        requireJapanesePrediction: .autoMix,
+        requireEnglishPrediction: .disabled,
         keyboardLanguage: .ja_JP,
         learningType: .nothing,
-        dictionaryResourceURL: execURL.appendingPathComponent("Dictionary"),
         memoryDirectoryURL: URL(filePath: "./test"),
         sharedContainerURL: URL(filePath: "./test"),
         textReplacer: .init {
             return execURL.appendingPathComponent("EmojiDictionary").appendingPathComponent("emoji_all_E15.1.txt")
         },
+        specialCandidateProviders: nil,
         // zenzai
         zenzaiMode: zenzaiEnabled ? .on(
             weight: execURL.appendingPathComponent("zenz.gguf"),
@@ -381,7 +398,6 @@ private func clampedCorrespondingCount(
                 )
             )
         ) : .off,
-        preloadDictionary: true,
         metadata: .init(versionString: "Azookey for Windows")
     )
 }
@@ -445,7 +461,7 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     let previousUsedCustomRomajiTable = customRomajiTableURL != nil
     var dynamicUserDictionary: [DicdataElement] = []
     defer {
-        converter.sendToDicdataStore(.importDynamicUserDict(dynamicUserDictionary))
+        converter.importDynamicUserDictionary(dynamicUserDictionary)
     }
 
     config["enable"] = false
@@ -553,6 +569,10 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     let path = String(cString: path)
     serverLog("INFO", "Initialize: start path=\(path) use_zenzai=\(use_zenzai)")
     execURL = URL(filePath: path)
+    converter = KanaKanjiConverter(
+        dictionaryURL: execURL.appendingPathComponent("Dictionary"),
+        preloadDictionary: true
+    )
 
     load_config()
 

--- a/server-swift/Sources/azookey-server/romaji_table_compiler.swift
+++ b/server-swift/Sources/azookey-server/romaji_table_compiler.swift
@@ -131,8 +131,8 @@ func buildCustomRomajiTableEntries(rows: [RomajiTableRow]) -> [(key: String, val
             literalEscaping: false
         )
         upsertEntry(
-            rawKey: "\(escapedInput){any-0x00}",
-            rawValue: "\(escapedOutput){any-0x00}",
+            rawKey: "\(escapedInput){any character}",
+            rawValue: "\(escapedOutput){any character}",
             source: .generated,
             literalEscaping: false
         )

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -37,7 +37,7 @@ private func packageRootURL() -> URL {
 private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions {
     let packageRoot = packageRootURL()
     return ConvertRequestOptions(
-        requireJapanesePrediction: .manualMix,
+        requireJapanesePrediction: .disabled,
         requireEnglishPrediction: .disabled,
         keyboardLanguage: .ja_JP,
         learningType: .nothing,
@@ -176,6 +176,19 @@ private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions 
     )
 
     #expect(enabled)
+}
+
+@Test func zenzaiBackendNormalizationIgnoresCaseAndWhitespace() async throws {
+    #expect(normalizedZenzaiBackend(" Vulkan ") == "vulkan")
+    #expect(normalizedZenzaiBackend(nil) == "cpu")
+}
+
+@Test func serverOptionsDisableJapanesePrediction() async throws {
+    let predictionMode = await MainActor.run {
+        getOptions(zenzaiEnabled: false).requireJapanesePrediction
+    }
+
+    #expect(predictionMode == .disabled)
 }
 
 @Test func surfaceCountTracksUnderlyingRomanInputLength() async throws {

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -12,14 +12,13 @@ private func makeTemporaryCustomInputStyle(_ rows: [RomajiTableRow]) throws -> I
         .appendingPathComponent("azookey-romaji-test-\(UUID().uuidString).tsv")
     let content = try #require(buildCustomRomajiTableContent(rows: rows))
     try content.write(to: fileURL, atomically: true, encoding: .utf8)
-    return .mapped(id: .custom(fileURL))
-}
-
-private func customInputStyleURL(_ inputStyle: InputStyle) -> URL? {
-    guard case .mapped(id: .custom(let url)) = inputStyle else {
-        return nil
+    defer {
+        try? FileManager.default.removeItem(at: fileURL)
     }
-    return url
+    let tableName = "azookey-windows-test-romaji-\(UUID().uuidString)"
+    let table = try InputStyleManager.loadTable(from: fileURL)
+    InputStyleManager.registerInputStyle(table: table, for: tableName)
+    return .mapped(id: .tableName(tableName))
 }
 
 private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
@@ -63,7 +62,7 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
 
     #expect(map["n"] == nil)
     #expect(map["n{composition-separator}"] == "ん")
-    #expect(map["n{any-0x00}"] == "ん{any-0x00}")
+    #expect(map["n{any character}"] == "ん{any character}")
     #expect(map["ny"] == "ny")
     #expect(map["na"] == "な")
     #expect(map["nn"] == "ん")
@@ -227,10 +226,6 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
         row("-", "ー"),
     ]
     let inputStyle = try makeTemporaryCustomInputStyle(rows)
-    let fileURL = try #require(customInputStyleURL(inputStyle))
-    defer {
-        try? FileManager.default.removeItem(at: fileURL)
-    }
 
     let result = await MainActor.run {
         var source = ComposingText()
@@ -242,6 +237,26 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
     #expect(result.source.convertTarget == "かげn")
     #expect(result.preview.syntheticEndOfText)
     #expect(result.preview.composingText.convertTarget == "かげん")
+}
+
+@Test func customRomajiTableCommitsNBeforeConsonant() async throws {
+    let rows = [
+        row("n", "ん"),
+        row("na", "な"),
+        row("nn", "ん"),
+        row("n'", "ん"),
+        row("nya", "にゃ"),
+        row("ta", "た"),
+    ]
+    let inputStyle = try makeTemporaryCustomInputStyle(rows)
+
+    let convertTarget = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("nta", inputStyle: inputStyle)
+        return source.convertTarget
+    }
+
+    #expect(convertTarget == "んた")
 }
 
 @Test func trailingNPreviewUsesPreviewSuffixForDisplaySubtext() async throws {
@@ -293,10 +308,6 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
         row("qa", "くぁ"),
     ]
     let inputStyle = try makeTemporaryCustomInputStyle(rows)
-    let fileURL = try #require(customInputStyleURL(inputStyle))
-    defer {
-        try? FileManager.default.removeItem(at: fileURL)
-    }
 
     let preview = await MainActor.run {
         var source = ComposingText()

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -37,7 +37,7 @@ private func packageRootURL() -> URL {
 private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions {
     let packageRoot = packageRootURL()
     return ConvertRequestOptions(
-        requireJapanesePrediction: .autoMix,
+        requireJapanesePrediction: .manualMix,
         requireEnglishPrediction: .disabled,
         keyboardLanguage: .ja_JP,
         learningType: .nothing,
@@ -313,6 +313,37 @@ private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions 
     }
 
     #expect(candidates.contains { $0.contains("加減") }, "candidates: \(candidates)")
+}
+
+@Test func singleWordKanjiCandidateBeatsHiraganaPrediction() async throws {
+    let packageRoot = packageRootURL()
+    let dictionaryURL = packageRoot
+        .appending(path: "azooKey_dictionary_storage")
+        .appending(path: "Dictionary")
+    let memoryURL = FileManager.default.temporaryDirectory
+        .appending(path: "azookey-server-test-\(UUID().uuidString)")
+    defer {
+        try? FileManager.default.removeItem(at: memoryURL)
+    }
+
+    let candidates = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("kannji", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source)
+        let previewHiragana = preview.composingText.convertTarget
+        let testConverter = KanaKanjiConverter(dictionaryURL: dictionaryURL, preloadDictionary: true)
+        return testConverter.requestCandidates(
+            preview.composingText,
+            options: testConvertRequestOptions(memoryURL: memoryURL)
+        )
+        .mainResults
+        .prefix(5)
+        .map { candidate in
+            constructCandidateString(candidate: candidate, hiragana: previewHiragana)
+        }
+    }
+
+    #expect(candidates.first == "感じ", "candidates: \(candidates)")
 }
 
 @Test func trailingNPreviewUsesPreviewSuffixForDisplaySubtext() async throws {

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -27,6 +27,34 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
     )
 }
 
+private func packageRootURL() -> URL {
+    URL(filePath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}
+
+private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions {
+    let packageRoot = packageRootURL()
+    return ConvertRequestOptions(
+        requireJapanesePrediction: .autoMix,
+        requireEnglishPrediction: .disabled,
+        keyboardLanguage: .ja_JP,
+        learningType: .nothing,
+        memoryDirectoryURL: memoryURL,
+        sharedContainerURL: memoryURL,
+        textReplacer: .init {
+            packageRoot
+                .appending(path: "azooKey_emoji_dictionary_storage")
+                .appending(path: "EmojiDictionary")
+                .appending(path: "emoji_all_E15.1.txt")
+        },
+        specialCandidateProviders: nil,
+        zenzaiMode: .off,
+        metadata: .init(versionString: "Azookey for Windows test")
+    )
+}
+
 @Test func supportsNextInputCarryForTsuRules() async throws {
     let map = tableMap([
         row("tt", "っ", "t"),
@@ -257,6 +285,34 @@ private func tableMap(_ rows: [RomajiTableRow]) -> [String: String] {
     }
 
     #expect(convertTarget == "んた")
+}
+
+@Test func dictionaryCandidatesIncludeKanjiAfterRomanTrailingNPreview() async throws {
+    let packageRoot = packageRootURL()
+    let dictionaryURL = packageRoot
+        .appending(path: "azooKey_dictionary_storage")
+        .appending(path: "Dictionary")
+    let memoryURL = FileManager.default.temporaryDirectory
+        .appending(path: "azookey-server-test-\(UUID().uuidString)")
+    defer {
+        try? FileManager.default.removeItem(at: memoryURL)
+    }
+
+    let candidates = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("iikagenn", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source)
+        let previewHiragana = preview.composingText.convertTarget
+        let testConverter = KanaKanjiConverter(dictionaryURL: dictionaryURL, preloadDictionary: true)
+        return testConverter.requestCandidates(
+            preview.composingText,
+            options: testConvertRequestOptions(memoryURL: memoryURL)
+        )
+        .mainResults
+        .map { constructCandidateString(candidate: $0, hiragana: previewHiragana) }
+    }
+
+    #expect(candidates.contains { $0.contains("加減") }, "candidates: \(candidates)")
 }
 
 @Test func trailingNPreviewUsesPreviewSuffixForDisplaySubtext() async throws {


### PR DESCRIPTION
## Summary
- Converter dependency を、マージ済みの `batao9/AzooKeyKanaKanjiConverter/main` (`56268957b81b004ca8231ffc3491a4af684d0e20`) へ更新しました。
- Zenzai backend 変更時に converter を作り直し、GPU/CPU 設定が既存 model/context に残らないようにしました。
- 現時点では予測変換を表示しないため、Japanese prediction を `.disabled` にして未使用の prediction 生成を止めました。

## Background
- Issue: #40
- Converter 側では `all_zenzai` の draft 間 lattice lookup seed 再利用、GPU layer runtime config、sequence-aware KV cache reuse を含む clean rebuild PR がマージ済みです。
- azooKey-Windows 側では、その merged main commit を参照しつつ、レビューで指摘された backend 切替時の model/context 再利用と未使用 prediction 計算を整理します。

## Changes
- server-swift
  - `KanaKanjiConverterEngineRuntime.configure(gpuLayerCount:)` を候補生成前に呼び、CPU/Zenzai disabled では `0`、GPU backend では `Int32.max` を設定
  - backend 変更時は `KanaKanjiConverter` を再生成し、同一 `zenz.gguf` URL の model cache/context を持ち越さないように変更
  - `requireJapanesePrediction` を `.disabled` に変更
  - backend normalization と prediction disabled の回帰 test を追加
- dependency
  - `AzooKeyKanaKanjiConverter` を `56268957b81b004ca8231ffc3491a4af684d0e20` に pin

## Verification
- [x] Converter PR #4 を `batao9/AzooKeyKanaKanjiConverter/main` へマージ済み
- [x] VM / 実機インストール後の動作確認
  - ユーザー確認済み
- [x] ローカル Windows VM build 成功
  - `.local/vm_build_master.sh feature/issue-40-clean-converter`
  - artifact: `.local/artifacts/azookey-setup-feature_issue-40-clean-converter-20260511-201253.exe`
- [x] ローカル Windows VM test（関連テスト）
  - `serverOptionsDisableJapanesePrediction`
  - `zenzaiBackendNormalizationIgnoresCaseAndWhitespace`
  - `singleWordKanjiCandidateBeatsHiraganaPrediction`
- [ ] GitHub Actions build 成功
  - run: 未実行

## Checklist
- [ ] CI run URL と結果を記載した
- [x] VM / 実機確認結果を記載した
- [x] 影響範囲を確認した
