### PR TITLE
fix(ime): stabilize lang bar settings menu

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -40,6 +40,7 @@ features = [
     "Win32_Security",
     "Win32_UI_TextServices",
     "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_Shell",
     "Win32_System_LibraryLoader",
     "Win32_UI_WindowsAndMessaging",
     "Win32_Graphics_Gdi",

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -54,8 +54,6 @@ pub extern "system" fn DllMain(
         tracing::debug!("DLL_PROCESS_DETACH");
 
         let result: anyhow::Result<()> = (|| {
-            tsf::language_bar::cleanup_menu_owner_window();
-
             let mut dll_instance = DllModule::get()?;
             dll_instance.hinst = None;
             // send a signal to the tracing writer thread to exit

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -54,6 +54,8 @@ pub extern "system" fn DllMain(
         tracing::debug!("DLL_PROCESS_DETACH");
 
         let result: anyhow::Result<()> = (|| {
+            tsf::language_bar::cleanup_menu_owner_window();
+
             let mut dll_instance = DllModule::get()?;
             dll_instance.hinst = None;
             // send a signal to the tracing writer thread to exit

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -2,6 +2,7 @@ use std::{
     cell::RefCell,
     env,
     path::{Path, PathBuf},
+    sync::atomic::{AtomicU32, Ordering},
 };
 
 use windows::{
@@ -29,9 +30,9 @@ use windows::{
             WindowsAndMessaging::{
                 AppendMenuW, CreatePopupMenu, CreateWindowExW, DefWindowProcW, DestroyMenu,
                 DestroyWindow, IsWindow, LoadImageW, PostMessageW, RegisterClassW,
-                SetForegroundWindow, TrackPopupMenu, HICON, HMENU, IMAGE_ICON, LR_DEFAULTCOLOR,
-                MF_STRING, SW_SHOWNORMAL, TPM_NONOTIFY, TPM_RETURNCMD, TPM_RIGHTBUTTON, WM_NULL,
-                WNDCLASSW, WS_EX_TOOLWINDOW, WS_POPUP,
+                SetForegroundWindow, TrackPopupMenu, UnregisterClassW, HICON, HMENU, IMAGE_ICON,
+                LR_DEFAULTCOLOR, MF_STRING, SW_SHOWNORMAL, TPM_NONOTIFY, TPM_RETURNCMD,
+                TPM_RIGHTBUTTON, WM_NULL, WNDCLASSW, WS_EX_TOOLWINDOW, WS_POPUP,
             },
         },
     },
@@ -42,6 +43,7 @@ use crate::{
         client_action::ClientAction, composition::CompositionState, input_mode::InputMode,
         state::IMEState, theme::get_theme,
     },
+    extension::StringExt as _,
     globals::{DllModule, GUID_TEXT_SERVICE, TEXTSERVICE_LANGBARITEMSINK_COOKIE},
 };
 
@@ -60,11 +62,12 @@ const INFO: TF_LANGBARITEMINFO = TF_LANGBARITEMINFO {
 const SETTINGS_MENU_ID: usize = 1;
 const SETTINGS_APP_DIRNAME: &str = "Azookey";
 const SETTINGS_APP_FILENAME: &str = "frontend.exe";
-const MENU_OWNER_WINDOW_CLASS_NAME: PCWSTR = w!("AzookeyLangBarMenuOwner");
 const SETTINGS_APP_UNINSTALL_SUBKEY: PCWSTR =
     w!(r"Software\Microsoft\Windows\CurrentVersion\Uninstall\Azookey");
 const SETTINGS_APP_INSTALL_LOCATION_VALUE: PCWSTR = w!("InstallLocation");
 const SETTINGS_APP_MAIN_BINARY_NAME_VALUE: PCWSTR = w!("MainBinaryName");
+
+static MENU_OWNER_WINDOW_CLASS_SEQUENCE: AtomicU32 = AtomicU32::new(0);
 
 thread_local! {
     static MENU_OWNER_WINDOW: RefCell<Option<MenuOwnerWindow>> = RefCell::new(None);
@@ -208,18 +211,29 @@ impl ITfLangBarItemButton_Impl for TextServiceFactory_Impl {
     }
 }
 
+pub(crate) fn cleanup_menu_owner_window() {
+    MENU_OWNER_WINDOW.with(|owner| {
+        owner.borrow_mut().take();
+    });
+}
+
 fn launch_settings_app_with_logging() {
     if let Err(error) = launch_settings_app() {
         tracing::warn!(?error, "Failed to launch settings app");
     }
 }
 
-struct MenuOwnerWindow(HWND);
+struct MenuOwnerWindow {
+    hwnd: HWND,
+    class_name: Vec<u16>,
+    hinstance: HINSTANCE,
+}
 
 impl Drop for MenuOwnerWindow {
     fn drop(&mut self) {
         unsafe {
-            let _ = DestroyWindow(self.0);
+            let _ = DestroyWindow(self.hwnd);
+            let _ = UnregisterClassW(PCWSTR(self.class_name.as_ptr()), self.hinstance);
         }
     }
 }
@@ -279,7 +293,7 @@ fn menu_owner_window() -> Result<HWND> {
             let owner = owner.borrow();
             owner
                 .as_ref()
-                .map(|window| unsafe { !IsWindow(window.0).as_bool() })
+                .map(|window| unsafe { !IsWindow(window.hwnd).as_bool() })
                 .unwrap_or(true)
         };
 
@@ -290,7 +304,7 @@ fn menu_owner_window() -> Result<HWND> {
         owner
             .borrow()
             .as_ref()
-            .map(|window| window.0)
+            .map(|window| window.hwnd)
             .context("Menu owner window is not available")
     })
 }
@@ -301,39 +315,62 @@ fn create_menu_owner_window() -> Result<MenuOwnerWindow> {
     let hinstance = HINSTANCE(hmodule.0);
 
     unsafe {
-        let window_class = WNDCLASSW {
-            lpfnWndProc: Some(menu_owner_window_proc),
-            hInstance: hinstance,
-            lpszClassName: MENU_OWNER_WINDOW_CLASS_NAME,
-            ..Default::default()
-        };
+        for _ in 0..32 {
+            let class_name = menu_owner_window_class_name(hmodule);
+            let window_class = WNDCLASSW {
+                lpfnWndProc: Some(menu_owner_window_proc),
+                hInstance: hinstance,
+                lpszClassName: PCWSTR(class_name.as_ptr()),
+                ..Default::default()
+            };
 
-        let atom = RegisterClassW(&window_class);
-        if atom == 0 {
-            let error = GetLastError();
-            if error != ERROR_CLASS_ALREADY_EXISTS {
+            let atom = RegisterClassW(&window_class);
+            if atom == 0 {
+                let error = GetLastError();
+                if error == ERROR_CLASS_ALREADY_EXISTS {
+                    continue;
+                }
+
                 anyhow::bail!("Failed to register menu owner window class: {:?}", error);
             }
+
+            let hwnd = CreateWindowExW(
+                WS_EX_TOOLWINDOW,
+                PCWSTR(class_name.as_ptr()),
+                w!(""),
+                WS_POPUP,
+                0,
+                0,
+                0,
+                0,
+                HWND::default(),
+                HMENU::default(),
+                hinstance,
+                None,
+            )
+            .context("Failed to create menu owner window")?;
+
+            return Ok(MenuOwnerWindow {
+                hwnd,
+                class_name,
+                hinstance,
+            });
         }
 
-        let hwnd = CreateWindowExW(
-            WS_EX_TOOLWINDOW,
-            MENU_OWNER_WINDOW_CLASS_NAME,
-            w!(""),
-            WS_POPUP,
-            0,
-            0,
-            0,
-            0,
-            HWND::default(),
-            HMENU::default(),
-            hinstance,
-            None,
-        )
-        .context("Failed to create menu owner window")?;
-
-        Ok(MenuOwnerWindow(hwnd))
+        anyhow::bail!("Failed to register unique menu owner window class")
     }
+}
+
+fn menu_owner_window_class_name(hmodule: windows::Win32::Foundation::HMODULE) -> Vec<u16> {
+    let sequence = MENU_OWNER_WINDOW_CLASS_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!(
+        "AzookeyLangBarMenuOwner-{}-{:p}-{}",
+        std::process::id(),
+        hmodule.0,
+        sequence
+    )
+    .as_str()
+    .to_wide_16()
 }
 
 fn launch_settings_app() -> Result<()> {
@@ -360,8 +397,10 @@ fn launch_settings_app() -> Result<()> {
 }
 
 fn shell_execute_open(settings_path: &Path, install_dir: &Path) -> Result<()> {
-    let settings_path = wide_null(&settings_path.to_string_lossy());
-    let install_dir = wide_null(&install_dir.to_string_lossy());
+    let settings_path = settings_path.to_string_lossy();
+    let settings_path = settings_path.as_ref().to_wide_16();
+    let install_dir = install_dir.to_string_lossy();
+    let install_dir = install_dir.as_ref().to_wide_16();
 
     let result = unsafe {
         ShellExecuteW(
@@ -379,10 +418,6 @@ fn shell_execute_open(settings_path: &Path, install_dir: &Path) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn wide_null(value: &str) -> Vec<u16> {
-    value.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -484,16 +519,23 @@ fn select_existing_settings_app_path(
     candidates: Vec<SettingsAppPath>,
     exists: impl Fn(&Path) -> bool,
 ) -> Result<SettingsAppPath> {
+    if let Some(index) = candidates
+        .iter()
+        .position(|candidate| exists(&candidate.path))
+    {
+        return Ok(candidates
+            .into_iter()
+            .nth(index)
+            .expect("selected candidate index should exist"));
+    }
+
     let candidate_list = candidates
         .iter()
         .map(|candidate| format!("{}={}", candidate.source, candidate.path.display()))
         .collect::<Vec<_>>()
         .join(", ");
 
-    candidates
-        .into_iter()
-        .find(|candidate| exists(&candidate.path))
-        .with_context(|| format!("Settings app not found in candidates: {candidate_list}"))
+    anyhow::bail!("Settings app not found in candidates: {candidate_list}")
 }
 
 fn resolve_settings_app_path_from_install_location(

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -336,9 +336,9 @@ fn create_menu_owner_window() -> Result<MenuOwnerWindow> {
 fn menu_owner_window_class_name(hmodule: windows::Win32::Foundation::HMODULE) -> Vec<u16> {
     let sequence = MENU_OWNER_WINDOW_CLASS_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     format!(
-        "AzookeyLangBarMenuOwner-{}-{:p}-{}",
+        "AzookeyLangBarMenuOwner-{}-{:#x}-{}",
         std::process::id(),
-        hmodule.0,
+        hmodule.0 as usize,
         sequence
     )
     .as_str()
@@ -510,6 +510,12 @@ fn select_existing_settings_app_path(
         }
 
         missing_candidates.push(candidate);
+    }
+
+    if missing_candidates.is_empty() {
+        anyhow::bail!(
+            "Settings app not found because no install metadata or LOCALAPPDATA fallback candidate is available"
+        );
     }
 
     let candidate_list = missing_candidates
@@ -717,5 +723,15 @@ mod tests {
         assert!(error
             .to_string()
             .contains("HKCU uninstall key=C:/Old/Azookey/frontend.exe"));
+    }
+
+    #[test]
+    fn select_existing_settings_app_path_reports_empty_candidates() {
+        let error = select_existing_settings_app_path(Vec::new(), |_| false)
+            .expect_err("empty candidates should fail");
+
+        assert!(error
+            .to_string()
+            .contains("no install metadata or LOCALAPPDATA fallback candidate is available"));
     }
 }

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -1,17 +1,17 @@
 use std::{
+    cell::RefCell,
     env,
     path::{Path, PathBuf},
-    process::Command,
 };
 
 use windows::{
     core::{w, IUnknown, Interface as _, BSTR, GUID, PCWSTR},
     Win32::{
         Foundation::{
-            BOOL, ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, ERROR_SUCCESS, E_INVALIDARG, HWND,
-            LPARAM, POINT, RECT, WPARAM,
+            GetLastError, BOOL, ERROR_CLASS_ALREADY_EXISTS, ERROR_FILE_NOT_FOUND,
+            ERROR_PATH_NOT_FOUND, ERROR_SUCCESS, E_INVALIDARG, HINSTANCE, HWND, LPARAM, LRESULT,
+            POINT, RECT, WPARAM,
         },
-        Graphics::Gdi::HBITMAP,
         System::{
             Ole::CONNECT_E_CANNOTCONNECT,
             Registry::{
@@ -20,17 +20,18 @@ use windows::{
             },
         },
         UI::{
+            Shell::ShellExecuteW,
             TextServices::{
                 ITfLangBarItemButton_Impl, ITfLangBarItemSink, ITfLangBarItem_Impl, ITfMenu,
                 ITfSource_Impl, TfLBIClick, GUID_LBI_INPUTMODE, TF_LANGBARITEMINFO,
                 TF_LBI_CLK_LEFT, TF_LBI_CLK_RIGHT, TF_LBI_STATUS_DISABLED, TF_LBI_STYLE_BTN_BUTTON,
-                TF_LBI_STYLE_BTN_MENU,
             },
             WindowsAndMessaging::{
-                AppendMenuW, CreatePopupMenu, DestroyMenu, GetAncestor, GetForegroundWindow,
-                LoadImageW, PostMessageW, SetForegroundWindow, TrackPopupMenu, WindowFromPoint,
-                GA_ROOT, HICON, HMENU, IMAGE_ICON, LR_DEFAULTCOLOR, MF_STRING, TPM_NONOTIFY,
-                TPM_RETURNCMD, TPM_RIGHTBUTTON, WM_NULL,
+                AppendMenuW, CreatePopupMenu, CreateWindowExW, DefWindowProcW, DestroyMenu,
+                DestroyWindow, IsWindow, LoadImageW, PostMessageW, RegisterClassW,
+                SetForegroundWindow, TrackPopupMenu, HICON, HMENU, IMAGE_ICON, LR_DEFAULTCOLOR,
+                MF_STRING, SW_SHOWNORMAL, TPM_NONOTIFY, TPM_RETURNCMD, TPM_RIGHTBUTTON, WM_NULL,
+                WNDCLASSW, WS_EX_TOOLWINDOW, WS_POPUP,
             },
         },
     },
@@ -51,7 +52,7 @@ use super::factory::TextServiceFactory_Impl;
 const INFO: TF_LANGBARITEMINFO = TF_LANGBARITEMINFO {
     clsidService: GUID_TEXT_SERVICE,
     guidItem: GUID_LBI_INPUTMODE,
-    dwStyle: TF_LBI_STYLE_BTN_BUTTON | TF_LBI_STYLE_BTN_MENU,
+    dwStyle: TF_LBI_STYLE_BTN_BUTTON,
     ulSort: 0,
     szDescription: [0; 32],
 };
@@ -59,10 +60,15 @@ const INFO: TF_LANGBARITEMINFO = TF_LANGBARITEMINFO {
 const SETTINGS_MENU_ID: usize = 1;
 const SETTINGS_APP_DIRNAME: &str = "Azookey";
 const SETTINGS_APP_FILENAME: &str = "frontend.exe";
+const MENU_OWNER_WINDOW_CLASS_NAME: PCWSTR = w!("AzookeyLangBarMenuOwner");
 const SETTINGS_APP_UNINSTALL_SUBKEY: PCWSTR =
     w!(r"Software\Microsoft\Windows\CurrentVersion\Uninstall\Azookey");
 const SETTINGS_APP_INSTALL_LOCATION_VALUE: PCWSTR = w!("InstallLocation");
 const SETTINGS_APP_MAIN_BINARY_NAME_VALUE: PCWSTR = w!("MainBinaryName");
+
+thread_local! {
+    static MENU_OWNER_WINDOW: RefCell<Option<MenuOwnerWindow>> = RefCell::new(None);
+}
 
 // you need to implement these three interfaces to create a language bar item
 // if not, you will get E_FAIL error in ITfLangBarItemMgr::AddItem
@@ -145,20 +151,12 @@ impl ITfLangBarItemButton_Impl for TextServiceFactory_Impl {
     }
 
     #[macros::anyhow]
-    fn InitMenu(&self, pmenu: Option<&ITfMenu>) -> Result<()> {
-        if let Some(menu) = pmenu {
-            add_settings_menu_item(menu)?;
-        }
-
+    fn InitMenu(&self, _pmenu: Option<&ITfMenu>) -> Result<()> {
         Ok(())
     }
 
     #[macros::anyhow]
-    fn OnMenuSelect(&self, w_id: u32) -> Result<()> {
-        if w_id == SETTINGS_MENU_ID as u32 {
-            launch_settings_app_with_logging();
-        }
-
+    fn OnMenuSelect(&self, _w_id: u32) -> Result<()> {
         Ok(())
     }
 
@@ -216,21 +214,14 @@ fn launch_settings_app_with_logging() {
     }
 }
 
-fn add_settings_menu_item(menu: &ITfMenu) -> Result<()> {
-    let text: Vec<u16> = "設定".encode_utf16().collect();
+struct MenuOwnerWindow(HWND);
 
-    unsafe {
-        menu.AddMenuItem(
-            SETTINGS_MENU_ID as u32,
-            0,
-            HBITMAP::default(),
-            HBITMAP::default(),
-            &text,
-            std::ptr::null_mut(),
-        )?;
+impl Drop for MenuOwnerWindow {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = DestroyWindow(self.0);
+        }
     }
-
-    Ok(())
 }
 
 fn show_settings_menu(pt: &POINT) -> Result<Option<u32>> {
@@ -248,10 +239,7 @@ fn show_settings_menu(pt: &POINT) -> Result<Option<u32>> {
         let menu = PopupMenu(CreatePopupMenu()?);
         AppendMenuW(menu.0, MF_STRING, SETTINGS_MENU_ID, w!("設定"))?;
 
-        let hwnd = resolve_menu_owner_window(*pt);
-        if hwnd.0.is_null() {
-            return Ok(None);
-        }
+        let hwnd = menu_owner_window()?;
 
         let _ = SetForegroundWindow(hwnd);
 
@@ -276,24 +264,81 @@ fn show_settings_menu(pt: &POINT) -> Result<Option<u32>> {
     }
 }
 
-fn resolve_menu_owner_window(pt: POINT) -> HWND {
-    unsafe {
-        let hwnd = WindowFromPoint(pt);
-        if !hwnd.0.is_null() {
-            let root = GetAncestor(hwnd, GA_ROOT);
-            if !root.0.is_null() {
-                return root;
-            }
+unsafe extern "system" fn menu_owner_window_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
+    unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) }
+}
 
-            return hwnd;
+fn menu_owner_window() -> Result<HWND> {
+    MENU_OWNER_WINDOW.with(|owner| {
+        let recreate = {
+            let owner = owner.borrow();
+            owner
+                .as_ref()
+                .map(|window| unsafe { !IsWindow(window.0).as_bool() })
+                .unwrap_or(true)
+        };
+
+        if recreate {
+            owner.borrow_mut().replace(create_menu_owner_window()?);
         }
 
-        GetForegroundWindow()
+        owner
+            .borrow()
+            .as_ref()
+            .map(|window| window.0)
+            .context("Menu owner window is not available")
+    })
+}
+
+fn create_menu_owner_window() -> Result<MenuOwnerWindow> {
+    let dll_module = DllModule::get()?;
+    let hmodule = dll_module.hinst.context("Dll instance not found")?;
+    let hinstance = HINSTANCE(hmodule.0);
+
+    unsafe {
+        let window_class = WNDCLASSW {
+            lpfnWndProc: Some(menu_owner_window_proc),
+            hInstance: hinstance,
+            lpszClassName: MENU_OWNER_WINDOW_CLASS_NAME,
+            ..Default::default()
+        };
+
+        let atom = RegisterClassW(&window_class);
+        if atom == 0 {
+            let error = GetLastError();
+            if error != ERROR_CLASS_ALREADY_EXISTS {
+                anyhow::bail!("Failed to register menu owner window class: {:?}", error);
+            }
+        }
+
+        let hwnd = CreateWindowExW(
+            WS_EX_TOOLWINDOW,
+            MENU_OWNER_WINDOW_CLASS_NAME,
+            w!(""),
+            WS_POPUP,
+            0,
+            0,
+            0,
+            0,
+            HWND::default(),
+            HMENU::default(),
+            hinstance,
+            None,
+        )
+        .context("Failed to create menu owner window")?;
+
+        Ok(MenuOwnerWindow(hwnd))
     }
 }
 
 fn launch_settings_app() -> Result<()> {
-    let settings_path = resolve_settings_app_path()?;
+    let settings_app = resolve_settings_app_path()?;
+    let settings_path = settings_app.path;
     let install_dir = settings_path
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
@@ -303,51 +348,111 @@ fn launch_settings_app() -> Result<()> {
         anyhow::bail!("Settings app not found: {}", settings_path.display());
     }
 
-    Command::new(&settings_path)
-        .current_dir(install_dir)
-        .spawn()
-        .with_context(|| format!("Failed to spawn {}", settings_path.display()))?;
+    shell_execute_open(&settings_path, install_dir).with_context(|| {
+        format!(
+            "Failed to launch settings app from {}: {}",
+            settings_app.source,
+            settings_path.display()
+        )
+    })?;
 
     Ok(())
 }
 
-fn resolve_settings_app_path() -> Result<PathBuf> {
-    if let Some(settings_path) = resolve_settings_app_path_from_registry()? {
-        return Ok(settings_path);
+fn shell_execute_open(settings_path: &Path, install_dir: &Path) -> Result<()> {
+    let settings_path = wide_null(&settings_path.to_string_lossy());
+    let install_dir = wide_null(&install_dir.to_string_lossy());
+
+    let result = unsafe {
+        ShellExecuteW(
+            HWND::default(),
+            w!("open"),
+            PCWSTR(settings_path.as_ptr()),
+            PCWSTR::null(),
+            PCWSTR(install_dir.as_ptr()),
+            SW_SHOWNORMAL,
+        )
+    };
+
+    if result.0 as isize <= 32 {
+        anyhow::bail!("ShellExecuteW failed: code={}", result.0 as isize);
     }
 
-    let local_app_data = env::var_os("LOCALAPPDATA").context("LOCALAPPDATA is not set")?;
-    let fallback_install_location = Path::new(&local_app_data).join(SETTINGS_APP_DIRNAME);
-    let fallback_install_location = fallback_install_location.to_string_lossy();
-
-    resolve_settings_app_path_from_install_location(
-        fallback_install_location.as_ref(),
-        SETTINGS_APP_FILENAME,
-    )
+    Ok(())
 }
 
-fn resolve_settings_app_path_from_registry() -> Result<Option<PathBuf>> {
-    for (hkey, flags) in [
-        (HKEY_CURRENT_USER, REG_ROUTINE_FLAGS(0)),
-        (HKEY_LOCAL_MACHINE, REG_ROUTINE_FLAGS(0)),
-        (HKEY_LOCAL_MACHINE, RRF_SUBKEY_WOW6464KEY),
+fn wide_null(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SettingsAppPath {
+    path: PathBuf,
+    source: &'static str,
+}
+
+fn resolve_settings_app_path() -> Result<SettingsAppPath> {
+    let mut candidates = resolve_settings_app_path_candidates()?;
+
+    if let Some(local_app_data) = env::var_os("LOCALAPPDATA") {
+        let fallback_install_location = Path::new(&local_app_data).join(SETTINGS_APP_DIRNAME);
+        let fallback_install_location = fallback_install_location.to_string_lossy();
+        candidates.push(SettingsAppPath {
+            path: resolve_settings_app_path_from_install_location(
+                fallback_install_location.as_ref(),
+                SETTINGS_APP_FILENAME,
+            )?,
+            source: "LOCALAPPDATA fallback",
+        });
+    } else {
+        tracing::debug!("LOCALAPPDATA is not set; skip settings app fallback path");
+    }
+
+    select_existing_settings_app_path(candidates, Path::is_file)
+}
+
+fn resolve_settings_app_path_candidates() -> Result<Vec<SettingsAppPath>> {
+    let mut candidates = Vec::new();
+
+    for (hkey, flags, source) in [
+        (
+            HKEY_CURRENT_USER,
+            REG_ROUTINE_FLAGS(0),
+            "HKCU uninstall key",
+        ),
+        (
+            HKEY_CURRENT_USER,
+            RRF_SUBKEY_WOW6464KEY,
+            "HKCU WOW64 uninstall key",
+        ),
+        (
+            HKEY_LOCAL_MACHINE,
+            REG_ROUTINE_FLAGS(0),
+            "HKLM uninstall key",
+        ),
+        (
+            HKEY_LOCAL_MACHINE,
+            RRF_SUBKEY_WOW6464KEY,
+            "HKLM WOW64 uninstall key",
+        ),
     ] {
-        match resolve_settings_app_path_from_uninstall_key(hkey, flags) {
-            Ok(Some(settings_path)) => return Ok(Some(settings_path)),
+        match resolve_settings_app_path_from_uninstall_key(hkey, flags, source) {
+            Ok(Some(settings_path)) => candidates.push(settings_path),
             Ok(None) => {}
             Err(error) => {
-                tracing::debug!(?error, "Skip invalid settings app install metadata");
+                tracing::debug!(?error, source, "Skip invalid settings app install metadata");
             }
         }
     }
 
-    Ok(None)
+    Ok(candidates)
 }
 
 fn resolve_settings_app_path_from_uninstall_key(
     hkey: HKEY,
     flags: REG_ROUTINE_FLAGS,
-) -> Result<Option<PathBuf>> {
+    source: &'static str,
+) -> Result<Option<SettingsAppPath>> {
     let install_location = match read_registry_string(
         hkey,
         SETTINGS_APP_UNINSTALL_SUBKEY,
@@ -369,7 +474,26 @@ fn resolve_settings_app_path_from_uninstall_key(
     let settings_path =
         resolve_settings_app_path_from_install_location(&install_location, &main_binary_name)?;
 
-    Ok(Some(settings_path))
+    Ok(Some(SettingsAppPath {
+        path: settings_path,
+        source,
+    }))
+}
+
+fn select_existing_settings_app_path(
+    candidates: Vec<SettingsAppPath>,
+    exists: impl Fn(&Path) -> bool,
+) -> Result<SettingsAppPath> {
+    let candidate_list = candidates
+        .iter()
+        .map(|candidate| format!("{}={}", candidate.source, candidate.path.display()))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    candidates
+        .into_iter()
+        .find(|candidate| exists(&candidate.path))
+        .with_context(|| format!("Settings app not found in candidates: {candidate_list}"))
 }
 
 fn resolve_settings_app_path_from_install_location(
@@ -489,7 +613,10 @@ impl ITfSource_Impl for TextServiceFactory_Impl {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_settings_app_path_from_install_location, trim_registry_string};
+    use super::{
+        resolve_settings_app_path_from_install_location, select_existing_settings_app_path,
+        trim_registry_string, SettingsAppPath,
+    };
     use std::path::PathBuf;
 
     #[test]
@@ -525,5 +652,45 @@ mod tests {
     #[test]
     fn trim_registry_string_removes_wrapping_quotes_only() {
         assert_eq!(trim_registry_string("  \"Azookey\"  "), "Azookey");
+    }
+
+    #[test]
+    fn select_existing_settings_app_path_skips_missing_registry_candidate() {
+        let candidates = vec![
+            SettingsAppPath {
+                path: PathBuf::from("C:/Old/Azookey/frontend.exe"),
+                source: "HKCU uninstall key",
+            },
+            SettingsAppPath {
+                path: PathBuf::from("C:/Users/test/AppData/Local/Azookey/frontend.exe"),
+                source: "LOCALAPPDATA fallback",
+            },
+        ];
+
+        let selected = select_existing_settings_app_path(candidates, |path| {
+            path == PathBuf::from("C:/Users/test/AppData/Local/Azookey/frontend.exe")
+        })
+        .expect("existing fallback should be selected");
+
+        assert_eq!(selected.source, "LOCALAPPDATA fallback");
+        assert_eq!(
+            selected.path,
+            PathBuf::from("C:/Users/test/AppData/Local/Azookey/frontend.exe")
+        );
+    }
+
+    #[test]
+    fn select_existing_settings_app_path_reports_all_missing_candidates() {
+        let candidates = vec![SettingsAppPath {
+            path: PathBuf::from("C:/Old/Azookey/frontend.exe"),
+            source: "HKCU uninstall key",
+        }];
+
+        let error = select_existing_settings_app_path(candidates, |_| false)
+            .expect_err("missing candidates should fail");
+
+        assert!(error
+            .to_string()
+            .contains("HKCU uninstall key=C:/Old/Azookey/frontend.exe"));
     }
 }

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -1,5 +1,4 @@
 use std::{
-    cell::RefCell,
     env,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU32, Ordering},
@@ -17,7 +16,7 @@ use windows::{
             Ole::CONNECT_E_CANNOTCONNECT,
             Registry::{
                 RegGetValueW, HKEY, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, REG_ROUTINE_FLAGS,
-                REG_VALUE_TYPE, RRF_RT_REG_SZ, RRF_SUBKEY_WOW6464KEY,
+                REG_VALUE_TYPE, RRF_RT_REG_SZ, RRF_SUBKEY_WOW6432KEY, RRF_SUBKEY_WOW6464KEY,
             },
         },
         UI::{
@@ -29,10 +28,10 @@ use windows::{
             },
             WindowsAndMessaging::{
                 AppendMenuW, CreatePopupMenu, CreateWindowExW, DefWindowProcW, DestroyMenu,
-                DestroyWindow, IsWindow, LoadImageW, PostMessageW, RegisterClassW,
-                SetForegroundWindow, TrackPopupMenu, UnregisterClassW, HICON, HMENU, IMAGE_ICON,
-                LR_DEFAULTCOLOR, MF_STRING, SW_SHOWNORMAL, TPM_NONOTIFY, TPM_RETURNCMD,
-                TPM_RIGHTBUTTON, WM_NULL, WNDCLASSW, WS_EX_TOOLWINDOW, WS_POPUP,
+                DestroyWindow, LoadImageW, PostMessageW, RegisterClassW, SetForegroundWindow,
+                TrackPopupMenu, UnregisterClassW, HICON, HMENU, IMAGE_ICON, LR_DEFAULTCOLOR,
+                MF_STRING, SW_SHOWNORMAL, TPM_NONOTIFY, TPM_RETURNCMD, TPM_RIGHTBUTTON, WM_NULL,
+                WNDCLASSW, WS_EX_TOOLWINDOW, WS_POPUP,
             },
         },
     },
@@ -68,10 +67,6 @@ const SETTINGS_APP_INSTALL_LOCATION_VALUE: PCWSTR = w!("InstallLocation");
 const SETTINGS_APP_MAIN_BINARY_NAME_VALUE: PCWSTR = w!("MainBinaryName");
 
 static MENU_OWNER_WINDOW_CLASS_SEQUENCE: AtomicU32 = AtomicU32::new(0);
-
-thread_local! {
-    static MENU_OWNER_WINDOW: RefCell<Option<MenuOwnerWindow>> = RefCell::new(None);
-}
 
 // you need to implement these three interfaces to create a language bar item
 // if not, you will get E_FAIL error in ITfLangBarItemMgr::AddItem
@@ -211,12 +206,6 @@ impl ITfLangBarItemButton_Impl for TextServiceFactory_Impl {
     }
 }
 
-pub(crate) fn cleanup_menu_owner_window() {
-    MENU_OWNER_WINDOW.with(|owner| {
-        owner.borrow_mut().take();
-    });
-}
-
 fn launch_settings_app_with_logging() {
     if let Err(error) = launch_settings_app() {
         tracing::warn!(?error, "Failed to launch settings app");
@@ -250,12 +239,11 @@ fn show_settings_menu(pt: &POINT) -> Result<Option<u32>> {
     }
 
     unsafe {
+        let owner = create_menu_owner_window()?;
         let menu = PopupMenu(CreatePopupMenu()?);
         AppendMenuW(menu.0, MF_STRING, SETTINGS_MENU_ID, w!("設定"))?;
 
-        let hwnd = menu_owner_window()?;
-
-        let _ = SetForegroundWindow(hwnd);
+        let _ = SetForegroundWindow(owner.hwnd);
 
         let selected = TrackPopupMenu(
             menu.0,
@@ -263,12 +251,12 @@ fn show_settings_menu(pt: &POINT) -> Result<Option<u32>> {
             pt.x,
             pt.y,
             0,
-            hwnd,
+            owner.hwnd,
             None,
         )
         .0 as u32;
 
-        let _ = PostMessageW(hwnd, WM_NULL, WPARAM(0), LPARAM(0));
+        let _ = PostMessageW(owner.hwnd, WM_NULL, WPARAM(0), LPARAM(0));
 
         if selected == 0 {
             Ok(None)
@@ -285,28 +273,6 @@ unsafe extern "system" fn menu_owner_window_proc(
     lparam: LPARAM,
 ) -> LRESULT {
     unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) }
-}
-
-fn menu_owner_window() -> Result<HWND> {
-    MENU_OWNER_WINDOW.with(|owner| {
-        let recreate = {
-            let owner = owner.borrow();
-            owner
-                .as_ref()
-                .map(|window| unsafe { !IsWindow(window.hwnd).as_bool() })
-                .unwrap_or(true)
-        };
-
-        if recreate {
-            owner.borrow_mut().replace(create_menu_owner_window()?);
-        }
-
-        owner
-            .borrow()
-            .as_ref()
-            .map(|window| window.hwnd)
-            .context("Menu owner window is not available")
-    })
 }
 
 fn create_menu_owner_window() -> Result<MenuOwnerWindow> {
@@ -334,7 +300,7 @@ fn create_menu_owner_window() -> Result<MenuOwnerWindow> {
                 anyhow::bail!("Failed to register menu owner window class: {:?}", error);
             }
 
-            let hwnd = CreateWindowExW(
+            let hwnd = match CreateWindowExW(
                 WS_EX_TOOLWINDOW,
                 PCWSTR(class_name.as_ptr()),
                 w!(""),
@@ -347,8 +313,13 @@ fn create_menu_owner_window() -> Result<MenuOwnerWindow> {
                 HMENU::default(),
                 hinstance,
                 None,
-            )
-            .context("Failed to create menu owner window")?;
+            ) {
+                Ok(hwnd) => hwnd,
+                Err(error) => {
+                    let _ = UnregisterClassW(PCWSTR(class_name.as_ptr()), hinstance);
+                    return Err(error).context("Failed to create menu owner window");
+                }
+            };
 
             return Ok(MenuOwnerWindow {
                 hwnd,
@@ -458,7 +429,12 @@ fn resolve_settings_app_path_candidates() -> Result<Vec<SettingsAppPath>> {
         (
             HKEY_CURRENT_USER,
             RRF_SUBKEY_WOW6464KEY,
-            "HKCU WOW64 uninstall key",
+            "HKCU 64-bit uninstall key",
+        ),
+        (
+            HKEY_CURRENT_USER,
+            RRF_SUBKEY_WOW6432KEY,
+            "HKCU 32-bit uninstall key",
         ),
         (
             HKEY_LOCAL_MACHINE,
@@ -468,7 +444,12 @@ fn resolve_settings_app_path_candidates() -> Result<Vec<SettingsAppPath>> {
         (
             HKEY_LOCAL_MACHINE,
             RRF_SUBKEY_WOW6464KEY,
-            "HKLM WOW64 uninstall key",
+            "HKLM 64-bit uninstall key",
+        ),
+        (
+            HKEY_LOCAL_MACHINE,
+            RRF_SUBKEY_WOW6432KEY,
+            "HKLM 32-bit uninstall key",
         ),
     ] {
         match resolve_settings_app_path_from_uninstall_key(hkey, flags, source) {

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -1,5 +1,6 @@
 use std::{
     env,
+    os::windows::ffi::OsStrExt as _,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU32, Ordering},
 };
@@ -368,10 +369,8 @@ fn launch_settings_app() -> Result<()> {
 }
 
 fn shell_execute_open(settings_path: &Path, install_dir: &Path) -> Result<()> {
-    let settings_path = settings_path.to_string_lossy();
-    let settings_path = settings_path.as_ref().to_wide_16();
-    let install_dir = install_dir.to_string_lossy();
-    let install_dir = install_dir.as_ref().to_wide_16();
+    let settings_path = path_to_wide(settings_path);
+    let install_dir = path_to_wide(install_dir);
 
     let result = unsafe {
         ShellExecuteW(
@@ -391,6 +390,13 @@ fn shell_execute_open(settings_path: &Path, install_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+fn path_to_wide(path: &Path) -> Vec<u16> {
+    path.as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SettingsAppPath {
     path: PathBuf,
@@ -401,13 +407,10 @@ fn resolve_settings_app_path() -> Result<SettingsAppPath> {
     let mut candidates = resolve_settings_app_path_candidates()?;
 
     if let Some(local_app_data) = env::var_os("LOCALAPPDATA") {
-        let fallback_install_location = Path::new(&local_app_data).join(SETTINGS_APP_DIRNAME);
-        let fallback_install_location = fallback_install_location.to_string_lossy();
         candidates.push(SettingsAppPath {
-            path: resolve_settings_app_path_from_install_location(
-                fallback_install_location.as_ref(),
-                SETTINGS_APP_FILENAME,
-            )?,
+            path: Path::new(&local_app_data)
+                .join(SETTINGS_APP_DIRNAME)
+                .join(SETTINGS_APP_FILENAME),
             source: "LOCALAPPDATA fallback",
         });
     } else {
@@ -500,17 +503,16 @@ fn select_existing_settings_app_path(
     candidates: Vec<SettingsAppPath>,
     exists: impl Fn(&Path) -> bool,
 ) -> Result<SettingsAppPath> {
-    if let Some(index) = candidates
-        .iter()
-        .position(|candidate| exists(&candidate.path))
-    {
-        return Ok(candidates
-            .into_iter()
-            .nth(index)
-            .expect("selected candidate index should exist"));
+    let mut missing_candidates = Vec::new();
+    for candidate in candidates {
+        if exists(&candidate.path) {
+            return Ok(candidate);
+        }
+
+        missing_candidates.push(candidate);
     }
 
-    let candidate_list = candidates
+    let candidate_list = missing_candidates
         .iter()
         .map(|candidate| format!("{}={}", candidate.source, candidate.path.display()))
         .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary
- 言語バーの右クリックメニュー経路を自前 popup に一本化し、TSF 標準メニューとの併存をやめました。
- 右クリックメニューの owner window を外部ウィンドウではなく、メニュー表示ごとに作成するプロセス内の非表示 window に変更しました。
- 設定画面起動を `ShellExecuteW` に変更し、古い registry path が残っていても実在する fallback の `frontend.exe` を選ぶようにしました。

## Background
- Issue: Closes #41
- 最新 Windows 11 で、言語バー右クリックメニューの `設定` を押しても設定画面が開かない報告がありました。
- こちらでは、1回目の右クリックではメニューが表示されず、2回連続でクリックすると表示されることがある問題も確認していました。
- 既存実装は `TF_LBI_STYLE_BTN_MENU` と自前 `TrackPopupMenu` の両方を持ち、さらに `TrackPopupMenu` の owner に `WindowFromPoint(pt)` 由来の外部 window を渡していたため、メニュー表示・選択イベントが不安定になる可能性がありました。

## Changes
- client / language bar
  - `TF_LBI_STYLE_BTN_MENU` を外し、右クリックは `OnClick(TF_LBI_CLK_RIGHT)` から自前 popup を表示する経路に統一
  - `WindowFromPoint` / `GetForegroundWindow` による owner 解決を廃止
  - メニュー表示ごとにプロセス内の非表示 owner window を作成し、`SetForegroundWindow` / `TrackPopupMenu` / `PostMessageW(WM_NULL)` に利用
  - owner window class は一意名で登録し、メニュー表示後または window 作成失敗時に unregister するように変更
- client / settings launch
  - `Command::spawn` から Windows GUI 起動向けの `ShellExecuteW("open", ...)` に変更
  - HKCU / HKCU 64-bit view / HKCU 32-bit view / HKLM / HKLM 64-bit view / HKLM 32-bit view / `%LOCALAPPDATA%\Azookey\frontend.exe` を候補化
  - registry 候補の exe が存在しない場合は次候補へ進み、全候補が存在しない場合は候補一覧を含めてログに出す
  - `ShellExecuteW` に渡す path は `OsStr::encode_wide` で UTF-16 化し、`LOCALAPPDATA` fallback は `PathBuf` で直接構築
- tests
  - 古い registry path をスキップして fallback を選ぶ unit test を追加
  - 全候補が存在しない場合に候補一覧を含む error になる unit test を追加

## Verification
- [x] Windows 実機確認
  - ユーザー確認済み
- [x] ローカル Windows VM build 成功
  - `.local/vm_build_master.sh fix/issue-41-langbar-settings-menu`
  - artifact: `.local/artifacts/azookey-setup-fix_issue-41-langbar-settings-menu-20260511-224010.exe`
- [x] ローカル Windows VM install 成功
  - `.local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-fix_issue-41-langbar-settings-menu-20260511-224010.exe`
  - install log: `.local/logs/win11-install-20260511-231619.log`
- [x] ローカル Windows VM test（関連テスト）
  - `ALLOW_DIRTY_WORKTREE=1 bash .local/vm_test_client_composition.sh fix/issue-41-langbar-settings-menu select_existing_settings_app_path skip`
  - latest log: `.local/logs/vm-client-test-20260512-073955.log`
- [x] 差分チェック
  - `git diff --check`
- [ ] GitHub Actions build 成功
  - run: 未実行

## Checklist
- [ ] CI run URL と結果を記載した
- [x] VM / 実機確認結果を記載した
- [x] 影響範囲を確認した