### PR TITLE
feat(composition): add clause state reducer

### DIFF
--- a/crates/client/src/engine/client_action.rs
+++ b/crates/client/src/engine/client_action.rs
@@ -18,6 +18,7 @@ pub enum ClientAction {
     SetTextWithType(SetTextType),
 
     MoveCursor(i32),
+    EnsureClauseNavigationReady,
     MoveClause(i32),
     AdjustBoundary(i32),
     SetSelection(SetSelectionType),

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -29,6 +29,12 @@ use windows::Win32::{
 
 use anyhow::{Context, Result};
 
+mod clause_state;
+pub(super) use clause_state::{
+    CandidateSelection, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut,
+    ClauseCommand, ClauseState, ClauseTransitionInput, MoveClauseProgressMarker,
+};
+
 #[derive(Default, Clone, PartialEq, Debug)]
 pub enum CompositionState {
     #[default]
@@ -98,70 +104,6 @@ pub struct FutureClauseSnapshot {
     candidates: Candidates,
 }
 
-#[derive(Debug, Clone)]
-struct CandidateSelection {
-    index: i32,
-    text: String,
-    sub_text: String,
-    hiragana: String,
-    corresponding_count: i32,
-}
-
-trait ClauseActionBackend {
-    fn move_cursor(&mut self, offset: i32) -> Result<Candidates>;
-    fn shrink_text(&mut self, offset: i32) -> Result<Candidates>;
-}
-
-impl ClauseActionBackend for IPCService {
-    fn move_cursor(&mut self, offset: i32) -> Result<Candidates> {
-        IPCService::move_cursor(self, offset)
-    }
-
-    fn shrink_text(&mut self, offset: i32) -> Result<Candidates> {
-        IPCService::shrink_text(self, offset)
-    }
-}
-
-struct ClauseActionStateMut<'a> {
-    preview: &'a mut String,
-    suffix: &'a mut String,
-    raw_input: &'a mut String,
-    raw_hiragana: &'a mut String,
-    fixed_prefix: &'a mut String,
-    corresponding_count: &'a mut i32,
-    selection_index: &'a mut i32,
-    candidates: &'a mut Candidates,
-    clause_snapshots: &'a mut Vec<ClauseSnapshot>,
-    future_clause_snapshots: &'a mut Vec<FutureClauseSnapshot>,
-    current_clause_is_split_derived: &'a mut bool,
-    current_clause_is_direct_split_remainder: &'a mut bool,
-    current_clause_has_split_left_neighbor: &'a mut bool,
-    current_clause_split_group_id: &'a mut Option<u64>,
-    next_split_group_id: &'a mut u64,
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-struct ClauseActionEffect {
-    applied: bool,
-    update_pos: bool,
-}
-
-impl ClauseActionEffect {
-    fn skipped() -> Self {
-        Self {
-            applied: false,
-            update_pos: false,
-        }
-    }
-
-    fn applied(update_pos: bool) -> Self {
-        Self {
-            applied: true,
-            update_pos,
-        }
-    }
-}
-
 impl ITfCompositionSink_Impl for TextServiceFactory_Impl {
     #[macros::anyhow]
     fn OnCompositionTerminated(
@@ -183,6 +125,7 @@ impl TextServiceFactory {
     const MOVE_CURSOR_CLEAR_CLAUSE_SNAPSHOTS: i32 = 125;
     const MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT: i32 = 126;
     const MOVE_CURSOR_POP_CLAUSE_SNAPSHOT: i32 = 127;
+    const MOVE_CLAUSE_TO_LAST: i32 = i32::MAX;
 
     #[inline]
     fn is_ctrl_pressed() -> bool {
@@ -238,11 +181,11 @@ impl TextServiceFactory {
     #[inline]
     fn normalize_direct_symbol_char(c: char) -> char {
         let halfwidth_ascii = Self::to_halfwidth_ascii_char(c);
-        if halfwidth_ascii.is_ascii_punctuation() {
+        if halfwidth_ascii.is_ascii_graphic() || halfwidth_ascii == ' ' {
             return halfwidth_ascii;
         }
 
-        if c.is_ascii_punctuation() {
+        if c.is_ascii_graphic() || c == ' ' {
             return c;
         }
 
@@ -605,6 +548,161 @@ impl TextServiceFactory {
                 .copied()
                 .unwrap_or(0),
         })
+    }
+
+    #[inline]
+    fn select_navigation_candidate_for_current_preview(
+        navigation_candidates: &Candidates,
+        current_preview: &str,
+        fixed_prefix: &str,
+        selection_index: i32,
+    ) -> Option<CandidateSelection> {
+        let target_clause_preview = current_preview
+            .strip_prefix(fixed_prefix)
+            .unwrap_or(current_preview);
+
+        if let Some(index) = (0..navigation_candidates.texts.len()).find(|index| {
+            let text = navigation_candidates
+                .texts
+                .get(*index)
+                .map(String::as_str)
+                .unwrap_or_default();
+            let sub_text = navigation_candidates
+                .sub_texts
+                .get(*index)
+                .map(String::as_str)
+                .unwrap_or_default();
+
+            target_clause_preview.strip_prefix(text) == Some(sub_text)
+        }) {
+            return Self::select_candidate(navigation_candidates, index as i32);
+        }
+
+        if let Some(index) = navigation_candidates
+            .texts
+            .iter()
+            .enumerate()
+            .filter(|(_, text)| !text.is_empty() && target_clause_preview.starts_with(*text))
+            .max_by_key(|(index, text)| {
+                (
+                    navigation_candidates
+                        .corresponding_count
+                        .get(*index)
+                        .copied()
+                        .unwrap_or(0),
+                    text.len(),
+                )
+            })
+            .map(|(index, _)| index)
+        {
+            return Self::select_candidate(navigation_candidates, index as i32);
+        }
+
+        Self::select_candidate(navigation_candidates, selection_index)
+    }
+
+    #[inline]
+    fn split_at_char_count(value: &str, char_count: i32) -> (String, String) {
+        let split_at = char_count.max(0) as usize;
+        let mut prefix = String::new();
+        let mut suffix = String::new();
+
+        for (index, ch) in value.chars().enumerate() {
+            if index < split_at {
+                prefix.push(ch);
+            } else {
+                suffix.push(ch);
+            }
+        }
+
+        (prefix, suffix)
+    }
+
+    #[inline]
+    fn display_override_set_type(
+        current_preview: &str,
+        fixed_prefix: &str,
+        raw_input: &str,
+        raw_hiragana: &str,
+    ) -> Option<SetTextType> {
+        let target_clause_preview = current_preview
+            .strip_prefix(fixed_prefix)
+            .unwrap_or(current_preview);
+        let set_types = [
+            SetTextType::Hiragana,
+            SetTextType::Katakana,
+            SetTextType::HalfKatakana,
+            SetTextType::FullLatin,
+            SetTextType::HalfLatin,
+        ];
+
+        for set_type in set_types {
+            if Self::converted_clause_preview_text(&set_type, raw_input, raw_hiragana)
+                != target_clause_preview
+            {
+                continue;
+            }
+
+            return Some(set_type);
+        }
+
+        None
+    }
+
+    #[inline]
+    fn display_override_split_for_selected_candidate(
+        set_type: &SetTextType,
+        raw_input: &str,
+        raw_hiragana: &str,
+        selected: &CandidateSelection,
+        suffix_raw_input: Option<&str>,
+        suffix_raw_hiragana: Option<&str>,
+    ) -> (String, String) {
+        let (clause_raw_input, suffix_raw_input) = suffix_raw_input
+            .and_then(|suffix| {
+                raw_input
+                    .strip_suffix(suffix)
+                    .map(|prefix| (prefix, suffix))
+            })
+            .map(|(prefix, suffix)| (prefix.to_string(), suffix.to_string()))
+            .unwrap_or_else(|| Self::split_at_char_count(raw_input, selected.corresponding_count));
+        let (clause_raw_hiragana, suffix_raw_hiragana) = suffix_raw_hiragana
+            .and_then(|suffix| {
+                raw_hiragana
+                    .strip_suffix(suffix)
+                    .map(|prefix| (prefix, suffix))
+            })
+            .map(|(prefix, suffix)| (prefix.to_string(), suffix.to_string()))
+            .unwrap_or_else(|| {
+                Self::split_at_char_count(raw_hiragana, selected.corresponding_count)
+            });
+
+        (
+            Self::converted_clause_preview_text(set_type, &clause_raw_input, &clause_raw_hiragana),
+            Self::converted_clause_preview_text(set_type, &suffix_raw_input, &suffix_raw_hiragana),
+        )
+    }
+
+    #[inline]
+    fn candidate_splits_raw_input(selected: &CandidateSelection, raw_input: &str) -> bool {
+        selected.corresponding_count > 0
+            && selected.corresponding_count < raw_input.chars().count() as i32
+            && !selected.sub_text.is_empty()
+    }
+
+    #[inline]
+    fn display_suffix_after_selected_clause(
+        preview: &str,
+        fixed_prefix: &str,
+        current_suffix: &str,
+        selected: &CandidateSelection,
+    ) -> String {
+        let current_preview = Self::current_clause_preview(preview, fixed_prefix);
+        current_preview
+            .strip_prefix(&selected.text)
+            .or_else(|| current_suffix.strip_prefix(&selected.text))
+            .map(str::to_string)
+            .unwrap_or_else(|| selected.sub_text.clone())
     }
 
     #[inline]
@@ -1022,6 +1120,7 @@ impl TextServiceFactory {
             ClientAction::CommitTextDirect(_) => "CommitTextDirect",
             ClientAction::RemoveText => "RemoveText",
             ClientAction::MoveCursor(_) => "MoveCursor",
+            ClientAction::EnsureClauseNavigationReady => "EnsureClauseNavigationReady",
             ClientAction::MoveClause(_) => "MoveClause",
             ClientAction::AdjustBoundary(_) => "AdjustBoundary",
             ClientAction::SetIMEMode(_) => "SetIMEMode",
@@ -1120,310 +1219,65 @@ impl TextServiceFactory {
         Self::clear_clause_snapshots(clause_snapshots, ipc_service)
     }
 
+    #[cfg(test)]
+    #[inline]
+    fn ensure_clause_navigation_ready<B: ClauseActionBackend>(
+        state: &mut ClauseActionStateMut<'_>,
+        backend: &mut B,
+    ) -> Result<ClauseActionEffect> {
+        Ok(ClauseState::transition_with_backend(
+            state,
+            ClauseCommand::StartClauseNavigation,
+            ClauseTransitionInput::default(),
+            backend,
+        )?
+        .effect)
+    }
+
+    #[cfg(test)]
     #[inline]
     fn apply_move_clause<B: ClauseActionBackend>(
         state: &mut ClauseActionStateMut<'_>,
         backend: &mut B,
         direction: i32,
     ) -> Result<ClauseActionEffect> {
-        if direction > 0 {
-            if state.suffix.is_empty() {
-                return Ok(ClauseActionEffect::skipped());
-            }
-
-            let mut snapshot = Self::build_clause_snapshot(
-                state.preview,
-                state.suffix,
-                state.raw_input,
-                state.raw_hiragana,
-                state.fixed_prefix,
-                *state.corresponding_count,
-                *state.selection_index,
-                *state.current_clause_is_split_derived,
-                *state.current_clause_has_split_left_neighbor,
-                state.candidates,
-            );
-            snapshot.split_group_id = *state.current_clause_split_group_id;
-            snapshot.is_direct_split_remainder = *state.current_clause_is_direct_split_remainder;
-            let current_clause_preview =
-                Self::current_clause_preview(state.preview, state.fixed_prefix);
-            let current_corresponding_count = *state.corresponding_count;
-
-            let _ = backend.move_cursor(Self::MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT)?;
-            state.clause_snapshots.push(snapshot);
-
-            *state.candidates = backend.shrink_text(current_corresponding_count)?;
-            *state.selection_index = 0;
-            *state.raw_input = state
-                .raw_input
-                .chars()
-                .skip(current_corresponding_count.max(0) as usize)
-                .collect();
-            state.fixed_prefix.push_str(&current_clause_preview);
-
-            if Self::future_snapshot_matches_server(state.future_clause_snapshots, state.candidates)
-            {
-                if let Some(restored_future) = state.future_clause_snapshots.pop() {
-                    Self::sync_backend_current_clause_to_future_snapshot(
-                        backend,
-                        state.candidates,
-                        &restored_future,
-                    )?;
-                    Self::restore_future_clause_snapshot(
-                        state.preview,
-                        state.suffix,
-                        state.raw_input,
-                        state.raw_hiragana,
-                        state.corresponding_count,
-                        state.selection_index,
-                        state.current_clause_is_split_derived,
-                        state.current_clause_is_direct_split_remainder,
-                        state.current_clause_has_split_left_neighbor,
-                        state.current_clause_split_group_id,
-                        state.candidates,
-                        state.fixed_prefix,
-                        &restored_future,
-                    );
-                    *state.suffix = Self::sync_current_clause_future_suffix(
-                        state.candidates,
-                        *state.selection_index,
-                        *state.corresponding_count,
-                        state.future_clause_snapshots,
-                    );
-                    return Ok(ClauseActionEffect::applied(true));
-                }
-            } else if let Some(selected) =
-                Self::select_candidate(state.candidates, *state.selection_index)
-            {
-                if !state.future_clause_snapshots.is_empty() {
-                    state.future_clause_snapshots.clear();
-                }
-                *state.current_clause_is_split_derived = false;
-                *state.current_clause_is_direct_split_remainder = false;
-                *state.current_clause_has_split_left_neighbor = false;
-                *state.current_clause_split_group_id = None;
-                *state.selection_index = selected.index;
-                *state.corresponding_count = selected.corresponding_count;
-                *state.preview =
-                    Self::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
-                *state.suffix = selected.sub_text.clone();
-                *state.raw_hiragana = selected.hiragana;
-                return Ok(ClauseActionEffect::applied(true));
-            } else {
-                let _ = backend.move_cursor(Self::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT)?;
-                if let Some(restored) = state.clause_snapshots.pop() {
-                    *state.preview = restored.preview;
-                    *state.suffix = restored.suffix;
-                    *state.raw_input = restored.raw_input;
-                    *state.raw_hiragana = restored.raw_hiragana;
-                    *state.fixed_prefix = restored.fixed_prefix;
-                    *state.corresponding_count = restored.corresponding_count;
-                    *state.selection_index = restored.selection_index;
-                    *state.current_clause_is_split_derived = restored.is_split_derived;
-                    *state.current_clause_is_direct_split_remainder =
-                        restored.is_direct_split_remainder;
-                    *state.current_clause_has_split_left_neighbor =
-                        restored.has_split_left_neighbor;
-                    *state.current_clause_split_group_id = restored.split_group_id;
-                    *state.candidates = restored.candidates;
-                    return Ok(ClauseActionEffect::applied(true));
-                }
-            }
-
-            Ok(ClauseActionEffect::skipped())
-        } else if direction < 0 {
-            if let Some(restored) = state.clause_snapshots.pop() {
-                Self::push_current_future_clause_snapshot(
-                    state.future_clause_snapshots,
-                    state.preview,
-                    state.suffix,
-                    state.raw_input,
-                    state.raw_hiragana,
-                    state.fixed_prefix,
-                    *state.corresponding_count,
-                    *state.selection_index,
-                    *state.current_clause_is_split_derived,
-                    *state.current_clause_is_direct_split_remainder,
-                    *state.current_clause_has_split_left_neighbor,
-                    *state.current_clause_split_group_id,
-                    state.candidates,
-                );
-                let _ = backend.move_cursor(Self::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT)?;
-
-                *state.preview = restored.preview;
-                *state.suffix = restored.suffix;
-                *state.raw_input = restored.raw_input;
-                *state.raw_hiragana = restored.raw_hiragana;
-                *state.fixed_prefix = restored.fixed_prefix;
-                *state.corresponding_count = restored.corresponding_count;
-                *state.selection_index = restored.selection_index;
-                *state.current_clause_is_split_derived = restored.is_split_derived;
-                *state.current_clause_is_direct_split_remainder =
-                    restored.is_direct_split_remainder;
-                *state.current_clause_has_split_left_neighbor = restored.has_split_left_neighbor;
-                *state.current_clause_split_group_id = restored.split_group_id;
-                *state.candidates = restored.candidates;
-                Ok(ClauseActionEffect::applied(true))
-            } else {
-                Ok(ClauseActionEffect::skipped())
-            }
-        } else {
-            Ok(ClauseActionEffect::skipped())
-        }
+        Ok(ClauseState::transition_with_backend(
+            state,
+            ClauseCommand::MoveBy(direction),
+            ClauseTransitionInput::default(),
+            backend,
+        )?
+        .effect)
     }
 
+    #[cfg(test)]
     #[inline]
     fn apply_adjust_boundary<B: ClauseActionBackend>(
         state: &mut ClauseActionStateMut<'_>,
         backend: &mut B,
         direction: i32,
     ) -> Result<ClauseActionEffect> {
-        if direction == 0 {
-            return Ok(ClauseActionEffect::skipped());
-        }
-
-        let fallback_candidates = state.candidates.clone();
-        if !state.suffix.is_empty() || !state.future_clause_snapshots.is_empty() {
-            Self::sync_backend_current_clause_to_target(
-                backend,
-                state.candidates,
-                state.raw_hiragana,
-                state.suffix,
-                *state.corresponding_count,
-            )?;
-        }
-
-        let _ = backend.move_cursor(direction)?;
-        let boundary_candidates = backend.move_cursor(0)?;
-        if boundary_candidates.texts.is_empty() {
-            if direction < 0 {
-                let _ = backend.move_cursor(1)?;
-                if let Some(selected) = Self::select_split_left_candidate(
-                    &fallback_candidates,
-                    *state.corresponding_count,
-                ) {
-                    *state.candidates = fallback_candidates;
-                    return Ok(Self::apply_boundary_candidate_selection(state, selected));
-                }
-            }
-            return Ok(ClauseActionEffect::skipped());
-        }
-
-        *state.candidates = boundary_candidates;
-        if let Some(selected) = Self::select_candidate(state.candidates, 0) {
-            Ok(Self::apply_boundary_candidate_selection(state, selected))
-        } else {
-            Ok(ClauseActionEffect::skipped())
-        }
+        Ok(ClauseState::transition_with_backend(
+            state,
+            ClauseCommand::AdjustBoundary(direction),
+            ClauseTransitionInput::default(),
+            backend,
+        )?
+        .effect)
     }
 
-    #[inline]
-    fn select_split_left_candidate(
-        candidates: &Candidates,
-        current_corresponding_count: i32,
-    ) -> Option<CandidateSelection> {
-        (0..candidates.texts.len())
-            .filter_map(|index| Self::select_candidate(candidates, index as i32))
-            .filter(|candidate| candidate.corresponding_count < current_corresponding_count)
-            .max_by_key(|candidate| candidate.corresponding_count)
-    }
-
-    #[inline]
-    fn apply_boundary_candidate_selection(
-        state: &mut ClauseActionStateMut<'_>,
-        selected: CandidateSelection,
-    ) -> ClauseActionEffect {
-        let split_group_id = (*state.current_clause_split_group_id)
-            .or_else(|| {
-                state.future_clause_snapshots.last().and_then(|snapshot| {
-                    snapshot
-                        .is_conservative
-                        .then_some(snapshot.split_group_id)
-                        .flatten()
-                        .or_else(|| {
-                            snapshot
-                                .has_split_left_neighbor
-                                .then_some(snapshot.split_group_id)
-                                .flatten()
-                        })
-                })
-            })
-            .unwrap_or_else(|| {
-                let group_id = *state.next_split_group_id;
-                *state.next_split_group_id += 1;
-                group_id
-            });
-        *state.selection_index = selected.index;
-        *state.corresponding_count = selected.corresponding_count;
-        *state.preview = Self::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
-        *state.raw_hiragana = selected.hiragana;
-        *state.suffix = selected.sub_text.clone();
-        *state.current_clause_split_group_id = Some(split_group_id);
-        let allow_bootstrap_without_existing_future = state.future_clause_snapshots.is_empty()
-            && !state.clause_snapshots.is_empty()
-            && Self::current_raw_suffix(state.raw_hiragana, *state.corresponding_count).is_empty();
-        Self::maybe_push_split_future_clause_snapshot(
-            state.future_clause_snapshots,
-            state.raw_input,
-            state.raw_hiragana,
-            *state.corresponding_count,
-            &selected.sub_text,
-            allow_bootstrap_without_existing_future,
-            Some(split_group_id),
-        );
-        let split_group_still_active = state
-            .future_clause_snapshots
-            .iter()
-            .any(|snapshot| snapshot.split_group_id == Some(split_group_id));
-        *state.current_clause_is_split_derived =
-            *state.current_clause_has_split_left_neighbor || split_group_still_active;
-        *state.current_clause_is_direct_split_remainder = false;
-        *state.current_clause_split_group_id = state
-            .current_clause_is_split_derived
-            .then_some(split_group_id);
-        *state.suffix = Self::sync_current_clause_future_suffix(
-            state.candidates,
-            *state.selection_index,
-            *state.corresponding_count,
-            state.future_clause_snapshots,
-        );
-        Self::sync_clause_snapshot_suffixes(state.clause_snapshots, state.preview, state.suffix);
-
-        ClauseActionEffect::applied(true)
-    }
-
+    #[cfg(test)]
     #[inline]
     fn apply_set_selection(
         state: &mut ClauseActionStateMut<'_>,
         selection: &SetSelectionType,
     ) -> ClauseActionEffect {
-        let desired_index = match selection {
-            SetSelectionType::Up => *state.selection_index - 1,
-            SetSelectionType::Down => *state.selection_index + 1,
-            SetSelectionType::Number(number) => *number,
-        };
-
-        if let Some(selected) = Self::select_candidate(state.candidates, desired_index) {
-            *state.selection_index = selected.index;
-            *state.corresponding_count = selected.corresponding_count;
-            *state.preview = Self::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
-            *state.raw_hiragana = selected.hiragana;
-            *state.suffix = Self::sync_current_clause_future_suffix(
-                state.candidates,
-                *state.selection_index,
-                *state.corresponding_count,
-                state.future_clause_snapshots,
-            );
-            Self::sync_clause_snapshot_suffixes(
-                state.clause_snapshots,
-                state.preview,
-                state.suffix,
-            );
-
-            ClauseActionEffect::applied(false)
-        } else {
-            ClauseActionEffect::skipped()
-        }
+        ClauseState::transition_without_backend(
+            state,
+            ClauseCommand::SetSelection(selection),
+            ClauseTransitionInput::default(),
+        )
+        .effect
     }
 
     #[inline]
@@ -1471,10 +1325,47 @@ impl TextServiceFactory {
 
     #[inline]
     fn current_raw_input_suffix(raw_input: &str, corresponding_count: i32) -> String {
-        raw_input
-            .chars()
-            .skip(corresponding_count.max(0) as usize)
-            .collect()
+        let chars = raw_input.chars().collect::<Vec<_>>();
+        let split_at = (corresponding_count.max(0) as usize).min(chars.len());
+        let adjusted_split_at = Self::adjust_single_n_raw_input_boundary(&chars, split_at);
+
+        chars[adjusted_split_at..].iter().collect()
+    }
+
+    #[inline]
+    fn adjust_single_n_raw_input_boundary(raw_input_chars: &[char], split_at: usize) -> usize {
+        if split_at == 0 || split_at >= raw_input_chars.len() {
+            return split_at;
+        }
+
+        let consumed = raw_input_chars[split_at - 1];
+        let next = raw_input_chars[split_at];
+        if !Self::is_ascii_romaji_consonant(consumed) || !Self::is_ascii_romaji_vowel(next) {
+            return split_at;
+        }
+
+        if raw_input_chars[..split_at - 1]
+            .iter()
+            .rev()
+            .find(|ch| ch.is_ascii_alphabetic())
+            .is_some_and(|ch| ch.eq_ignore_ascii_case(&'n'))
+        {
+            split_at - 1
+        } else {
+            split_at
+        }
+    }
+
+    #[inline]
+    fn is_ascii_romaji_vowel(ch: char) -> bool {
+        matches!(ch.to_ascii_lowercase(), 'a' | 'i' | 'u' | 'e' | 'o')
+    }
+
+    #[inline]
+    fn is_ascii_romaji_consonant(ch: char) -> bool {
+        ch.is_ascii_alphabetic()
+            && !Self::is_ascii_romaji_vowel(ch)
+            && !ch.eq_ignore_ascii_case(&'n')
     }
 
     #[inline]
@@ -1604,6 +1495,65 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn trusted_raw_hiragana_suffix(raw_hiragana: &str, raw_suffix_hint: &str) -> Option<String> {
+        (!raw_suffix_hint.is_empty() && raw_hiragana.ends_with(raw_suffix_hint))
+            .then(|| raw_suffix_hint.to_string())
+    }
+
+    #[inline]
+    fn common_suffix_char_count(left: &str, right: &str) -> usize {
+        left.chars()
+            .rev()
+            .zip(right.chars().rev())
+            .take_while(|(left, right)| left == right)
+            .count()
+    }
+
+    #[inline]
+    fn recover_single_n_raw_hiragana_suffix(
+        full_raw_hiragana: &str,
+        server_raw_hiragana: &str,
+    ) -> Option<String> {
+        if server_raw_hiragana.is_empty() {
+            return None;
+        }
+
+        if full_raw_hiragana.ends_with(server_raw_hiragana) {
+            return None;
+        }
+
+        let common_suffix_len =
+            Self::common_suffix_char_count(full_raw_hiragana, server_raw_hiragana);
+        let server_len = server_raw_hiragana.chars().count();
+        if common_suffix_len == 0 || common_suffix_len + 1 != server_len {
+            return None;
+        }
+
+        let full_len = full_raw_hiragana.chars().count();
+        if full_len <= common_suffix_len {
+            return None;
+        }
+
+        Some(
+            full_raw_hiragana
+                .chars()
+                .skip(full_len - common_suffix_len - 1)
+                .collect(),
+        )
+    }
+
+    #[inline]
+    fn has_recoverable_single_n_raw_hiragana_suffix(
+        server_raw_hiragana: &str,
+        snapshot_raw_hiragana: &str,
+    ) -> bool {
+        !server_raw_hiragana.is_empty()
+            && server_raw_hiragana.chars().count() == snapshot_raw_hiragana.chars().count()
+            && Self::common_suffix_char_count(server_raw_hiragana, snapshot_raw_hiragana) + 1
+                == snapshot_raw_hiragana.chars().count()
+    }
+
+    #[inline]
     fn maybe_push_split_future_clause_snapshot(
         future_clause_snapshots: &mut Vec<FutureClauseSnapshot>,
         raw_input: &str,
@@ -1613,37 +1563,30 @@ impl TextServiceFactory {
         allow_bootstrap_without_existing_future: bool,
         current_clause_split_group_id: Option<u64>,
     ) {
-        let raw_input_suffix: String = raw_input
-            .chars()
-            .skip(corresponding_count.max(0) as usize)
-            .collect();
+        let raw_input_suffix = Self::current_raw_input_suffix(raw_input, corresponding_count);
         let normalized_raw_suffix_hint = future_clause_snapshots
             .last()
             .and_then(|snapshot| Self::restore_raw_suffix_from_sub_text(raw_suffix_hint, snapshot))
             .unwrap_or_else(|| raw_suffix_hint.to_string());
-        let has_matching_future_hint = !normalized_raw_suffix_hint.is_empty()
-            && future_clause_snapshots.last().is_some_and(|snapshot| {
-                Self::future_snapshot_matches_raw_suffix(snapshot, &normalized_raw_suffix_hint)
-            });
-        let mut raw_suffix =
-            if has_matching_future_hint {
-                normalized_raw_suffix_hint
-            } else if let Some(snapshot) = future_clause_snapshots.iter().rev().find(|snapshot| {
-                !raw_input_suffix.is_empty() && raw_input_suffix == snapshot.raw_input
-            }) {
-                snapshot.raw_hiragana.clone()
-            } else {
-                let raw_suffix = Self::current_raw_suffix(raw_hiragana, corresponding_count);
-                if raw_suffix.is_empty()
-                    && future_clause_snapshots.is_empty()
-                    && allow_bootstrap_without_existing_future
-                    && !normalized_raw_suffix_hint.is_empty()
-                {
-                    normalized_raw_suffix_hint
-                } else {
-                    raw_suffix
-                }
-            };
+        let mut raw_suffix = if let Some(snapshot) = future_clause_snapshots
+            .iter()
+            .rev()
+            .find(|snapshot| !raw_input_suffix.is_empty() && raw_input_suffix == snapshot.raw_input)
+        {
+            snapshot.raw_hiragana.clone()
+        } else if let Some(raw_suffix) =
+            Self::trusted_raw_hiragana_suffix(raw_hiragana, &normalized_raw_suffix_hint)
+        {
+            raw_suffix
+        } else if let Some(snapshot) = future_clause_snapshots.last().filter(|snapshot| {
+            Self::future_snapshot_matches_raw_suffix(snapshot, &normalized_raw_suffix_hint)
+        }) {
+            snapshot.raw_hiragana.clone()
+        } else if !future_clause_snapshots.is_empty() && !allow_bootstrap_without_existing_future {
+            Self::current_raw_suffix(raw_hiragana, corresponding_count)
+        } else {
+            String::new()
+        };
         if raw_suffix.is_empty() {
             return;
         }
@@ -1904,10 +1847,14 @@ impl TextServiceFactory {
             *state.current_clause_has_split_left_neighbor;
         let mut temp_current_clause_split_group_id = *state.current_clause_split_group_id;
         let mut temp_next_split_group_id = *state.next_split_group_id;
+        let initial_suffix = state.suffix.clone();
+        let initial_raw_input_suffix =
+            Self::current_raw_input_suffix(state.raw_input, *state.corresponding_count);
+        let initial_raw_hiragana = state.raw_hiragana.clone();
         let mut collected = Vec::new();
 
         loop {
-            let effect = {
+            let (effect, made_progress) = {
                 let mut temp_state = ClauseActionStateMut {
                     preview: &mut temp_preview,
                     suffix: &mut temp_suffix,
@@ -1927,9 +1874,18 @@ impl TextServiceFactory {
                     current_clause_split_group_id: &mut temp_current_clause_split_group_id,
                     next_split_group_id: &mut temp_next_split_group_id,
                 };
-                Self::apply_move_clause(&mut temp_state, backend, 1)?
+                let before = MoveClauseProgressMarker::from_state(&temp_state);
+                let effect = ClauseState::transition_with_backend(
+                    &mut temp_state,
+                    ClauseCommand::MoveRight,
+                    ClauseTransitionInput::default(),
+                    backend,
+                )?
+                .effect;
+                let after = MoveClauseProgressMarker::from_state(&temp_state);
+                (effect, before != after)
             };
-            if !effect.applied {
+            if !effect.applied || !made_progress {
                 break;
             }
 
@@ -1948,6 +1904,29 @@ impl TextServiceFactory {
                 snapshot.is_direct_split_remainder = true;
                 snapshot.has_split_left_neighbor = true;
                 snapshot.split_group_id = *state.current_clause_split_group_id;
+                if temp_suffix.is_empty()
+                    && !initial_suffix.is_empty()
+                    && !initial_raw_input_suffix.is_empty()
+                    && temp_raw_input == initial_raw_input_suffix
+                {
+                    if let Some(raw_hiragana_suffix) = Self::recover_single_n_raw_hiragana_suffix(
+                        &initial_raw_hiragana,
+                        &snapshot.raw_hiragana,
+                    ) {
+                        let mut repaired_snapshot = Self::build_conservative_future_clause_snapshot(
+                            &initial_suffix,
+                            "",
+                            &initial_raw_input_suffix,
+                            &raw_hiragana_suffix,
+                            initial_raw_input_suffix.chars().count() as i32,
+                        );
+                        repaired_snapshot.is_split_derived = true;
+                        repaired_snapshot.is_direct_split_remainder = true;
+                        repaired_snapshot.has_split_left_neighbor = true;
+                        repaired_snapshot.split_group_id = *state.current_clause_split_group_id;
+                        snapshot = repaired_snapshot;
+                    }
+                }
             } else {
                 snapshot.is_split_derived = temp_current_clause_is_split_derived;
                 snapshot.is_direct_split_remainder = temp_current_clause_is_direct_split_remainder;
@@ -2060,8 +2039,15 @@ impl TextServiceFactory {
             .last()
             .map(|snapshot| {
                 server_candidates.hiragana == snapshot.raw_hiragana
+                    || server_candidates
+                        .hiragana
+                        .starts_with(&snapshot.raw_hiragana)
                     || server_candidates.hiragana.ends_with(&snapshot.raw_hiragana)
                     || snapshot.raw_hiragana.ends_with(&server_candidates.hiragana)
+                    || Self::has_recoverable_single_n_raw_hiragana_suffix(
+                        &server_candidates.hiragana,
+                        &snapshot.raw_hiragana,
+                    )
             })
             .unwrap_or(false)
     }
@@ -2195,6 +2181,15 @@ impl TextServiceFactory {
                 CompositionState::Composing,
                 vec![ClientAction::ShrinkText("".to_string())],
             )
+        }
+    }
+
+    #[inline]
+    fn commit_enter_actions(composition: &Composition) -> (CompositionState, Vec<ClientAction>) {
+        if ClauseState::is_active_for_composition(composition) {
+            (CompositionState::None, vec![ClientAction::EndComposition])
+        } else {
+            Self::commit_current_clause_actions(composition)
         }
     }
 
@@ -2344,6 +2339,48 @@ impl TextServiceFactory {
         }
         actions.push(ClientAction::SetSelection(SetSelectionType::Down));
         actions
+    }
+
+    #[inline]
+    fn clause_navigation_actions(composition: &Composition, direction: i32) -> Vec<ClientAction> {
+        if ClauseState::is_active_for_composition(composition) || !composition.suffix.is_empty() {
+            return vec![
+                ClientAction::EnsureClauseNavigationReady,
+                ClientAction::MoveClause(direction),
+            ];
+        }
+
+        if direction < 0 {
+            vec![
+                ClientAction::EnsureClauseNavigationReady,
+                ClientAction::MoveClause(Self::MOVE_CLAUSE_TO_LAST),
+            ]
+        } else {
+            vec![ClientAction::EnsureClauseNavigationReady]
+        }
+    }
+
+    #[inline]
+    fn should_defer_clause_navigation_ready_sync(actions: &[ClientAction], index: usize) -> bool {
+        matches!(
+            (actions.get(index), actions.get(index + 1)),
+            (
+                Some(ClientAction::EnsureClauseNavigationReady),
+                Some(ClientAction::MoveClause(direction)),
+            ) if *direction == Self::MOVE_CLAUSE_TO_LAST
+        )
+    }
+
+    #[inline]
+    fn deferred_clause_navigation_ready_sync_update_pos(
+        deferred_update_pos: Option<bool>,
+        move_effect: ClauseActionEffect,
+    ) -> Option<bool> {
+        if move_effect.applied {
+            None
+        } else {
+            deferred_update_pos
+        }
     }
 
     #[inline]
@@ -2519,7 +2556,8 @@ impl TextServiceFactory {
                         Some((CompositionState::Composing, vec![ClientAction::RemoveText]))
                     }
                 }
-                UserAction::Enter | UserAction::CommitAndNextClause => {
+                UserAction::Enter => Some(Self::commit_enter_actions(composition)),
+                UserAction::CommitAndNextClause => {
                     Some(Self::commit_current_clause_actions(composition))
                 }
                 UserAction::CommitFirstClause => {
@@ -2536,11 +2574,11 @@ impl TextServiceFactory {
                 UserAction::Navigation(direction) => match direction {
                     Navigation::Right => Some((
                         CompositionState::Composing,
-                        vec![ClientAction::MoveClause(1)],
+                        Self::clause_navigation_actions(composition, 1),
                     )),
                     Navigation::Left => Some((
                         CompositionState::Composing,
-                        vec![ClientAction::MoveClause(-1)],
+                        Self::clause_navigation_actions(composition, -1),
                     )),
                     Navigation::Up => Some((
                         CompositionState::Previewing,
@@ -2669,7 +2707,8 @@ impl TextServiceFactory {
                         Some((CompositionState::Composing, vec![ClientAction::RemoveText]))
                     }
                 }
-                UserAction::Enter | UserAction::CommitAndNextClause => {
+                UserAction::Enter => Some(Self::commit_enter_actions(composition)),
+                UserAction::CommitAndNextClause => {
                     Some(Self::commit_current_clause_actions(composition))
                 }
                 UserAction::CommitFirstClause => {
@@ -2686,11 +2725,11 @@ impl TextServiceFactory {
                 UserAction::Navigation(direction) => match direction {
                     Navigation::Right => Some((
                         CompositionState::Composing,
-                        vec![ClientAction::MoveClause(1)],
+                        Self::clause_navigation_actions(composition, 1),
                     )),
                     Navigation::Left => Some((
                         CompositionState::Composing,
-                        vec![ClientAction::MoveClause(-1)],
+                        Self::clause_navigation_actions(composition, -1),
                     )),
                     Navigation::Up => Some((
                         CompositionState::Previewing,
@@ -3060,10 +3099,11 @@ impl TextServiceFactory {
             .clone()
             .context("ipc_service is None")?;
         let mut transition = transition;
+        let mut deferred_clause_navigation_ready_sync_update_pos = None;
 
         self.update_context(&preview)?;
 
-        for action in actions {
+        for (action_index, action) in actions.iter().enumerate() {
             match action {
                 ClientAction::StartComposition => {
                     self.start_composition()?;
@@ -3273,6 +3313,112 @@ impl TextServiceFactory {
                         self.update_pos()?;
                     }
                 }
+                ClientAction::EnsureClauseNavigationReady => {
+                    Self::log_clause_action_state(
+                        "before",
+                        action,
+                        &preview,
+                        &suffix,
+                        &raw_input,
+                        &raw_hiragana,
+                        &fixed_prefix,
+                        corresponding_count,
+                        selection_index,
+                        &candidates,
+                        &clause_snapshots,
+                        &future_clause_snapshots,
+                    );
+                    let effect = {
+                        let mut state = ClauseState::from_composition_parts(
+                            &mut preview,
+                            &mut suffix,
+                            &mut raw_input,
+                            &mut raw_hiragana,
+                            &mut fixed_prefix,
+                            &mut corresponding_count,
+                            &mut selection_index,
+                            &mut candidates,
+                            &mut clause_snapshots,
+                            &mut future_clause_snapshots,
+                            &mut current_clause_is_split_derived,
+                            &mut current_clause_is_direct_split_remainder,
+                            &mut current_clause_has_split_left_neighbor,
+                            &mut current_clause_split_group_id,
+                            &mut next_split_group_id,
+                        );
+                        let transition = ClauseState::transition_with_backend(
+                            &mut state,
+                            ClauseCommand::StartClauseNavigation,
+                            ClauseTransitionInput::default(),
+                            &mut ipc_service,
+                        )?;
+                        let effect = transition.effect;
+                        ClauseState::write_back(state);
+                        effect
+                    };
+
+                    if effect.applied {
+                        let defer_ui_sync =
+                            Self::should_defer_clause_navigation_ready_sync(actions, action_index);
+                        if defer_ui_sync {
+                            deferred_clause_navigation_ready_sync_update_pos =
+                                Some(effect.update_pos);
+                            Self::log_clause_action_state(
+                                "defer",
+                                action,
+                                &preview,
+                                &suffix,
+                                &raw_input,
+                                &raw_hiragana,
+                                &fixed_prefix,
+                                corresponding_count,
+                                selection_index,
+                                &candidates,
+                                &clause_snapshots,
+                                &future_clause_snapshots,
+                            );
+                            continue;
+                        }
+
+                        self.sync_clause_action_ui(
+                            &preview,
+                            &suffix,
+                            &candidates,
+                            selection_index,
+                            &mut ipc_service,
+                            effect.update_pos,
+                        )?;
+                        Self::log_clause_action_state(
+                            "after",
+                            action,
+                            &preview,
+                            &suffix,
+                            &raw_input,
+                            &raw_hiragana,
+                            &fixed_prefix,
+                            corresponding_count,
+                            selection_index,
+                            &candidates,
+                            &clause_snapshots,
+                            &future_clause_snapshots,
+                        );
+                    } else {
+                        Self::log_clause_action_state(
+                            "skip",
+                            action,
+                            &preview,
+                            &suffix,
+                            &raw_input,
+                            &raw_hiragana,
+                            &fixed_prefix,
+                            corresponding_count,
+                            selection_index,
+                            &candidates,
+                            &clause_snapshots,
+                            &future_clause_snapshots,
+                        );
+                    }
+                }
                 ClientAction::MoveClause(direction) => {
                     Self::log_clause_action_state(
                         "before",
@@ -3289,28 +3435,39 @@ impl TextServiceFactory {
                         &future_clause_snapshots,
                     );
                     let effect = {
-                        let mut state = ClauseActionStateMut {
-                            preview: &mut preview,
-                            suffix: &mut suffix,
-                            raw_input: &mut raw_input,
-                            raw_hiragana: &mut raw_hiragana,
-                            fixed_prefix: &mut fixed_prefix,
-                            corresponding_count: &mut corresponding_count,
-                            selection_index: &mut selection_index,
-                            candidates: &mut candidates,
-                            clause_snapshots: &mut clause_snapshots,
-                            future_clause_snapshots: &mut future_clause_snapshots,
-                            current_clause_is_split_derived: &mut current_clause_is_split_derived,
-                            current_clause_is_direct_split_remainder:
-                                &mut current_clause_is_direct_split_remainder,
-                            current_clause_has_split_left_neighbor:
-                                &mut current_clause_has_split_left_neighbor,
-                            current_clause_split_group_id: &mut current_clause_split_group_id,
-                            next_split_group_id: &mut next_split_group_id,
-                        };
-                        Self::apply_move_clause(&mut state, &mut ipc_service, *direction)?
+                        let mut state = ClauseState::from_composition_parts(
+                            &mut preview,
+                            &mut suffix,
+                            &mut raw_input,
+                            &mut raw_hiragana,
+                            &mut fixed_prefix,
+                            &mut corresponding_count,
+                            &mut selection_index,
+                            &mut candidates,
+                            &mut clause_snapshots,
+                            &mut future_clause_snapshots,
+                            &mut current_clause_is_split_derived,
+                            &mut current_clause_is_direct_split_remainder,
+                            &mut current_clause_has_split_left_neighbor,
+                            &mut current_clause_split_group_id,
+                            &mut next_split_group_id,
+                        );
+                        let transition = ClauseState::transition_with_backend(
+                            &mut state,
+                            ClauseCommand::MoveBy(*direction),
+                            ClauseTransitionInput::default(),
+                            &mut ipc_service,
+                        )?;
+                        let effect = transition.effect;
+                        ClauseState::write_back(state);
+                        effect
                     };
 
+                    let deferred_sync_update_pos =
+                        Self::deferred_clause_navigation_ready_sync_update_pos(
+                            deferred_clause_navigation_ready_sync_update_pos.take(),
+                            effect,
+                        );
                     if effect.applied {
                         self.sync_clause_action_ui(
                             &preview,
@@ -3322,6 +3479,29 @@ impl TextServiceFactory {
                         )?;
                         Self::log_clause_action_state(
                             "after",
+                            action,
+                            &preview,
+                            &suffix,
+                            &raw_input,
+                            &raw_hiragana,
+                            &fixed_prefix,
+                            corresponding_count,
+                            selection_index,
+                            &candidates,
+                            &clause_snapshots,
+                            &future_clause_snapshots,
+                        );
+                    } else if let Some(update_pos) = deferred_sync_update_pos {
+                        self.sync_clause_action_ui(
+                            &preview,
+                            &suffix,
+                            &candidates,
+                            selection_index,
+                            &mut ipc_service,
+                            update_pos,
+                        )?;
+                        Self::log_clause_action_state(
+                            "after-deferred",
                             action,
                             &preview,
                             &suffix,
@@ -3367,26 +3547,32 @@ impl TextServiceFactory {
                         &future_clause_snapshots,
                     );
                     let effect = {
-                        let mut state = ClauseActionStateMut {
-                            preview: &mut preview,
-                            suffix: &mut suffix,
-                            raw_input: &mut raw_input,
-                            raw_hiragana: &mut raw_hiragana,
-                            fixed_prefix: &mut fixed_prefix,
-                            corresponding_count: &mut corresponding_count,
-                            selection_index: &mut selection_index,
-                            candidates: &mut candidates,
-                            clause_snapshots: &mut clause_snapshots,
-                            future_clause_snapshots: &mut future_clause_snapshots,
-                            current_clause_is_split_derived: &mut current_clause_is_split_derived,
-                            current_clause_is_direct_split_remainder:
-                                &mut current_clause_is_direct_split_remainder,
-                            current_clause_has_split_left_neighbor:
-                                &mut current_clause_has_split_left_neighbor,
-                            current_clause_split_group_id: &mut current_clause_split_group_id,
-                            next_split_group_id: &mut next_split_group_id,
-                        };
-                        Self::apply_adjust_boundary(&mut state, &mut ipc_service, *direction)?
+                        let mut state = ClauseState::from_composition_parts(
+                            &mut preview,
+                            &mut suffix,
+                            &mut raw_input,
+                            &mut raw_hiragana,
+                            &mut fixed_prefix,
+                            &mut corresponding_count,
+                            &mut selection_index,
+                            &mut candidates,
+                            &mut clause_snapshots,
+                            &mut future_clause_snapshots,
+                            &mut current_clause_is_split_derived,
+                            &mut current_clause_is_direct_split_remainder,
+                            &mut current_clause_has_split_left_neighbor,
+                            &mut current_clause_split_group_id,
+                            &mut next_split_group_id,
+                        );
+                        let transition = ClauseState::transition_with_backend(
+                            &mut state,
+                            ClauseCommand::AdjustBoundary(*direction),
+                            ClauseTransitionInput::default(),
+                            &mut ipc_service,
+                        )?;
+                        let effect = transition.effect;
+                        ClauseState::write_back(state);
+                        effect
                     };
 
                     if effect.applied {
@@ -3483,26 +3669,31 @@ impl TextServiceFactory {
                         &future_clause_snapshots,
                     );
                     let effect = {
-                        let mut state = ClauseActionStateMut {
-                            preview: &mut preview,
-                            suffix: &mut suffix,
-                            raw_input: &mut raw_input,
-                            raw_hiragana: &mut raw_hiragana,
-                            fixed_prefix: &mut fixed_prefix,
-                            corresponding_count: &mut corresponding_count,
-                            selection_index: &mut selection_index,
-                            candidates: &mut candidates,
-                            clause_snapshots: &mut clause_snapshots,
-                            future_clause_snapshots: &mut future_clause_snapshots,
-                            current_clause_is_split_derived: &mut current_clause_is_split_derived,
-                            current_clause_is_direct_split_remainder:
-                                &mut current_clause_is_direct_split_remainder,
-                            current_clause_has_split_left_neighbor:
-                                &mut current_clause_has_split_left_neighbor,
-                            current_clause_split_group_id: &mut current_clause_split_group_id,
-                            next_split_group_id: &mut next_split_group_id,
-                        };
-                        Self::apply_set_selection(&mut state, selection)
+                        let mut state = ClauseState::from_composition_parts(
+                            &mut preview,
+                            &mut suffix,
+                            &mut raw_input,
+                            &mut raw_hiragana,
+                            &mut fixed_prefix,
+                            &mut corresponding_count,
+                            &mut selection_index,
+                            &mut candidates,
+                            &mut clause_snapshots,
+                            &mut future_clause_snapshots,
+                            &mut current_clause_is_split_derived,
+                            &mut current_clause_is_direct_split_remainder,
+                            &mut current_clause_has_split_left_neighbor,
+                            &mut current_clause_split_group_id,
+                            &mut next_split_group_id,
+                        );
+                        let transition = ClauseState::transition_without_backend(
+                            &mut state,
+                            ClauseCommand::SetSelection(selection),
+                            ClauseTransitionInput::default(),
+                        );
+                        let effect = transition.effect;
+                        ClauseState::write_back(state);
+                        effect
                     };
 
                     if effect.applied {
@@ -3556,10 +3747,8 @@ impl TextServiceFactory {
                     current_clause_is_direct_split_remainder = false;
                     current_clause_has_split_left_neighbor = false;
                     current_clause_split_group_id = None;
-                    let shrunk_raw_input: String = raw_input
-                        .chars()
-                        .skip(corresponding_count.max(0) as usize)
-                        .collect();
+                    let shrunk_raw_input =
+                        Self::current_raw_input_suffix(&raw_input, corresponding_count);
                     let resolved_symbol_text = match mode {
                         InputMode::Kana => {
                             Self::resolve_symbol_input_text(&shrunk_raw_input, text, &app_config)
@@ -3605,10 +3794,8 @@ impl TextServiceFactory {
                     current_clause_is_direct_split_remainder = false;
                     current_clause_has_split_left_neighbor = false;
                     current_clause_split_group_id = None;
-                    let mut updated_raw_input: String = raw_input
-                        .chars()
-                        .skip(corresponding_count.max(0) as usize)
-                        .collect();
+                    let mut updated_raw_input =
+                        Self::current_raw_input_suffix(&raw_input, corresponding_count);
                     updated_raw_input.push_str(text);
 
                     let shrunk_candidates = ipc_service.shrink_text(corresponding_count)?;
@@ -3644,10 +3831,8 @@ impl TextServiceFactory {
                     current_clause_is_direct_split_remainder = false;
                     current_clause_has_split_left_neighbor = false;
                     current_clause_split_group_id = None;
-                    let mut updated_raw_input: String = raw_input
-                        .chars()
-                        .skip(corresponding_count.max(0) as usize)
-                        .collect();
+                    let mut updated_raw_input =
+                        Self::current_raw_input_suffix(&raw_input, corresponding_count);
                     updated_raw_input.push_str(text);
 
                     let shrunk_candidates = ipc_service.shrink_text(corresponding_count)?;

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1272,12 +1272,8 @@ impl TextServiceFactory {
         state: &mut ClauseActionStateMut<'_>,
         selection: &SetSelectionType,
     ) -> ClauseActionEffect {
-        ClauseState::transition_without_backend(
-            state,
-            ClauseCommand::SetSelection(selection),
-            ClauseTransitionInput::default(),
-        )
-        .effect
+        ClauseState::transition_without_backend(state, ClauseCommand::SetSelection(selection))
+            .effect
     }
 
     #[inline]
@@ -1325,32 +1321,48 @@ impl TextServiceFactory {
 
     #[inline]
     fn current_raw_input_suffix(raw_input: &str, corresponding_count: i32) -> String {
-        let chars = raw_input.chars().collect::<Vec<_>>();
-        let split_at = (corresponding_count.max(0) as usize).min(chars.len());
-        let adjusted_split_at = Self::adjust_single_n_raw_input_boundary(&chars, split_at);
+        let split_at = Self::byte_index_after_chars(raw_input, corresponding_count.max(0) as usize);
+        let adjusted_split_at = Self::adjust_single_n_raw_input_boundary(raw_input, split_at);
 
-        chars[adjusted_split_at..].iter().collect()
+        raw_input[adjusted_split_at..].to_string()
     }
 
     #[inline]
-    fn adjust_single_n_raw_input_boundary(raw_input_chars: &[char], split_at: usize) -> usize {
-        if split_at == 0 || split_at >= raw_input_chars.len() {
+    fn byte_index_after_chars(text: &str, char_count: usize) -> usize {
+        if char_count == 0 {
+            return 0;
+        }
+
+        text.char_indices()
+            .nth(char_count)
+            .map(|(byte_index, _)| byte_index)
+            .unwrap_or(text.len())
+    }
+
+    #[inline]
+    fn adjust_single_n_raw_input_boundary(raw_input: &str, split_at: usize) -> usize {
+        if split_at == 0 || split_at >= raw_input.len() || !raw_input.is_char_boundary(split_at) {
             return split_at;
         }
 
-        let consumed = raw_input_chars[split_at - 1];
-        let next = raw_input_chars[split_at];
+        let Some(consumed) = raw_input[..split_at].chars().next_back() else {
+            return split_at;
+        };
+        let Some(next) = raw_input[split_at..].chars().next() else {
+            return split_at;
+        };
         if !Self::is_ascii_romaji_consonant(consumed) || !Self::is_ascii_romaji_vowel(next) {
             return split_at;
         }
 
-        if raw_input_chars[..split_at - 1]
-            .iter()
+        if raw_input[..split_at]
+            .chars()
             .rev()
+            .skip(1)
             .find(|ch| ch.is_ascii_alphabetic())
             .is_some_and(|ch| ch.eq_ignore_ascii_case(&'n'))
         {
-            split_at - 1
+            split_at - consumed.len_utf8()
         } else {
             split_at
         }
@@ -3689,7 +3701,6 @@ impl TextServiceFactory {
                         let transition = ClauseState::transition_without_backend(
                             &mut state,
                             ClauseCommand::SetSelection(selection),
-                            ClauseTransitionInput::default(),
                         );
                         let effect = transition.effect;
                         ClauseState::write_back(state);

--- a/crates/client/src/engine/composition/clause_state.rs
+++ b/crates/client/src/engine/composition/clause_state.rs
@@ -196,10 +196,10 @@ impl ClauseState {
         input: ClauseTransitionInput,
         backend: &mut B,
     ) -> Result<ClauseTransition> {
-        let _ = input.candidates.as_ref();
+        let candidates = input.candidates;
         let effect = match command {
             ClauseCommand::StartClauseNavigation => {
-                Self::ensure_clause_navigation_ready(state, backend)?
+                Self::ensure_clause_navigation_ready(state, backend, candidates)?
             }
             ClauseCommand::MoveBy(direction) => Self::apply_move_clause(state, backend, direction)?,
             ClauseCommand::MoveLeft => Self::apply_move_clause(state, backend, -1)?,
@@ -223,9 +223,7 @@ impl ClauseState {
     pub(crate) fn transition_without_backend(
         state: &mut ClauseActionStateMut<'_>,
         command: ClauseCommand<'_>,
-        input: ClauseTransitionInput,
     ) -> ClauseTransition {
-        let _ = input.candidates.as_ref();
         let effect = match command {
             ClauseCommand::SetSelection(selection) => Self::apply_set_selection(state, selection),
             ClauseCommand::CommitAll
@@ -255,6 +253,7 @@ impl ClauseState {
     pub(crate) fn ensure_clause_navigation_ready<B: ClauseActionBackend>(
         state: &mut ClauseActionStateMut<'_>,
         backend: &mut B,
+        candidates: Option<Candidates>,
     ) -> Result<ClauseActionEffect> {
         if ClauseState::is_clause_navigation_state_active(state)
             || state.candidates.texts.is_empty()
@@ -267,7 +266,10 @@ impl ClauseState {
             return Ok(ClauseActionEffect::skipped());
         }
 
-        let navigation_candidates = backend.move_cursor(0)?;
+        let navigation_candidates = match candidates {
+            Some(candidates) => candidates,
+            None => backend.move_cursor(0)?,
+        };
         let Some(mut selected) =
             TextServiceFactory::select_navigation_candidate_for_current_preview(
                 &navigation_candidates,

--- a/crates/client/src/engine/composition/clause_state.rs
+++ b/crates/client/src/engine/composition/clause_state.rs
@@ -1,0 +1,754 @@
+use anyhow::Result;
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash as _, Hasher as _},
+};
+
+use super::{ClauseSnapshot, Composition, FutureClauseSnapshot, TextServiceFactory};
+use crate::engine::{
+    client_action::SetSelectionType,
+    ipc_service::{Candidates, IPCService},
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct CandidateSelection {
+    pub(crate) index: i32,
+    pub(crate) text: String,
+    pub(crate) sub_text: String,
+    pub(crate) hiragana: String,
+    pub(crate) corresponding_count: i32,
+}
+
+pub(crate) trait ClauseActionBackend {
+    fn move_cursor(&mut self, offset: i32) -> Result<Candidates>;
+    fn shrink_text(&mut self, offset: i32) -> Result<Candidates>;
+}
+
+impl ClauseActionBackend for IPCService {
+    fn move_cursor(&mut self, offset: i32) -> Result<Candidates> {
+        IPCService::move_cursor(self, offset)
+    }
+
+    fn shrink_text(&mut self, offset: i32) -> Result<Candidates> {
+        IPCService::shrink_text(self, offset)
+    }
+}
+
+pub(crate) struct ClauseActionStateMut<'a> {
+    pub(crate) preview: &'a mut String,
+    pub(crate) suffix: &'a mut String,
+    pub(crate) raw_input: &'a mut String,
+    pub(crate) raw_hiragana: &'a mut String,
+    pub(crate) fixed_prefix: &'a mut String,
+    pub(crate) corresponding_count: &'a mut i32,
+    pub(crate) selection_index: &'a mut i32,
+    pub(crate) candidates: &'a mut Candidates,
+    pub(crate) clause_snapshots: &'a mut Vec<ClauseSnapshot>,
+    pub(crate) future_clause_snapshots: &'a mut Vec<FutureClauseSnapshot>,
+    pub(crate) current_clause_is_split_derived: &'a mut bool,
+    pub(crate) current_clause_is_direct_split_remainder: &'a mut bool,
+    pub(crate) current_clause_has_split_left_neighbor: &'a mut bool,
+    pub(crate) current_clause_split_group_id: &'a mut Option<u64>,
+    pub(crate) next_split_group_id: &'a mut u64,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ClauseActionEffect {
+    pub(crate) applied: bool,
+    pub(crate) update_pos: bool,
+}
+
+impl ClauseActionEffect {
+    pub(crate) fn skipped() -> Self {
+        Self {
+            applied: false,
+            update_pos: false,
+        }
+    }
+
+    pub(crate) fn applied(update_pos: bool) -> Self {
+        Self {
+            applied: true,
+            update_pos,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MoveClauseProgressMarker {
+    preview_len: usize,
+    suffix_len: usize,
+    raw_input_len: usize,
+    raw_hiragana_len: usize,
+    fixed_prefix_len: usize,
+    text_hash: u64,
+    corresponding_count: i32,
+    selection_index: i32,
+    clause_snapshot_count: usize,
+    future_clause_snapshot_count: usize,
+    current_clause_is_split_derived: bool,
+    current_clause_is_direct_split_remainder: bool,
+    current_clause_has_split_left_neighbor: bool,
+    current_clause_split_group_id: Option<u64>,
+}
+
+impl MoveClauseProgressMarker {
+    pub(crate) fn from_state(state: &ClauseActionStateMut<'_>) -> Self {
+        let mut hasher = DefaultHasher::new();
+        state.preview.hash(&mut hasher);
+        state.suffix.hash(&mut hasher);
+        state.raw_input.hash(&mut hasher);
+        state.raw_hiragana.hash(&mut hasher);
+        state.fixed_prefix.hash(&mut hasher);
+
+        Self {
+            preview_len: state.preview.len(),
+            suffix_len: state.suffix.len(),
+            raw_input_len: state.raw_input.len(),
+            raw_hiragana_len: state.raw_hiragana.len(),
+            fixed_prefix_len: state.fixed_prefix.len(),
+            text_hash: hasher.finish(),
+            corresponding_count: *state.corresponding_count,
+            selection_index: *state.selection_index,
+            clause_snapshot_count: state.clause_snapshots.len(),
+            future_clause_snapshot_count: state.future_clause_snapshots.len(),
+            current_clause_is_split_derived: *state.current_clause_is_split_derived,
+            current_clause_is_direct_split_remainder: *state
+                .current_clause_is_direct_split_remainder,
+            current_clause_has_split_left_neighbor: *state.current_clause_has_split_left_neighbor,
+            current_clause_split_group_id: *state.current_clause_split_group_id,
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum ClauseCommand<'a> {
+    StartClauseNavigation,
+    MoveBy(i32),
+    MoveLeft,
+    MoveRight,
+    MoveToLast,
+    AdjustBoundary(i32),
+    AdjustBoundaryLeft,
+    AdjustBoundaryRight,
+    SetSelection(&'a SetSelectionType),
+    CommitAll,
+    CommitCurrentAndMoveNext,
+    CommitFirst,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ClauseTransitionInput {
+    pub(crate) candidates: Option<Candidates>,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ClauseTransition {
+    pub(crate) effect: ClauseActionEffect,
+}
+
+pub(crate) struct ClauseState;
+
+impl ClauseState {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_composition_parts<'a>(
+        preview: &'a mut String,
+        suffix: &'a mut String,
+        raw_input: &'a mut String,
+        raw_hiragana: &'a mut String,
+        fixed_prefix: &'a mut String,
+        corresponding_count: &'a mut i32,
+        selection_index: &'a mut i32,
+        candidates: &'a mut Candidates,
+        clause_snapshots: &'a mut Vec<ClauseSnapshot>,
+        future_clause_snapshots: &'a mut Vec<FutureClauseSnapshot>,
+        current_clause_is_split_derived: &'a mut bool,
+        current_clause_is_direct_split_remainder: &'a mut bool,
+        current_clause_has_split_left_neighbor: &'a mut bool,
+        current_clause_split_group_id: &'a mut Option<u64>,
+        next_split_group_id: &'a mut u64,
+    ) -> ClauseActionStateMut<'a> {
+        ClauseActionStateMut {
+            preview,
+            suffix,
+            raw_input,
+            raw_hiragana,
+            fixed_prefix,
+            corresponding_count,
+            selection_index,
+            candidates,
+            clause_snapshots,
+            future_clause_snapshots,
+            current_clause_is_split_derived,
+            current_clause_is_direct_split_remainder,
+            current_clause_has_split_left_neighbor,
+            current_clause_split_group_id,
+            next_split_group_id,
+        }
+    }
+
+    pub(crate) fn write_back(_state: ClauseActionStateMut<'_>) {}
+
+    pub(crate) fn transition_with_backend<B: ClauseActionBackend>(
+        state: &mut ClauseActionStateMut<'_>,
+        command: ClauseCommand<'_>,
+        input: ClauseTransitionInput,
+        backend: &mut B,
+    ) -> Result<ClauseTransition> {
+        let _ = input.candidates.as_ref();
+        let effect = match command {
+            ClauseCommand::StartClauseNavigation => {
+                Self::ensure_clause_navigation_ready(state, backend)?
+            }
+            ClauseCommand::MoveBy(direction) => Self::apply_move_clause(state, backend, direction)?,
+            ClauseCommand::MoveLeft => Self::apply_move_clause(state, backend, -1)?,
+            ClauseCommand::MoveRight => Self::apply_move_clause(state, backend, 1)?,
+            ClauseCommand::MoveToLast => {
+                Self::apply_move_clause(state, backend, TextServiceFactory::MOVE_CLAUSE_TO_LAST)?
+            }
+            ClauseCommand::AdjustBoundary(direction) => {
+                Self::apply_adjust_boundary(state, backend, direction)?
+            }
+            ClauseCommand::AdjustBoundaryLeft => Self::apply_adjust_boundary(state, backend, -1)?,
+            ClauseCommand::AdjustBoundaryRight => Self::apply_adjust_boundary(state, backend, 1)?,
+            ClauseCommand::SetSelection(selection) => Self::apply_set_selection(state, selection),
+            ClauseCommand::CommitAll
+            | ClauseCommand::CommitCurrentAndMoveNext
+            | ClauseCommand::CommitFirst => ClauseActionEffect::skipped(),
+        };
+        Ok(ClauseTransition { effect })
+    }
+
+    pub(crate) fn transition_without_backend(
+        state: &mut ClauseActionStateMut<'_>,
+        command: ClauseCommand<'_>,
+        input: ClauseTransitionInput,
+    ) -> ClauseTransition {
+        let _ = input.candidates.as_ref();
+        let effect = match command {
+            ClauseCommand::SetSelection(selection) => Self::apply_set_selection(state, selection),
+            ClauseCommand::CommitAll
+            | ClauseCommand::CommitCurrentAndMoveNext
+            | ClauseCommand::CommitFirst => ClauseActionEffect::skipped(),
+            _ => ClauseActionEffect::skipped(),
+        };
+        ClauseTransition { effect }
+    }
+
+    pub(crate) fn is_active_for_composition(composition: &Composition) -> bool {
+        !composition.clause_snapshots.is_empty()
+            || !composition.future_clause_snapshots.is_empty()
+            || composition.current_clause_is_split_derived
+            || composition.current_clause_split_group_id.is_some()
+    }
+
+    #[inline]
+    pub(crate) fn is_clause_navigation_state_active(state: &ClauseActionStateMut<'_>) -> bool {
+        !state.clause_snapshots.is_empty()
+            || !state.future_clause_snapshots.is_empty()
+            || *state.current_clause_is_split_derived
+            || state.current_clause_split_group_id.is_some()
+    }
+
+    #[inline]
+    pub(crate) fn ensure_clause_navigation_ready<B: ClauseActionBackend>(
+        state: &mut ClauseActionStateMut<'_>,
+        backend: &mut B,
+    ) -> Result<ClauseActionEffect> {
+        if ClauseState::is_clause_navigation_state_active(state)
+            || state.candidates.texts.is_empty()
+            || state.raw_hiragana.is_empty()
+        {
+            return Ok(ClauseActionEffect::skipped());
+        }
+
+        if !state.suffix.is_empty() {
+            return Ok(ClauseActionEffect::skipped());
+        }
+
+        let navigation_candidates = backend.move_cursor(0)?;
+        let Some(mut selected) =
+            TextServiceFactory::select_navigation_candidate_for_current_preview(
+                &navigation_candidates,
+                state.preview,
+                state.fixed_prefix,
+                *state.selection_index,
+            )
+        else {
+            return Ok(ClauseActionEffect::skipped());
+        };
+
+        if !TextServiceFactory::candidate_splits_raw_input(&selected, state.raw_input) {
+            return Ok(ClauseActionEffect::skipped());
+        }
+
+        let display_override_set_type = TextServiceFactory::display_override_set_type(
+            state.preview,
+            state.fixed_prefix,
+            state.raw_input,
+            state.raw_hiragana,
+        );
+
+        *state.candidates = navigation_candidates;
+        *state.selection_index = selected.index;
+        *state.corresponding_count = selected.corresponding_count;
+        let display_suffix = TextServiceFactory::display_suffix_after_selected_clause(
+            state.preview,
+            state.fixed_prefix,
+            state.suffix,
+            &selected,
+        );
+        selected.sub_text = display_suffix.clone();
+        if let Some(sub_text) = state
+            .candidates
+            .sub_texts
+            .get_mut(selected.index.max(0) as usize)
+        {
+            *sub_text = display_suffix.clone();
+        }
+        *state.preview =
+            TextServiceFactory::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
+        *state.suffix = display_suffix;
+        *state.raw_hiragana = selected.hiragana.clone();
+        *state.current_clause_is_split_derived = true;
+        *state.current_clause_is_direct_split_remainder = false;
+        *state.current_clause_has_split_left_neighbor = false;
+        *state.current_clause_split_group_id = None;
+        TextServiceFactory::rebuild_future_clause_snapshots_from_backend(state, backend)?;
+        if let Some(set_type) = display_override_set_type {
+            let suffix_raw_input = state
+                .future_clause_snapshots
+                .last()
+                .map(|snapshot| snapshot.raw_input.as_str());
+            let suffix_raw_hiragana = state
+                .future_clause_snapshots
+                .last()
+                .map(|snapshot| snapshot.raw_hiragana.as_str());
+            let (converted_text, converted_sub_text) =
+                TextServiceFactory::display_override_split_for_selected_candidate(
+                    &set_type,
+                    state.raw_input,
+                    state.raw_hiragana,
+                    &selected,
+                    suffix_raw_input,
+                    suffix_raw_hiragana,
+                );
+            selected.text = converted_text;
+            selected.sub_text = converted_sub_text;
+            let selected_index = selected.index.max(0) as usize;
+            if let Some(text) = state.candidates.texts.get_mut(selected_index) {
+                *text = selected.text.clone();
+            }
+            if let Some(sub_text) = state.candidates.sub_texts.get_mut(selected_index) {
+                *sub_text = selected.sub_text.clone();
+            }
+            *state.preview =
+                TextServiceFactory::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
+        }
+        *state.suffix = TextServiceFactory::sync_current_clause_future_suffix(
+            state.candidates,
+            *state.selection_index,
+            *state.corresponding_count,
+            state.future_clause_snapshots,
+        );
+
+        Ok(ClauseActionEffect::applied(true))
+    }
+
+    #[inline]
+    pub(crate) fn apply_move_clause<B: ClauseActionBackend>(
+        state: &mut ClauseActionStateMut<'_>,
+        backend: &mut B,
+        direction: i32,
+    ) -> Result<ClauseActionEffect> {
+        if direction == TextServiceFactory::MOVE_CLAUSE_TO_LAST {
+            let mut applied_any = false;
+            loop {
+                let before = MoveClauseProgressMarker::from_state(state);
+                let effect = ClauseState::apply_move_clause(state, backend, 1)?;
+                if !effect.applied {
+                    break;
+                }
+                let after = MoveClauseProgressMarker::from_state(state);
+                if before == after {
+                    break;
+                }
+                applied_any = true;
+                if state.suffix.is_empty() {
+                    break;
+                }
+            }
+
+            return Ok(if applied_any {
+                ClauseActionEffect::applied(true)
+            } else {
+                ClauseActionEffect::skipped()
+            });
+        }
+
+        if direction > 0 {
+            if state.suffix.is_empty() {
+                return Ok(ClauseActionEffect::skipped());
+            }
+
+            let mut snapshot = TextServiceFactory::build_clause_snapshot(
+                state.preview,
+                state.suffix,
+                state.raw_input,
+                state.raw_hiragana,
+                state.fixed_prefix,
+                *state.corresponding_count,
+                *state.selection_index,
+                *state.current_clause_is_split_derived,
+                *state.current_clause_has_split_left_neighbor,
+                state.candidates,
+            );
+            snapshot.split_group_id = *state.current_clause_split_group_id;
+            snapshot.is_direct_split_remainder = *state.current_clause_is_direct_split_remainder;
+            let current_clause_preview =
+                TextServiceFactory::current_clause_preview(state.preview, state.fixed_prefix);
+            let current_corresponding_count = *state.corresponding_count;
+
+            let _ = backend.move_cursor(TextServiceFactory::MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT)?;
+            state.clause_snapshots.push(snapshot);
+
+            *state.candidates = backend.shrink_text(current_corresponding_count)?;
+            *state.selection_index = 0;
+            *state.raw_input = TextServiceFactory::current_raw_input_suffix(
+                state.raw_input,
+                current_corresponding_count,
+            );
+            state.fixed_prefix.push_str(&current_clause_preview);
+
+            if TextServiceFactory::future_snapshot_matches_server(
+                state.future_clause_snapshots,
+                state.candidates,
+            ) {
+                if let Some(restored_future) = state.future_clause_snapshots.pop() {
+                    TextServiceFactory::sync_backend_current_clause_to_future_snapshot(
+                        backend,
+                        state.candidates,
+                        &restored_future,
+                    )?;
+                    TextServiceFactory::restore_future_clause_snapshot(
+                        state.preview,
+                        state.suffix,
+                        state.raw_input,
+                        state.raw_hiragana,
+                        state.corresponding_count,
+                        state.selection_index,
+                        state.current_clause_is_split_derived,
+                        state.current_clause_is_direct_split_remainder,
+                        state.current_clause_has_split_left_neighbor,
+                        state.current_clause_split_group_id,
+                        state.candidates,
+                        state.fixed_prefix,
+                        &restored_future,
+                    );
+                    *state.suffix = TextServiceFactory::sync_current_clause_future_suffix(
+                        state.candidates,
+                        *state.selection_index,
+                        *state.corresponding_count,
+                        state.future_clause_snapshots,
+                    );
+                    return Ok(ClauseActionEffect::applied(true));
+                }
+            } else {
+                if !state.future_clause_snapshots.is_empty() {
+                    state.future_clause_snapshots.clear();
+                }
+
+                if state.future_clause_snapshots.is_empty() {
+                    let navigation_candidates = backend.move_cursor(0)?;
+                    if let Some(navigation_selected) = TextServiceFactory::select_candidate(
+                        &navigation_candidates,
+                        *state.selection_index,
+                    ) {
+                        let navigation_has_richer_current_candidates =
+                            navigation_candidates.texts.len() > state.candidates.texts.len()
+                                && ClauseState::candidate_hiragana_matches_current_clause(
+                                    state.candidates,
+                                    &navigation_candidates,
+                                );
+                        if TextServiceFactory::candidate_splits_raw_input(
+                            &navigation_selected,
+                            state.raw_input,
+                        ) || navigation_has_richer_current_candidates
+                        {
+                            *state.candidates = navigation_candidates;
+                            *state.selection_index = navigation_selected.index;
+                        }
+                    }
+                }
+
+                let Some(selected) =
+                    TextServiceFactory::select_candidate(state.candidates, *state.selection_index)
+                else {
+                    let _ =
+                        backend.move_cursor(TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT)?;
+                    if let Some(restored) = state.clause_snapshots.pop() {
+                        *state.preview = restored.preview;
+                        *state.suffix = restored.suffix;
+                        *state.raw_input = restored.raw_input;
+                        *state.raw_hiragana = restored.raw_hiragana;
+                        *state.fixed_prefix = restored.fixed_prefix;
+                        *state.corresponding_count = restored.corresponding_count;
+                        *state.selection_index = restored.selection_index;
+                        *state.current_clause_is_split_derived = restored.is_split_derived;
+                        *state.current_clause_is_direct_split_remainder =
+                            restored.is_direct_split_remainder;
+                        *state.current_clause_has_split_left_neighbor =
+                            restored.has_split_left_neighbor;
+                        *state.current_clause_split_group_id = restored.split_group_id;
+                        *state.candidates = restored.candidates;
+                        return Ok(ClauseActionEffect::applied(true));
+                    }
+                    return Ok(ClauseActionEffect::skipped());
+                };
+
+                *state.current_clause_is_split_derived = false;
+                *state.current_clause_is_direct_split_remainder = false;
+                *state.current_clause_has_split_left_neighbor = false;
+                *state.current_clause_split_group_id = None;
+                *state.selection_index = selected.index;
+                *state.corresponding_count = selected.corresponding_count;
+                let display_suffix = TextServiceFactory::display_suffix_after_selected_clause(
+                    state.preview,
+                    state.fixed_prefix,
+                    state.suffix,
+                    &selected,
+                );
+                *state.preview = TextServiceFactory::merge_preview_with_prefix(
+                    state.fixed_prefix,
+                    &selected.text,
+                );
+                *state.suffix = display_suffix;
+                *state.raw_hiragana = selected.hiragana;
+                return Ok(ClauseActionEffect::applied(true));
+            }
+
+            Ok(ClauseActionEffect::skipped())
+        } else if direction < 0 {
+            if let Some(restored) = state.clause_snapshots.pop() {
+                TextServiceFactory::push_current_future_clause_snapshot(
+                    state.future_clause_snapshots,
+                    state.preview,
+                    state.suffix,
+                    state.raw_input,
+                    state.raw_hiragana,
+                    state.fixed_prefix,
+                    *state.corresponding_count,
+                    *state.selection_index,
+                    *state.current_clause_is_split_derived,
+                    *state.current_clause_is_direct_split_remainder,
+                    *state.current_clause_has_split_left_neighbor,
+                    *state.current_clause_split_group_id,
+                    state.candidates,
+                );
+                let _ = backend.move_cursor(TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT)?;
+
+                *state.preview = restored.preview;
+                *state.suffix = restored.suffix;
+                *state.raw_input = restored.raw_input;
+                *state.raw_hiragana = restored.raw_hiragana;
+                *state.fixed_prefix = restored.fixed_prefix;
+                *state.corresponding_count = restored.corresponding_count;
+                *state.selection_index = restored.selection_index;
+                *state.current_clause_is_split_derived = restored.is_split_derived;
+                *state.current_clause_is_direct_split_remainder =
+                    restored.is_direct_split_remainder;
+                *state.current_clause_has_split_left_neighbor = restored.has_split_left_neighbor;
+                *state.current_clause_split_group_id = restored.split_group_id;
+                *state.candidates = restored.candidates;
+                Ok(ClauseActionEffect::applied(true))
+            } else {
+                Ok(ClauseActionEffect::skipped())
+            }
+        } else {
+            Ok(ClauseActionEffect::skipped())
+        }
+    }
+
+    #[inline]
+    fn candidate_hiragana_matches_current_clause(
+        current_candidates: &Candidates,
+        next_candidates: &Candidates,
+    ) -> bool {
+        current_candidates.hiragana.is_empty()
+            || next_candidates.hiragana == current_candidates.hiragana
+            || current_candidates
+                .hiragana
+                .ends_with(&next_candidates.hiragana)
+    }
+
+    #[inline]
+    pub(crate) fn apply_adjust_boundary<B: ClauseActionBackend>(
+        state: &mut ClauseActionStateMut<'_>,
+        backend: &mut B,
+        direction: i32,
+    ) -> Result<ClauseActionEffect> {
+        if direction == 0 {
+            return Ok(ClauseActionEffect::skipped());
+        }
+
+        let fallback_candidates = state.candidates.clone();
+        if !state.suffix.is_empty() || !state.future_clause_snapshots.is_empty() {
+            TextServiceFactory::sync_backend_current_clause_to_target(
+                backend,
+                state.candidates,
+                state.raw_hiragana,
+                state.suffix,
+                *state.corresponding_count,
+            )?;
+        }
+
+        let _ = backend.move_cursor(direction)?;
+        let boundary_candidates = backend.move_cursor(0)?;
+        if boundary_candidates.texts.is_empty() {
+            if direction < 0 {
+                let _ = backend.move_cursor(1)?;
+                if let Some(selected) = ClauseState::select_split_left_candidate(
+                    &fallback_candidates,
+                    *state.corresponding_count,
+                ) {
+                    *state.candidates = fallback_candidates;
+                    return Ok(ClauseState::apply_boundary_candidate_selection(
+                        state, selected,
+                    ));
+                }
+            }
+            return Ok(ClauseActionEffect::skipped());
+        }
+
+        *state.candidates = boundary_candidates;
+        if let Some(selected) = TextServiceFactory::select_candidate(state.candidates, 0) {
+            Ok(ClauseState::apply_boundary_candidate_selection(
+                state, selected,
+            ))
+        } else {
+            Ok(ClauseActionEffect::skipped())
+        }
+    }
+
+    #[inline]
+    pub(crate) fn select_split_left_candidate(
+        candidates: &Candidates,
+        current_corresponding_count: i32,
+    ) -> Option<CandidateSelection> {
+        (0..candidates.texts.len())
+            .filter_map(|index| TextServiceFactory::select_candidate(candidates, index as i32))
+            .filter(|candidate| candidate.corresponding_count < current_corresponding_count)
+            .max_by_key(|candidate| candidate.corresponding_count)
+    }
+
+    #[inline]
+    pub(crate) fn apply_boundary_candidate_selection(
+        state: &mut ClauseActionStateMut<'_>,
+        selected: CandidateSelection,
+    ) -> ClauseActionEffect {
+        let split_group_id = (*state.current_clause_split_group_id)
+            .or_else(|| {
+                state.future_clause_snapshots.last().and_then(|snapshot| {
+                    snapshot
+                        .is_conservative
+                        .then_some(snapshot.split_group_id)
+                        .flatten()
+                        .or_else(|| {
+                            snapshot
+                                .has_split_left_neighbor
+                                .then_some(snapshot.split_group_id)
+                                .flatten()
+                        })
+                })
+            })
+            .unwrap_or_else(|| {
+                let group_id = *state.next_split_group_id;
+                *state.next_split_group_id += 1;
+                group_id
+            });
+        *state.selection_index = selected.index;
+        *state.corresponding_count = selected.corresponding_count;
+        *state.preview =
+            TextServiceFactory::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
+        *state.raw_hiragana = selected.hiragana;
+        *state.suffix = selected.sub_text.clone();
+        *state.current_clause_split_group_id = Some(split_group_id);
+        let allow_bootstrap_without_existing_future = state.future_clause_snapshots.is_empty()
+            && !state.clause_snapshots.is_empty()
+            && TextServiceFactory::current_raw_suffix(
+                state.raw_hiragana,
+                *state.corresponding_count,
+            )
+            .is_empty();
+        TextServiceFactory::maybe_push_split_future_clause_snapshot(
+            state.future_clause_snapshots,
+            state.raw_input,
+            state.raw_hiragana,
+            *state.corresponding_count,
+            &selected.sub_text,
+            allow_bootstrap_without_existing_future,
+            Some(split_group_id),
+        );
+        let split_group_still_active = state
+            .future_clause_snapshots
+            .iter()
+            .any(|snapshot| snapshot.split_group_id == Some(split_group_id));
+        *state.current_clause_is_split_derived =
+            *state.current_clause_has_split_left_neighbor || split_group_still_active;
+        *state.current_clause_is_direct_split_remainder = false;
+        *state.current_clause_split_group_id = state
+            .current_clause_is_split_derived
+            .then_some(split_group_id);
+        *state.suffix = TextServiceFactory::sync_current_clause_future_suffix(
+            state.candidates,
+            *state.selection_index,
+            *state.corresponding_count,
+            state.future_clause_snapshots,
+        );
+        TextServiceFactory::sync_clause_snapshot_suffixes(
+            state.clause_snapshots,
+            state.preview,
+            state.suffix,
+        );
+
+        ClauseActionEffect::applied(true)
+    }
+
+    #[inline]
+    pub(crate) fn apply_set_selection(
+        state: &mut ClauseActionStateMut<'_>,
+        selection: &SetSelectionType,
+    ) -> ClauseActionEffect {
+        let desired_index = match selection {
+            SetSelectionType::Up => *state.selection_index - 1,
+            SetSelectionType::Down => *state.selection_index + 1,
+            SetSelectionType::Number(number) => *number,
+        };
+
+        if let Some(selected) =
+            TextServiceFactory::select_candidate(state.candidates, desired_index)
+        {
+            *state.selection_index = selected.index;
+            *state.corresponding_count = selected.corresponding_count;
+            *state.preview =
+                TextServiceFactory::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
+            *state.raw_hiragana = selected.hiragana;
+            *state.suffix = TextServiceFactory::sync_current_clause_future_suffix(
+                state.candidates,
+                *state.selection_index,
+                *state.corresponding_count,
+                state.future_clause_snapshots,
+            );
+            TextServiceFactory::sync_clause_snapshot_suffixes(
+                state.clause_snapshots,
+                state.preview,
+                state.suffix,
+            );
+
+            ClauseActionEffect::applied(false)
+        } else {
+            ClauseActionEffect::skipped()
+        }
+    }
+}

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    Candidates, ClauseActionBackend, ClauseActionStateMut, ClauseSnapshot, Composition,
-    CompositionState, FutureClauseSnapshot, TextServiceFactory,
+    Candidates, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut, ClauseSnapshot,
+    ClauseState, Composition, CompositionState, FutureClauseSnapshot, TextServiceFactory,
 };
 use crate::engine::{
     client_action::{ClientAction, SetSelectionType, SetTextType},
@@ -110,6 +110,809 @@ fn delayed_candidate_window_shows_when_space_opens_preview() {
             ClientAction::ShowCandidateWindow,
             ClientAction::SetSelection(SetSelectionType::Down)
         ]
+    );
+}
+
+#[test]
+fn right_arrow_prepares_clause_navigation_without_initial_move() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        preview: "いい加減統一しろ".to_string(),
+        raw_input: "iikagentouitusiro".to_string(),
+        raw_hiragana: "いいかげんとういつしろ".to_string(),
+        corresponding_count: 17,
+        ..Composition::default()
+    };
+
+    let (_, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Navigation(Navigation::Right),
+        &InputMode::Kana,
+        false,
+        &AppConfig::default(),
+        false,
+    )
+    .expect("right arrow should prepare clause navigation");
+
+    assert_eq!(actions, vec![ClientAction::EnsureClauseNavigationReady]);
+}
+
+#[test]
+fn initial_left_arrow_defers_clause_navigation_ready_ui_sync_until_last_clause() {
+    let actions = vec![
+        ClientAction::EnsureClauseNavigationReady,
+        ClientAction::MoveClause(TextServiceFactory::MOVE_CLAUSE_TO_LAST),
+    ];
+
+    assert!(TextServiceFactory::should_defer_clause_navigation_ready_sync(&actions, 0));
+    assert!(!TextServiceFactory::should_defer_clause_navigation_ready_sync(&actions, 1));
+}
+
+#[test]
+fn skipped_move_to_last_flushes_deferred_clause_navigation_ready_ui_sync() {
+    assert_eq!(
+        TextServiceFactory::deferred_clause_navigation_ready_sync_update_pos(
+            Some(true),
+            ClauseActionEffect::skipped()
+        ),
+        Some(true)
+    );
+    assert_eq!(
+        TextServiceFactory::deferred_clause_navigation_ready_sync_update_pos(
+            Some(true),
+            ClauseActionEffect::applied(true)
+        ),
+        None
+    );
+}
+
+#[test]
+fn enter_commits_all_when_clause_navigation_is_active() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        preview: "加減".to_string(),
+        raw_input: "kagentouitu".to_string(),
+        raw_hiragana: "かげんとういつ".to_string(),
+        corresponding_count: 5,
+        future_clause_snapshots: vec![actual_future_snapshot("統一", "", "touitu", "とういつ", 6)],
+        ..Composition::default()
+    };
+
+    let (transition, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Enter,
+        &InputMode::Kana,
+        false,
+        &AppConfig::default(),
+        false,
+    )
+    .expect("enter should commit active clause navigation");
+
+    assert_eq!(transition, CompositionState::None);
+    assert_eq!(actions, vec![ClientAction::EndComposition]);
+}
+
+#[test]
+fn ctrl_down_keeps_current_clause_commit_in_clause_navigation() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        preview: "加減".to_string(),
+        suffix: "統一".to_string(),
+        raw_input: "kagentouitu".to_string(),
+        raw_hiragana: "かげんとういつ".to_string(),
+        corresponding_count: 5,
+        future_clause_snapshots: vec![actual_future_snapshot("統一", "", "touitu", "とういつ", 6)],
+        ..Composition::default()
+    };
+
+    let (transition, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::CommitAndNextClause,
+        &InputMode::Kana,
+        false,
+        &AppConfig::default(),
+        false,
+    )
+    .expect("ctrl+down should commit current clause");
+
+    assert_eq!(transition, CompositionState::Composing);
+    assert_eq!(actions, vec![ClientAction::ShrinkText("".to_string())]);
+}
+
+struct NonProgressMoveBackend {
+    shrink_calls: usize,
+}
+
+impl ClauseActionBackend for NonProgressMoveBackend {
+    fn move_cursor(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        self.shrink_calls += 1;
+        assert!(
+            self.shrink_calls <= 1,
+            "MOVE_CLAUSE_TO_LAST retried a non-progressing right move"
+        );
+        Ok(Candidates::default())
+    }
+}
+
+#[test]
+fn move_clause_to_last_stops_when_right_move_makes_no_progress() {
+    let mut preview = "いい加減".to_string();
+    let mut suffix = "統一".to_string();
+    let mut raw_input = "iikagentouitu".to_string();
+    let mut raw_hiragana = "いいかげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 7;
+    let mut selection_index = 0;
+    let mut candidates = candidates(&["いい加減"], &["統一"], "いいかげんとういつ", &[7]);
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = true;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = NonProgressMoveBackend { shrink_calls: 0 };
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::apply_move_clause(
+        &mut state,
+        &mut backend,
+        TextServiceFactory::MOVE_CLAUSE_TO_LAST,
+    )
+    .expect("move to last should return");
+
+    assert!(!effect.applied);
+    assert_eq!(backend.shrink_calls, 1);
+}
+
+struct NonProgressEnsureBackend {
+    move_cursor_zero_calls: usize,
+    shrink_calls: usize,
+}
+
+impl ClauseActionBackend for NonProgressEnsureBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        if offset == 0 {
+            self.move_cursor_zero_calls += 1;
+            if self.move_cursor_zero_calls == 1 {
+                return Ok(candidates(
+                    &["いい加減"],
+                    &["統一"],
+                    "いいかげんとういつ",
+                    &[7],
+                ));
+            }
+        }
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        self.shrink_calls += 1;
+        assert!(
+            self.shrink_calls <= 1,
+            "future snapshot rebuild retried a non-progressing right move"
+        );
+        Ok(Candidates::default())
+    }
+}
+
+#[test]
+fn ensure_clause_navigation_stops_rebuilding_future_on_non_progress_move() {
+    let mut preview = "いい加減統一".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "iikagentouitu".to_string();
+    let mut raw_hiragana = "いいかげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 13;
+    let mut selection_index = 0;
+    let mut candidates = candidates(&["いい加減統一"], &[""], "いいかげんとういつ", &[13]);
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = NonProgressEnsureBackend {
+        move_cursor_zero_calls: 0,
+        shrink_calls: 0,
+    };
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+        .expect("ensure clause navigation should return");
+
+    assert!(effect.applied);
+    assert_eq!(backend.shrink_calls, 1);
+    assert!(future_clause_snapshots.is_empty());
+}
+
+struct PreserveSelectionEnsureBackend;
+
+impl ClauseActionBackend for PreserveSelectionEnsureBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        if offset == 0 {
+            return Ok(candidates(
+                &["いい加減", "良い加減"],
+                &["統一", "統一"],
+                "いいかげんとういつ",
+                &[7, 7],
+            ));
+        }
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        Ok(candidates(&["統一"], &[""], "とういつ", &[6]))
+    }
+}
+
+struct ReorderedNavigationEnsureBackend;
+
+impl ClauseActionBackend for ReorderedNavigationEnsureBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        if offset == 0 {
+            return Ok(candidates(
+                &["いい加減", "良い加減", "程良い加減"],
+                &["統一", "統一", "統一"],
+                "いいかげんとういつ",
+                &[7, 7, 7],
+            ));
+        }
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        Ok(candidates(&["統一"], &[""], "とういつ", &[6]))
+    }
+}
+
+struct FKeyDisplayEnsureBackend {
+    shrunk: bool,
+}
+
+impl ClauseActionBackend for FKeyDisplayEnsureBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        if offset == 0 && !self.shrunk {
+            return Ok(candidates(
+                &["加減", "下限", "かげん"],
+                &["統一", "統一", "統一"],
+                "かげんとういつ",
+                &[5, 5, 5],
+            ));
+        }
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        self.shrunk = true;
+        Ok(candidates(&["統一"], &[""], "とういつ", &[6]))
+    }
+}
+
+#[test]
+fn ensure_clause_navigation_preserves_current_candidate_selection() {
+    let mut preview = "良い加減統一".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "iikagentouitu".to_string();
+    let mut raw_hiragana = "いいかげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 13;
+    let mut selection_index = 1;
+    let mut current_candidates = candidates(
+        &["いい加減統一", "良い加減統一"],
+        &["", ""],
+        "いいかげんとういつ",
+        &[13, 13],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = PreserveSelectionEnsureBackend;
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+        .expect("ensure clause navigation should return");
+
+    assert!(effect.applied);
+    assert_eq!(preview, "良い加減");
+    assert_eq!(selection_index, 1);
+    assert_eq!(corresponding_count, 7);
+    assert_eq!(suffix, "統一");
+}
+
+#[test]
+fn ensure_clause_navigation_matches_current_preview_before_reusing_index() {
+    let mut preview = "程良い加減統一".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "iikagentouitu".to_string();
+    let mut raw_hiragana = "いいかげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 13;
+    let mut selection_index = 1;
+    let mut current_candidates = candidates(
+        &["いい加減統一", "程良い加減統一"],
+        &["", ""],
+        "いいかげんとういつ",
+        &[13, 13],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = ReorderedNavigationEnsureBackend;
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+        .expect("ensure clause navigation should return");
+
+    assert!(effect.applied);
+    assert_eq!(preview, "程良い加減");
+    assert_eq!(selection_index, 2);
+    assert_eq!(corresponding_count, 7);
+    assert_eq!(suffix, "統一");
+}
+
+#[test]
+fn ensure_clause_navigation_preserves_fkey_display_preview() {
+    let mut preview = "カゲントウイツ".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "kagentouitu".to_string();
+    let mut raw_hiragana = "かげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 11;
+    let mut selection_index = 0;
+    let mut current_candidates = candidates(
+        &["加減統一", "下限統一", "かげん統一"],
+        &["", "", ""],
+        "かげんとういつ",
+        &[11, 11, 11],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = FKeyDisplayEnsureBackend { shrunk: false };
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+        .expect("ensure clause navigation should return");
+
+    assert!(effect.applied);
+    assert_eq!(preview, "カゲン");
+    assert_eq!(suffix, "トウイツ");
+    assert_eq!(selection_index, 0);
+    assert_eq!(corresponding_count, 5);
+    assert_eq!(current_candidates.texts[0], "カゲン");
+    assert_eq!(current_candidates.sub_texts[0], "トウイツ");
+}
+
+#[test]
+fn ensure_clause_navigation_clamps_out_of_range_selection_index() {
+    let mut preview = "程良い加減統一".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "iikagentouitu".to_string();
+    let mut raw_hiragana = "いいかげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 13;
+    let mut selection_index = 3;
+    let mut current_candidates = candidates(
+        &[
+            "いい加減統一",
+            "良い加減統一",
+            "好い加減統一",
+            "程良い加減統一",
+        ],
+        &["", "", "", ""],
+        "いいかげんとういつ",
+        &[13, 13, 13, 13],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = PreserveSelectionEnsureBackend;
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+        .expect("ensure clause navigation should return");
+
+    assert!(effect.applied);
+    assert_eq!(preview, "良い加減");
+    assert_eq!(selection_index, 1);
+    assert_eq!(corresponding_count, 7);
+    assert_eq!(suffix, "統一");
+}
+
+struct MoveRightCollapsedRemainderBackend {
+    moved_left: bool,
+}
+
+impl ClauseActionBackend for MoveRightCollapsedRemainderBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        if offset < 0 {
+            self.moved_left = true;
+        }
+
+        if self.moved_left {
+            return Ok(candidates(
+                &["長い", "永い", "ながい"],
+                &["文節でも複数に分割される"; 3],
+                "ながいぶんせつでもふくすうにぶんかつされる",
+                &[5, 5, 5],
+            ));
+        }
+
+        Ok(Candidates::default())
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        Ok(candidates(
+            &["長い文節でも複数に分割される"],
+            &[""],
+            "ながいぶんせつでもふくすうにぶんかつされる",
+            &[26],
+        ))
+    }
+}
+
+#[test]
+fn move_clause_right_preserves_future_clause_when_server_returns_collapsed_remainder() {
+    let mut preview = "ある程度".to_string();
+    let mut suffix = "長い文節でも複数に分割される".to_string();
+    let mut raw_input = "aruteidonagaibunsetudemohukusuunibunkatusareru".to_string();
+    let mut raw_hiragana = "あるていどながいぶんせつでもふくすうにぶんかつされる".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 9;
+    let mut selection_index = 0;
+    let mut current_candidates = candidates(
+        &["ある程度"],
+        &["長い文節でも複数に分割される"],
+        "あるていどながいぶんせつでもふくすうにぶんかつされる",
+        &[9],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = vec![
+        actual_future_snapshot(
+            "文節でも",
+            "複数に分割される",
+            "bunsetudemohukusuunibunkatusareru",
+            "ぶんせつでもふくすうにぶんかつされる",
+            11,
+        ),
+        TextServiceFactory::build_future_clause_snapshot(
+            "長い",
+            "文節でも複数に分割される",
+            "nagaibunsetudemohukusuunibunkatusareru",
+            "ながいぶんせつでもふくすうにぶんかつされる",
+            "",
+            5,
+            0,
+            &candidates(
+                &["長い", "永い", "ながい"],
+                &["文節でも複数に分割される"; 3],
+                "ながいぶんせつでもふくすうにぶんかつされる",
+                &[5, 5, 5],
+            ),
+        ),
+    ];
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = MoveRightCollapsedRemainderBackend { moved_left: false };
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::apply_move_clause(&mut state, &mut backend, 1)
+        .expect("right move should return");
+
+    assert!(effect.applied);
+    assert!(backend.moved_left);
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&preview, &fixed_prefix),
+        "長い"
+    );
+    assert_eq!(suffix, "文節でも複数に分割される");
+    assert_eq!(
+        TextServiceFactory::clause_texts_for_log(
+            &preview,
+            &fixed_prefix,
+            &[],
+            &future_clause_snapshots
+        ),
+        "長い / 文節でも"
+    );
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SingleNBoundaryServerState {
+    Full,
+    BadSuffix,
+}
+
+struct InitialSplitSingleNBoundaryBackend {
+    server: SingleNBoundaryServerState,
+    snapshots: Vec<SingleNBoundaryServerState>,
+}
+
+impl InitialSplitSingleNBoundaryBackend {
+    fn current_candidates(&self) -> Candidates {
+        match self.server {
+            SingleNBoundaryServerState::Full => {
+                candidates(&["いい加減"], &["横溢しろ"], "いいかげんとういつしろ", &[7])
+            }
+            SingleNBoundaryServerState::BadSuffix => {
+                candidates(&["横溢しろ"], &[""], "おういつしろ", &[9])
+            }
+        }
+    }
+}
+
+impl ClauseActionBackend for InitialSplitSingleNBoundaryBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        match offset {
+            value if value == TextServiceFactory::MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT => {
+                self.snapshots.push(self.server);
+            }
+            value if value == TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT => {
+                if let Some(restored) = self.snapshots.pop() {
+                    self.server = restored;
+                }
+            }
+            _ => {}
+        }
+        Ok(self.current_candidates())
+    }
+
+    fn shrink_text(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        assert_eq!(offset, 7);
+        self.server = SingleNBoundaryServerState::BadSuffix;
+        Ok(self.current_candidates())
+    }
+}
+
+#[test]
+fn initial_auto_split_recovers_single_n_suffix_without_reinput() {
+    let mut preview = "いい加減統一しろ".to_string();
+    let mut suffix = String::new();
+    let mut raw_input = "iikagentouitusiro".to_string();
+    let mut raw_hiragana = "いいかげんとういつしろ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 17;
+    let mut selection_index = 0;
+    let mut current_candidates = candidates(
+        &["いい加減統一しろ"],
+        &[""],
+        "いいかげんとういつしろ",
+        &[17],
+    );
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = false;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = InitialSplitSingleNBoundaryBackend {
+        server: SingleNBoundaryServerState::Full,
+        snapshots: Vec::new(),
+    };
+
+    {
+        let mut state = ClauseActionStateMut {
+            preview: &mut preview,
+            suffix: &mut suffix,
+            raw_input: &mut raw_input,
+            raw_hiragana: &mut raw_hiragana,
+            fixed_prefix: &mut fixed_prefix,
+            corresponding_count: &mut corresponding_count,
+            selection_index: &mut selection_index,
+            candidates: &mut current_candidates,
+            clause_snapshots: &mut clause_snapshots,
+            future_clause_snapshots: &mut future_clause_snapshots,
+            current_clause_is_split_derived: &mut current_clause_is_split_derived,
+            current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+            current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+            current_clause_split_group_id: &mut current_clause_split_group_id,
+            next_split_group_id: &mut next_split_group_id,
+        };
+        let effect = TextServiceFactory::ensure_clause_navigation_ready(&mut state, &mut backend)
+            .expect("clause navigation should prepare");
+        assert!(effect.applied);
+    }
+
+    assert_eq!(backend.server, SingleNBoundaryServerState::Full);
+    assert_eq!(backend.snapshots.len(), 0);
+    assert_eq!(suffix, "統一しろ");
+    assert_eq!(
+        future_clause_snapshots
+            .last()
+            .map(|snapshot| snapshot.selected_text.as_str()),
+        Some("統一しろ")
+    );
+    assert_eq!(
+        future_clause_snapshots
+            .last()
+            .map(|snapshot| snapshot.raw_input.as_str()),
+        Some("touitusiro")
+    );
+    assert_eq!(
+        future_clause_snapshots
+            .last()
+            .map(|snapshot| snapshot.raw_hiragana.as_str()),
+        Some("とういつしろ")
+    );
+
+    {
+        let mut state = ClauseActionStateMut {
+            preview: &mut preview,
+            suffix: &mut suffix,
+            raw_input: &mut raw_input,
+            raw_hiragana: &mut raw_hiragana,
+            fixed_prefix: &mut fixed_prefix,
+            corresponding_count: &mut corresponding_count,
+            selection_index: &mut selection_index,
+            candidates: &mut current_candidates,
+            clause_snapshots: &mut clause_snapshots,
+            future_clause_snapshots: &mut future_clause_snapshots,
+            current_clause_is_split_derived: &mut current_clause_is_split_derived,
+            current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+            current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+            current_clause_split_group_id: &mut current_clause_split_group_id,
+            next_split_group_id: &mut next_split_group_id,
+        };
+        let effect = TextServiceFactory::apply_move_clause(&mut state, &mut backend, 1)
+            .expect("right move should restore the cached suffix");
+        assert!(effect.applied);
+    }
+
+    assert_eq!(suffix, "");
+    assert_eq!(raw_input, "touitusiro");
+    assert_eq!(raw_hiragana, "とういつしろ");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&preview, &fixed_prefix),
+        "統一しろ"
+    );
+    assert_eq!(
+        current_candidates.texts.first().map(String::as_str),
+        Some("統一しろ")
     );
 }
 

--- a/crates/client/src/engine/composition/tests/integration_patterns.rs
+++ b/crates/client/src/engine/composition/tests/integration_patterns.rs
@@ -269,7 +269,7 @@ fn clause_integration_fkeys_preserve_display_when_moving_right() {
 }
 
 #[test]
-fn clause_integration_fkeys_preserve_display_when_committing_current_clause() {
+fn clause_integration_fkeys_commit_all_clauses_when_clause_navigation_is_active() {
     for (set_type, converted_clause) in fkey_cases() {
         let extra = vec![
             HarnessUserAction::SetTextType(set_type),
@@ -288,13 +288,160 @@ fn clause_integration_fkeys_preserve_display_when_committing_current_clause() {
         );
         assert_eq!(harness_raw_clauses(&harness), "かげん / とういつ");
         assert_eq!(harness_clause_input_lengths(&harness), "5 / 6");
-        assert_eq!(harness.committed_clauses.len(), 1);
-        assert_eq!(
-            TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
-            "統一"
-        );
-        assert_eq!(harness.state, CompositionState::Composing);
+        assert_eq!(harness.committed_clauses.len(), 2);
+        assert!(harness.preview.is_empty());
+        assert!(harness.future_clause_snapshots.is_empty());
+        assert_eq!(harness.state, CompositionState::None);
     }
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_uses_first_clause_for_ju_sequence() {
+    let extra = vec![HarnessUserAction::Right];
+    let (harness, _, history) = run_from_auto_clause_ju(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "準備して / 発表に / 臨む",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+    );
+    assert_eq!(harness_clause_input_lengths(&harness), "9 / 11 / 6");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "準備して"
+    );
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_moves_to_second_clause_on_next_right() {
+    let extra = vec![HarnessUserAction::Right, HarnessUserAction::Right];
+    let (harness, _, history) = run_from_auto_clause_ju(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "準備して / 発表に / 臨む",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+    );
+    assert_eq!(harness_clause_input_lengths(&harness), "9 / 11 / 6");
+    assert_eq!(harness.raw_input, "haxtupyouninozomu");
+    assert_eq!(harness.raw_hiragana, "はっぴょうにのぞむ");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "発表に"
+    );
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_preserves_tyu_sequence_boundary() {
+    let extra = vec![HarnessUserAction::Right];
+    let (harness, _, history) = run_from_auto_clause_tyu(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "注意 / して",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+    );
+    assert_eq!(harness_raw_clauses(&harness), "ちゅうい / して");
+    assert_eq!(harness_clause_input_lengths(&harness), "5 / 4");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "注意"
+    );
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_moves_tyu_to_second_clause_on_next_right() {
+    let extra = vec![HarnessUserAction::Right, HarnessUserAction::Right];
+    let (harness, _, history) = run_from_auto_clause_tyu(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "注意 / して",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+    );
+    assert_eq!(harness_raw_clauses(&harness), "ちゅうい / して");
+    assert_eq!(harness_clause_input_lengths(&harness), "5 / 4");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "して"
+    );
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_preserves_realtime_suffix_display() {
+    let extra = vec![HarnessUserAction::Right];
+    let (harness, _, history) = run_from_auto_clause_preserved_suffix(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "ある程度 / 長い / 文節でも / 複数に分割される",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}\npreview={} fixed_prefix={} suffix={}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+        harness.preview,
+        harness.fixed_prefix,
+        harness.suffix,
+    );
+    assert_eq!(harness.suffix, "長い文節でも複数に分割される");
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "ある程度"
+    );
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_left_starts_at_last_clause() {
+    let extra = vec![HarnessUserAction::Left];
+    let (harness, _, history) = run_from_auto_clause_preserved_suffix(&extra);
+
+    assert_eq!(
+        harness_visible_clauses(&harness),
+        "ある程度 / 長い / 文節でも / 複数に分割される",
+        "history: {}\nraw clauses: {}\nclause_snapshots: {}\nfuture_clause_snapshots: {}\npreview={} fixed_prefix={} suffix={}",
+        history_string(&history),
+        harness_raw_clauses(&harness),
+        TextServiceFactory::debug_clause_snapshots(&harness.clause_snapshots),
+        TextServiceFactory::debug_future_clause_snapshots(&harness.future_clause_snapshots),
+        harness.preview,
+        harness.fixed_prefix,
+        harness.suffix,
+    );
+    assert!(harness.suffix.is_empty());
+    assert_eq!(
+        TextServiceFactory::current_clause_preview(&harness.preview, &harness.fixed_prefix),
+        "複数に分割される"
+    );
+}
+
+#[test]
+fn clause_integration_auto_clause_navigation_routes_shift_arrows_to_reducer() {
+    let right_extra = vec![HarnessUserAction::Right];
+    let (right_harness, _, _) = run_from_auto_clause_preserved_suffix(&right_extra);
+    assert_adjust_boundary_is_routed(&right_harness, -1);
+    assert_adjust_boundary_is_routed(&right_harness, 1);
+
+    let left_extra = vec![HarnessUserAction::Left];
+    let (left_harness, _, _) = run_from_auto_clause_preserved_suffix(&left_extra);
+    assert_adjust_boundary_is_routed(&left_harness, -1);
+    assert_adjust_boundary_is_routed(&left_harness, 1);
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests/snapshot_restore.rs
+++ b/crates/client/src/engine/composition/tests/snapshot_restore.rs
@@ -114,6 +114,142 @@ fn move_clause_right_restores_future_clause_without_dropping_following_clauses()
     );
 }
 
+struct RichNavigationAfterShrinkBackend {
+    shrink_candidates: Candidates,
+    navigation_candidates: Candidates,
+}
+
+impl ClauseActionBackend for RichNavigationAfterShrinkBackend {
+    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        if offset == 0 {
+            Ok(self.navigation_candidates.clone())
+        } else {
+            Ok(self.shrink_candidates.clone())
+        }
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        Ok(self.shrink_candidates.clone())
+    }
+}
+
+#[test]
+fn move_clause_right_prefers_rich_navigation_candidates_after_two_clause_shrink() {
+    let mut preview = "いい加減".to_string();
+    let mut suffix = "統一しろ".to_string();
+    let mut raw_input = "iikagentouitusiro".to_string();
+    let mut raw_hiragana = "いいかげんとういつしろ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 7;
+    let mut selection_index = 0;
+    let mut current_candidates =
+        candidates(&["いい加減"], &["統一しろ"], "いいかげんとういつしろ", &[7]);
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = true;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+    let mut backend = RichNavigationAfterShrinkBackend {
+        shrink_candidates: candidates(&["統一しろ"], &[""], "とういつしろ", &[10]),
+        navigation_candidates: candidates(
+            &["統一しろ", "とういつしろ", "トウイツしろ"],
+            &["", "", ""],
+            "とういつしろ",
+            &[10, 10, 10],
+        ),
+    };
+
+    let effect = ClauseState::apply_move_clause(&mut state, &mut backend, 1)
+        .expect("move right should succeed");
+
+    assert!(effect.applied);
+    assert_eq!(
+        state.candidates.texts,
+        vec!["統一しろ", "とういつしろ", "トウイツしろ"]
+    );
+}
+
+#[test]
+fn auto_split_future_snapshot_preserves_rich_candidates_for_exact_two_clause_suffix() {
+    let mut preview = "いい加減".to_string();
+    let mut suffix = "統一しろ".to_string();
+    let mut raw_input = "iikagentouitusiro".to_string();
+    let mut raw_hiragana = "いいかげんとういつしろ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 7;
+    let mut selection_index = 0;
+    let mut current_candidates =
+        candidates(&["いい加減"], &["統一しろ"], "いいかげんとういつしろ", &[7]);
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = true;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = Some(1);
+    let mut next_split_group_id = 2;
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+    let suffix_candidates = candidates(
+        &["統一しろ", "統一し路", "とういつしろ", "統一白"],
+        &["", "", "", ""],
+        "とういつしろ",
+        &[10, 10, 10, 10],
+    );
+    let mut backend = RichNavigationAfterShrinkBackend {
+        shrink_candidates: suffix_candidates.clone(),
+        navigation_candidates: suffix_candidates,
+    };
+
+    TextServiceFactory::rebuild_future_clause_snapshots_from_backend(&mut state, &mut backend)
+        .expect("future snapshots should rebuild");
+
+    let snapshot = state
+        .future_clause_snapshots
+        .last()
+        .expect("future suffix snapshot");
+    assert_eq!(snapshot.raw_input, "touitusiro");
+    assert_eq!(snapshot.raw_hiragana, "とういつしろ");
+    assert_eq!(
+        snapshot.candidates.texts,
+        vec!["統一しろ", "統一し路", "とういつしろ", "統一白"]
+    );
+    assert!(!snapshot.is_conservative);
+}
+
 #[test]
 fn move_clause_right_restores_split_group_from_actual_future_clause() {
     let split_group_id = 3;
@@ -210,6 +346,100 @@ fn adjust_boundary_without_existing_future_cache_does_not_capture_initial_split_
         "いかげんとういつしろ",
         false,
         None,
+    );
+
+    assert!(future.is_empty());
+}
+
+#[test]
+fn auto_split_bootstrap_uses_raw_suffix_hint_when_input_count_is_not_kana_count() {
+    let mut future = Vec::new();
+
+    TextServiceFactory::maybe_push_split_future_clause_snapshot(
+        &mut future,
+        "iikagentouitusiro",
+        "いいかげんとういつしろ",
+        7,
+        "とういつしろ",
+        true,
+        Some(1),
+    );
+
+    let snapshot = future
+        .last()
+        .expect("auto split should cache the remaining clause");
+    assert_eq!(snapshot.raw_input, "touitusiro");
+    assert_eq!(snapshot.raw_hiragana, "とういつしろ");
+    assert_eq!(snapshot.clause_preview, "とういつしろ");
+}
+
+#[test]
+fn auto_split_bootstrap_recovers_single_n_boundary_consumed_consonant() {
+    let mut future = Vec::new();
+
+    TextServiceFactory::maybe_push_split_future_clause_snapshot(
+        &mut future,
+        "iikagentouitusiro",
+        "いいかげんとういつしろ",
+        8,
+        "とういつしろ",
+        true,
+        Some(1),
+    );
+
+    let snapshot = future
+        .last()
+        .expect("single-n auto split should recover the consonant after n");
+    assert_eq!(snapshot.raw_input, "touitusiro");
+    assert_eq!(snapshot.raw_hiragana, "とういつしろ");
+    assert_eq!(snapshot.clause_preview, "とういつしろ");
+}
+
+#[test]
+fn exact_suffix_does_not_trigger_single_n_recovery() {
+    assert_eq!(
+        TextServiceFactory::recover_single_n_raw_hiragana_suffix(
+            "いいかげんとういつしろ",
+            "とういつしろ",
+        ),
+        None
+    );
+}
+
+#[test]
+fn auto_split_bootstrap_keeps_double_n_suffix_boundary() {
+    let mut future = Vec::new();
+
+    TextServiceFactory::maybe_push_split_future_clause_snapshot(
+        &mut future,
+        "iikagenntouitusiro",
+        "いいかげんとういつしろ",
+        8,
+        "とういつしろ",
+        true,
+        Some(1),
+    );
+
+    let snapshot = future
+        .last()
+        .expect("double-n auto split should cache the same remaining clause");
+    assert_eq!(snapshot.raw_input, "touitusiro");
+    assert_eq!(snapshot.raw_hiragana, "とういつしろ");
+    assert_eq!(snapshot.clause_preview, "とういつしろ");
+}
+
+#[test]
+fn auto_split_bootstrap_does_not_cache_untrusted_display_suffix() {
+    let mut future = Vec::new();
+
+    TextServiceFactory::maybe_push_split_future_clause_snapshot(
+        &mut future,
+        "iikagentouitusiro",
+        "いいかげんとういつしろ",
+        7,
+        "横溢しろ",
+        true,
+        Some(1),
     );
 
     assert!(future.is_empty());

--- a/crates/client/src/engine/composition/tests/stateful_harness.rs
+++ b/crates/client/src/engine/composition/tests/stateful_harness.rs
@@ -60,10 +60,54 @@ impl SimClause {
 
     fn candidate_texts(&self) -> Vec<String> {
         match (self.uniform_origin_id(), self.raw_hiragana().as_str()) {
+            (None, "じゅんびしてはっぴょうにのぞむ") => {
+                vec!["準備して発表に臨む".to_string()]
+            }
+            (None, "ちゅういして") => vec!["注意して".to_string()],
+            (None, "あるていどながいぶんせつでもふくすうにぶんかつされる") =>
+            {
+                vec!["ある程度長い文節でも複数に分割される".to_string()]
+            }
+            (None, "ながいぶんせつでもふくすうにぶんかつされる") => {
+                vec!["長い文節でも複数に分割される".to_string()]
+            }
+            (None, "ぶんせつでもふくすうにぶんかつされる") => {
+                vec!["文節でも複数に分割される".to_string()]
+            }
             (Some(1), "かげん") => {
                 vec!["加減".to_string(), "下限".to_string(), "かげん".to_string()]
             }
             (Some(2), "とういつ") => vec!["統一".to_string(), "とういつ".to_string()],
+            (Some(4), "じゅんびして") => {
+                vec!["準備して".to_string(), "じゅんびして".to_string()]
+            }
+            (Some(5), "はっぴょうに") => {
+                vec!["発表に".to_string(), "はっぴょうに".to_string()]
+            }
+            (Some(6), "のぞむ") => {
+                vec!["臨む".to_string(), "望む".to_string(), "のぞむ".to_string()]
+            }
+            (Some(7), "ちゅうい") => vec!["注意".to_string(), "ちゅうい".to_string()],
+            (Some(8), "して") => vec!["して".to_string()],
+            (Some(9), "あるていど") => vec![
+                "ある程度".to_string(),
+                "有る程度".to_string(),
+                "あるていど".to_string(),
+                "アルテイド".to_string(),
+            ],
+            (Some(10), "ながい") => {
+                vec!["長い".to_string(), "永い".to_string(), "ながい".to_string()]
+            }
+            (Some(11), "ぶんせつでも") => vec![
+                "文節でも".to_string(),
+                "分節でも".to_string(),
+                "ぶんせつでも".to_string(),
+            ],
+            (Some(12), "ふくすうにぶんかつされる") => vec![
+                "複数に分割される".to_string(),
+                "服数に分割される".to_string(),
+                "ふくすうにぶんかつされる".to_string(),
+            ],
             _ => vec![self.raw_hiragana()],
         }
     }
@@ -284,6 +328,77 @@ fn fkey_two_clause_spec_state() -> SimSpecState {
     }
 }
 
+fn auto_clause_ju_spec_state() -> SimSpecState {
+    SimSpecState {
+        committed_clauses: Vec::new(),
+        clauses: vec![clause(vec![
+            unit("じゅ", "ju", "じゅ", 4),
+            unit("ん", "n", "ん", 4),
+            unit("び", "bi", "び", 4),
+            unit("し", "si", "し", 4),
+            unit("て", "te", "て", 4),
+            unit("は", "ha", "は", 5),
+            unit("っ", "xtu", "っ", 5),
+            unit("ぴょ", "pyo", "ぴょ", 5),
+            unit("う", "u", "う", 5),
+            unit("に", "ni", "に", 5),
+            unit("の", "no", "の", 6),
+            unit("ぞ", "zo", "ぞ", 6),
+            unit("む", "mu", "む", 6),
+        ])],
+        current_index: 0,
+    }
+}
+
+fn auto_clause_tyu_spec_state() -> SimSpecState {
+    SimSpecState {
+        committed_clauses: Vec::new(),
+        clauses: vec![clause(vec![
+            unit("ちゅ", "tyu", "ちゅ", 7),
+            unit("う", "u", "う", 7),
+            unit("い", "i", "い", 7),
+            unit("し", "si", "し", 8),
+            unit("て", "te", "て", 8),
+        ])],
+        current_index: 0,
+    }
+}
+
+fn auto_clause_preserved_suffix_spec_state() -> SimSpecState {
+    SimSpecState {
+        committed_clauses: Vec::new(),
+        clauses: vec![clause(vec![
+            unit("あ", "a", "あ", 9),
+            unit("る", "ru", "る", 9),
+            unit("て", "te", "て", 9),
+            unit("い", "i", "い", 9),
+            unit("ど", "do", "ど", 9),
+            unit("な", "na", "な", 10),
+            unit("が", "ga", "が", 10),
+            unit("い", "i", "い", 10),
+            unit("ぶ", "bu", "ぶ", 11),
+            unit("ん", "n", "ん", 11),
+            unit("せ", "se", "せ", 11),
+            unit("つ", "tu", "つ", 11),
+            unit("で", "de", "で", 11),
+            unit("も", "mo", "も", 11),
+            unit("ふ", "fu", "ふ", 12),
+            unit("く", "ku", "く", 12),
+            unit("す", "su", "す", 12),
+            unit("う", "u", "う", 12),
+            unit("に", "ni", "に", 12),
+            unit("ぶ", "bu", "ぶ", 12),
+            unit("ん", "n", "ん", 12),
+            unit("か", "ka", "か", 12),
+            unit("つ", "tu", "つ", 12),
+            unit("さ", "sa", "さ", 12),
+            unit("れ", "re", "れ", 12),
+            unit("る", "ru", "る", 12),
+        ])],
+        current_index: 0,
+    }
+}
+
 fn candidates_owned(
     texts: Vec<String>,
     sub_texts: Vec<String>,
@@ -408,6 +523,46 @@ fn candidates_for_clause(spec: &SimSpecState, clause_index: usize) -> Candidates
         spec_join_raw_hiragana(&spec.clauses[clause_index..]),
         vec![current.corresponding_count(); texts.len()],
     )
+}
+
+fn auto_split_clauses_by_origin(units: &[SimUnit]) -> Vec<SimClause> {
+    let mut clauses: Vec<SimClause> = Vec::new();
+
+    for unit in units.iter().cloned() {
+        if let Some(last) = clauses.last_mut() {
+            if last.uniform_origin_id() == Some(unit.origin_id) {
+                last.units.push(unit);
+                continue;
+            }
+        }
+
+        clauses.push(clause(vec![unit]));
+    }
+
+    clauses
+}
+
+fn auto_first_clause_candidates(spec: &SimSpecState) -> Option<Candidates> {
+    let only_clause = spec.clauses.first()?;
+    let auto_clauses = auto_split_clauses_by_origin(&only_clause.units);
+    if auto_clauses.len() <= 1 {
+        return None;
+    }
+
+    let auto_spec = SimSpecState {
+        committed_clauses: Vec::new(),
+        clauses: auto_clauses,
+        current_index: 0,
+    };
+    let current = &auto_spec.clauses[0];
+    let texts = current.candidate_texts();
+    let raw_suffix = spec_join_raw_hiragana(&auto_spec.clauses[1..]);
+    Some(candidates_owned(
+        texts.clone(),
+        vec![raw_suffix; texts.len()],
+        spec_join_raw_hiragana(&auto_spec.clauses),
+        vec![current.corresponding_count(); texts.len()],
+    ))
 }
 
 fn split_units_by_offset(units: &[SimUnit], offset: i32) -> Option<(Vec<SimUnit>, Vec<SimUnit>)> {
@@ -739,7 +894,8 @@ pub(super) fn harness_raw_clauses(harness: &ClauseHarness) -> String {
         return clauses.join(" / ");
     }
 
-    let trailing = harness.suffix.clone();
+    let trailing =
+        TextServiceFactory::current_raw_suffix(&harness.raw_hiragana, harness.corresponding_count);
     let current_raw = harness
         .raw_hiragana
         .strip_suffix(&trailing)
@@ -842,6 +998,28 @@ fn harness_as_composition(harness: &ClauseHarness) -> Composition {
     }
 }
 
+pub(super) fn assert_adjust_boundary_is_routed(harness: &ClauseHarness, direction: i32) {
+    let composition = harness_as_composition(harness);
+    let app_config = AppConfig::default();
+    let Some((transition, actions)) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::AdjustClauseBoundary(direction),
+        &crate::engine::input_mode::InputMode::Kana,
+        true,
+        &app_config,
+        false,
+    ) else {
+        panic!("adjust boundary was not consumed for direction {direction}");
+    };
+
+    assert_eq!(transition, composition.state);
+    assert_eq!(
+        actions,
+        vec![ClientAction::AdjustBoundary(direction)],
+        "adjust boundary should be delegated to the reducer: direction={direction}"
+    );
+}
+
 fn committed_clause_from_snapshot(
     snapshot: &ClauseSnapshot,
     next_raw_hiragana: Option<&str>,
@@ -872,6 +1050,21 @@ fn committed_current_clause_from_harness(harness: &ClauseHarness) -> SimCommitte
             &harness.future_clause_snapshots,
         ),
         corresponding_count: harness.corresponding_count,
+    }
+}
+
+fn committed_clause_from_future_snapshot(
+    snapshot: &FutureClauseSnapshot,
+    next_raw_hiragana: Option<&str>,
+) -> SimCommittedClause {
+    SimCommittedClause {
+        display: snapshot.selected_text.clone(),
+        raw_hiragana: TextServiceFactory::clause_raw_preview(
+            &snapshot.raw_hiragana,
+            next_raw_hiragana,
+            snapshot.corresponding_count,
+        ),
+        corresponding_count: snapshot.corresponding_count,
     }
 }
 
@@ -1010,6 +1203,30 @@ impl ScenarioBackend {
         }
     }
 
+    fn move_spec_to_last(&mut self) {
+        if !self.spec.clauses.is_empty() {
+            self.spec.current_index = self.spec.clauses.len() - 1;
+            if let Some(current) = self.spec.clauses.get_mut(self.spec.current_index) {
+                current.pending_remainder = false;
+            }
+        }
+    }
+
+    fn ensure_spec_clause_navigation_ready(&mut self) {
+        if self.spec.clauses.len() != 1 || self.spec.current_index != 0 {
+            return;
+        }
+
+        let units = self.spec.clauses[0].units.clone();
+        let auto_clauses = auto_split_clauses_by_origin(&units);
+        if auto_clauses.len() <= 1 {
+            return;
+        }
+
+        self.spec.clauses = auto_clauses;
+        self.spec.current_index = 0;
+    }
+
     fn step_spec_selection(&mut self, delta: i32) {
         let Some(current) = self.spec.clauses.get_mut(self.spec.current_index) else {
             return;
@@ -1021,16 +1238,8 @@ impl ScenarioBackend {
         current.clamp_selection();
     }
 
-    fn commit_spec_current_clause(&mut self) {
-        if self.spec.clauses.is_empty() || self.spec.current_index >= self.spec.clauses.len() {
-            return;
-        }
-
-        let committed = self
-            .spec
-            .clauses
-            .drain(..=self.spec.current_index)
-            .collect::<Vec<_>>();
+    fn commit_spec_all_clauses(&mut self) {
+        let committed = self.spec.clauses.drain(..).collect::<Vec<_>>();
         self.spec
             .committed_clauses
             .extend(committed.into_iter().map(|clause| SimCommittedClause {
@@ -1038,15 +1247,7 @@ impl ScenarioBackend {
                 raw_hiragana: clause.raw_hiragana(),
                 corresponding_count: clause.corresponding_count(),
             }));
-
-        if self.spec.clauses.is_empty() {
-            self.spec.current_index = 0;
-        } else {
-            self.spec.current_index = 0;
-            if let Some(current) = self.spec.clauses.get_mut(0) {
-                current.pending_remainder = false;
-            }
-        }
+        self.spec.current_index = 0;
     }
 
     fn apply_expected_user_action(&mut self, op: HarnessUserAction) {
@@ -1055,7 +1256,7 @@ impl ScenarioBackend {
             HarnessUserAction::Right => self.move_spec_right(),
             HarnessUserAction::ShiftLeft => self.split_spec_left(),
             HarnessUserAction::Space => {}
-            HarnessUserAction::Enter => self.commit_spec_current_clause(),
+            HarnessUserAction::Enter => self.commit_spec_all_clauses(),
             HarnessUserAction::SetTextType(set_type) => {
                 if let Some(current) = self.spec.clauses.get_mut(self.spec.current_index) {
                     current.display_override = Some(set_type);
@@ -1087,6 +1288,8 @@ impl ClauseActionBackend for ScenarioBackend {
             0 => {
                 if self.blocked_boundary {
                     Ok(Candidates::default())
+                } else if let Some(candidates) = auto_first_clause_candidates(&self.server) {
+                    Ok(candidates)
                 } else {
                     Ok(self.current_candidates())
                 }
@@ -1307,8 +1510,37 @@ fn apply_user_action(
         )
     });
 
+    if actions.is_empty() {
+        harness.state = transition;
+        return;
+    }
+
     for action in actions {
         match action {
+            ClientAction::EnsureClauseNavigationReady => {
+                let mut state = ClauseActionStateMut {
+                    preview: &mut harness.preview,
+                    suffix: &mut harness.suffix,
+                    raw_input: &mut harness.raw_input,
+                    raw_hiragana: &mut harness.raw_hiragana,
+                    fixed_prefix: &mut harness.fixed_prefix,
+                    corresponding_count: &mut harness.corresponding_count,
+                    selection_index: &mut harness.selection_index,
+                    candidates: &mut harness.candidates,
+                    clause_snapshots: &mut harness.clause_snapshots,
+                    future_clause_snapshots: &mut harness.future_clause_snapshots,
+                    current_clause_is_split_derived: &mut harness.current_clause_is_split_derived,
+                    current_clause_is_direct_split_remainder: &mut harness
+                        .current_clause_is_direct_split_remainder,
+                    current_clause_has_split_left_neighbor: &mut harness
+                        .current_clause_has_split_left_neighbor,
+                    current_clause_split_group_id: &mut harness.current_clause_split_group_id,
+                    next_split_group_id: &mut harness.next_split_group_id,
+                };
+                TextServiceFactory::ensure_clause_navigation_ready(&mut state, backend)
+                    .expect("ensure_clause_navigation_ready");
+                backend.ensure_spec_clause_navigation_ready();
+            }
             ClientAction::MoveClause(direction) => {
                 backend.sync_current_selection(harness.selection_index);
                 let effect = {
@@ -1354,6 +1586,13 @@ fn apply_user_action(
                     harness.corresponding_count,
                     harness.selection_index,
                 );
+                if direction == TextServiceFactory::MOVE_CLAUSE_TO_LAST {
+                    backend.move_spec_to_last();
+                } else if direction > 0 {
+                    backend.move_spec_right();
+                } else if direction < 0 {
+                    backend.move_spec_left();
+                }
             }
             ClientAction::AdjustBoundary(direction) => {
                 let effect = {
@@ -1497,6 +1736,22 @@ fn apply_user_action(
                         .committed_clauses
                         .push(committed_current_clause_from_harness(harness));
                 }
+                let ordered_future = harness
+                    .future_clause_snapshots
+                    .iter()
+                    .rev()
+                    .collect::<Vec<_>>();
+                for (index, snapshot) in ordered_future.iter().enumerate() {
+                    let next_raw_hiragana = ordered_future
+                        .get(index + 1)
+                        .map(|next| next.raw_hiragana.as_str());
+                    harness
+                        .committed_clauses
+                        .push(committed_clause_from_future_snapshot(
+                            snapshot,
+                            next_raw_hiragana,
+                        ));
+                }
                 harness.preview.clear();
                 harness.suffix.clear();
                 harness.raw_input.clear();
@@ -1609,7 +1864,9 @@ fn apply_user_action(
         }
     }
 
-    backend.apply_expected_user_action(op);
+    if !matches!(op, HarnessUserAction::Left | HarnessUserAction::Right) {
+        backend.apply_expected_user_action(op);
+    }
     harness.state = transition;
 }
 
@@ -1631,6 +1888,15 @@ fn run_to_logged_baseline() -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserA
 
 fn run_to_fkey_baseline() -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
     let spec = fkey_two_clause_spec_state();
+    let harness = build_harness_from_spec(&spec, CompositionState::Composing);
+    let backend = ScenarioBackend::new(spec);
+    let history = Vec::new();
+    (harness, backend, history)
+}
+
+fn run_to_auto_clause(
+    spec: SimSpecState,
+) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
     let harness = build_harness_from_spec(&spec, CompositionState::Composing);
     let backend = ScenarioBackend::new(spec);
     let history = Vec::new();
@@ -1672,6 +1938,49 @@ pub(super) fn run_from_fkey_baseline(
         history.push(*op);
         apply_user_action(&mut harness, &mut backend, *op, &history);
         assert_harness_matches_spec(&harness, &backend.spec, &history);
+    }
+
+    (harness, backend, history)
+}
+
+fn run_from_auto_clause(
+    spec: SimSpecState,
+    extra_actions: &[HarnessUserAction],
+) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
+    let (mut harness, mut backend, mut history) = run_to_auto_clause(spec);
+    assert_harness_matches_spec(&harness, &backend.spec, &history);
+
+    for op in extra_actions {
+        history.push(*op);
+        apply_user_action(&mut harness, &mut backend, *op, &history);
+        assert_harness_matches_spec(&harness, &backend.spec, &history);
+    }
+
+    (harness, backend, history)
+}
+
+pub(super) fn run_from_auto_clause_ju(
+    extra_actions: &[HarnessUserAction],
+) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
+    run_from_auto_clause(auto_clause_ju_spec_state(), extra_actions)
+}
+
+pub(super) fn run_from_auto_clause_tyu(
+    extra_actions: &[HarnessUserAction],
+) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
+    run_from_auto_clause(auto_clause_tyu_spec_state(), extra_actions)
+}
+
+pub(super) fn run_from_auto_clause_preserved_suffix(
+    extra_actions: &[HarnessUserAction],
+) -> (ClauseHarness, ScenarioBackend, Vec<HarnessUserAction>) {
+    let (mut harness, mut backend, mut history) =
+        run_to_auto_clause(auto_clause_preserved_suffix_spec_state());
+    assert_harness_matches_spec(&harness, &backend.spec, &history);
+
+    for op in extra_actions {
+        history.push(*op);
+        apply_user_action(&mut harness, &mut backend, *op, &history);
     }
 
     (harness, backend, history)

--- a/crates/client/src/engine/full_width.rs
+++ b/crates/client/src/engine/full_width.rs
@@ -108,22 +108,23 @@ static HALF_FULL_AZOOKEY: LazyLock<HashMap<&'static str, &'static str>> = LazyLo
     ])
 });
 
-static HALF_FULL_CONFIGURABLE: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
-    let mut map = HALF_FULL_AZOOKEY.clone();
-    map.extend([
-        ("0", "０"),
-        ("1", "１"),
-        ("2", "２"),
-        ("3", "３"),
-        ("4", "４"),
-        ("5", "５"),
-        ("6", "６"),
-        ("7", "７"),
-        ("8", "８"),
-        ("9", "９"),
-    ]);
-    map
-});
+static HALF_FULL_CONFIGURABLE: LazyLock<HashMap<&'static str, &'static str>> =
+    LazyLock::new(|| {
+        let mut map = HALF_FULL_AZOOKEY.clone();
+        map.extend([
+            ("0", "０"),
+            ("1", "１"),
+            ("2", "２"),
+            ("3", "３"),
+            ("4", "４"),
+            ("5", "５"),
+            ("6", "６"),
+            ("7", "７"),
+            ("8", "８"),
+            ("9", "９"),
+        ]);
+        map
+    });
 
 static SYMBOL_FULLWIDTH_DEFAULTS: LazyLock<HashMap<&'static str, bool>> =
     LazyLock::new(|| HashMap::from(CHARACTER_WIDTH_SYMBOL_DEFAULTS));
@@ -237,7 +238,9 @@ pub fn convert_kana_symbol(
 
             let base = apply_basic_setting(&key, general)
                 .map(str::to_string)
-                .unwrap_or_else(|| legacy_fullwidth_or_half(&key, &character_width.symbol_fullwidth));
+                .unwrap_or_else(|| {
+                    legacy_fullwidth_or_half(&key, &character_width.symbol_fullwidth)
+                });
 
             apply_width_groups_with_source_key(&base, &key, groups)
         })
@@ -302,7 +305,9 @@ fn legacy_fullwidth_or_half(key: &str, symbol_fullwidth: &HashMap<String, bool>)
 }
 
 fn apply_width_groups(text: &str, groups: &CharacterWidthGroups) -> String {
-    text.chars().map(|c| apply_width_group_char(c, groups)).collect()
+    text.chars()
+        .map(|c| apply_width_group_char(c, groups))
+        .collect()
 }
 
 fn apply_width_groups_with_source_key(
@@ -565,6 +570,9 @@ mod tests {
         let mut config = default_character_width();
         config.groups.hash_group = WidthMode::Full;
 
-        assert_eq!(convert_kana_symbol("ˆ", &GeneralConfig::default(), &config, &[]), "＾");
+        assert_eq!(
+            convert_kana_symbol("ˆ", &GeneralConfig::default(), &config, &[]),
+            "＾"
+        );
     }
 }

--- a/crates/client/src/engine/user_action.rs
+++ b/crates/client/src/engine/user_action.rs
@@ -165,14 +165,14 @@ impl TryFrom<usize> for UserAction {
             0x77 => UserAction::Function(Function::Eight), // VK_F8
             0x78 => UserAction::Function(Function::Nine), // VK_F9
             0x79 => UserAction::Function(Function::Ten), // VK_F10
-            0x6A => UserAction::NumpadSymbol('*'), // VK_MULTIPLY
-            0x6B => UserAction::NumpadSymbol('+'), // VK_ADD
-            0x6C => UserAction::NumpadSymbol(','), // VK_SEPARATOR
-            0x6D => UserAction::NumpadSymbol('-'), // VK_SUBTRACT
-            0x6E => UserAction::NumpadSymbol('.'), // VK_DECIMAL
-            0x6F => UserAction::NumpadSymbol('/'), // VK_DIVIDE
-            0x16 => UserAction::InputModeOn,  // VK_IME_ON
-            0x1A => UserAction::InputModeOff, // VK_IME_OFF
+            0x6A => UserAction::NumpadSymbol('*'),       // VK_MULTIPLY
+            0x6B => UserAction::NumpadSymbol('+'),       // VK_ADD
+            0x6C => UserAction::NumpadSymbol(','),       // VK_SEPARATOR
+            0x6D => UserAction::NumpadSymbol('-'),       // VK_SUBTRACT
+            0x6E => UserAction::NumpadSymbol('.'),       // VK_DECIMAL
+            0x6F => UserAction::NumpadSymbol('/'),       // VK_DIVIDE
+            0x16 => UserAction::InputModeOn,             // VK_IME_ON
+            0x1A => UserAction::InputModeOff,            // VK_IME_OFF
 
             0xF3 | 0xF4 => UserAction::ToggleInputMode, // Zenkaku/Hankaku
 

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -35,6 +35,8 @@ private let fallbackDictionaryURL: URL = {
 let maxUserDictionaryEntryCount = 50
 let minInputCountForZenzaiCandidates = 4
 let minHiraganaCountForZenzaiCandidates = 2
+// Request exact-clause supplements only when boundary-matched candidates are sparse.
+let cursorPrefixExactClauseSupplementCandidateThreshold = 5
 let serverLogFileName = "server.log"
 
 private enum ServerLogLevel: Int {
@@ -278,6 +280,80 @@ private func clampedCorrespondingCount(
     min(composingText.input.count, max(0, rawCount))
 }
 
+private func inputCharacter(_ element: ComposingText.InputElement) -> Character? {
+    switch element.piece {
+    case .character(let character):
+        character
+    case .key(_, let input, _):
+        input
+    case .compositionSeparator:
+        nil
+    }
+}
+
+private func asciiLowercase(_ character: Character) -> Character? {
+    let scalars = String(character).unicodeScalars
+    guard scalars.count == 1, let scalar = scalars.first else {
+        return nil
+    }
+
+    let value = scalar.value
+    if (65...90).contains(value), let lowered = UnicodeScalar(value + 32) {
+        return Character(lowered)
+    }
+    if (97...122).contains(value) {
+        return character
+    }
+    return nil
+}
+
+private func isAsciiRomajiVowel(_ character: Character) -> Bool {
+    guard let lowered = asciiLowercase(character) else {
+        return false
+    }
+    switch lowered {
+    case "a", "i", "u", "e", "o":
+        return true
+    default:
+        return false
+    }
+}
+
+private func isAsciiRomajiConsonantExceptN(_ character: Character) -> Bool {
+    guard let lowered = asciiLowercase(character) else {
+        return false
+    }
+    return lowered != "n" && !isAsciiRomajiVowel(lowered)
+}
+
+private func adjustedCorrespondingCountForDelayedSingleN(
+    composingText: ComposingText,
+    rawCount: Int
+) -> Int {
+    let splitAt = clampedCorrespondingCount(composingText: composingText, rawCount: rawCount)
+    guard splitAt >= 2, splitAt < composingText.input.count else {
+        return splitAt
+    }
+
+    let previousElement = composingText.input[splitAt - 2]
+    let consumedElement = composingText.input[splitAt - 1]
+    let nextElement = composingText.input[splitAt]
+    guard previousElement.inputStyle != .direct,
+          consumedElement.inputStyle != .direct,
+          nextElement.inputStyle != .direct,
+          let previous = inputCharacter(previousElement),
+          asciiLowercase(previous) == "n",
+          let consumed = inputCharacter(consumedElement),
+          isAsciiRomajiConsonantExceptN(consumed),
+          let next = inputCharacter(nextElement),
+          isAsciiRomajiVowel(next)
+    else {
+        return splitAt
+    }
+
+    return splitAt - 1
+}
+
 @MainActor func resolveCandidateComposition(
     composingText: ComposingText,
     candidateComposingCount: ComposingCount
@@ -285,11 +361,24 @@ private func clampedCorrespondingCount(
     var remainingComposingText = composingText
     remainingComposingText.prefixComplete(composingCount: candidateComposingCount)
 
+    let rawCount = composingText.input.count - remainingComposingText.input.count
+    let correspondingCount = adjustedCorrespondingCountForDelayedSingleN(
+        composingText: composingText,
+        rawCount: rawCount
+    )
+    if correspondingCount != rawCount {
+        var adjustedRemainingComposingText = composingText
+        adjustedRemainingComposingText.prefixComplete(
+            composingCount: .inputCount(correspondingCount)
+        )
+        return (
+            correspondingCount: correspondingCount,
+            remainingConvertTarget: adjustedRemainingComposingText.convertTarget
+        )
+    }
+
     return (
-        correspondingCount: clampedCorrespondingCount(
-            composingText: composingText,
-            rawCount: composingText.input.count - remainingComposingText.input.count
-        ),
+        correspondingCount: correspondingCount,
         remainingConvertTarget: remainingComposingText.convertTarget
     )
 }
@@ -358,6 +447,116 @@ private func clampedCorrespondingCount(
     )
 }
 
+typealias CandidateDisplayResolution = (correspondingCount: Int, remainingConvertTarget: String)
+
+struct CursorPrefixCandidateResult {
+    let candidate: Candidate
+    let displayText: String
+}
+
+private struct CursorPrefixBoundaryCandidate {
+    let index: Int
+    let correspondingCount: Int
+    let score: Int
+}
+
+private let cursorPrefixClauseTerminalSuffixes = [
+    "ではない",
+    "じゃない",
+    "である",
+    "でした",
+    "だった",
+    "ました",
+    "ません",
+    "です",
+    "ます",
+    "ない",
+]
+
+private func candidateRubyBoundarySet(_ candidate: Candidate) -> Set<Int> {
+    var boundaries = Set<Int>()
+    var cursor = 0
+    for element in candidate.data {
+        cursor += element.ruby.count
+        boundaries.insert(cursor)
+    }
+    return boundaries
+}
+
+private func cursorPrefixTerminalPhraseBonus(prefixHiragana: String) -> Int {
+    cursorPrefixClauseTerminalSuffixes.contains { prefixHiragana.hasSuffix($0) } ? 120 : 0
+}
+
+private func cursorPrefixTokenBoundaryPenalty(
+    candidate: Candidate,
+    prefixSurfaceCount: Int
+) -> Int {
+    guard prefixSurfaceCount > 0,
+          prefixSurfaceCount < candidate.rubyCount
+    else {
+        return 0
+    }
+
+    return candidateRubyBoundarySet(candidate).contains(prefixSurfaceCount) ? 0 : 160
+}
+
+private func cursorPrefixBoundaryScore(
+    candidate: Candidate,
+    candidateIndex: Int,
+    resolution: CandidateDisplayResolution,
+    previewHiragana: String
+) -> Int {
+    let remainingCount = resolution.remainingConvertTarget.count
+    let prefixSurfaceCount = max(0, previewHiragana.count - remainingCount)
+    let prefixHiragana = String(previewHiragana.prefix(prefixSurfaceCount))
+    let terminalBonus = cursorPrefixTerminalPhraseBonus(prefixHiragana: prefixHiragana)
+    let tokenBoundaryPenalty = cursorPrefixTokenBoundaryPenalty(
+        candidate: candidate,
+        prefixSurfaceCount: prefixSurfaceCount
+    )
+
+    return resolution.correspondingCount * 4
+        + terminalBonus
+        - tokenBoundaryPenalty
+        - candidateIndex
+}
+
+private func preferCursorPrefixBoundary(
+    _ candidate: CursorPrefixBoundaryCandidate,
+    over current: CursorPrefixBoundaryCandidate?
+) -> Bool {
+    guard let current else {
+        return true
+    }
+    if candidate.score != current.score {
+        return candidate.score > current.score
+    }
+    if candidate.correspondingCount != current.correspondingCount {
+        return candidate.correspondingCount > current.correspondingCount
+    }
+    return candidate.index < current.index
+}
+
+@MainActor func resolveCandidateCompositionForDisplay(
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText,
+    candidateComposingCount: ComposingCount,
+    resolutionCache: inout [String: CandidateDisplayResolution]
+) -> CandidateDisplayResolution {
+    let cacheKey = String(describing: candidateComposingCount)
+    if let cached = resolutionCache[cacheKey] {
+        return cached
+    }
+
+    let resolved = resolveCandidateCompositionForDisplay(
+        originalComposingText: originalComposingText,
+        previewComposingText: previewComposingText,
+        candidateComposingCount: candidateComposingCount
+    )
+    resolutionCache[cacheKey] = resolved
+    return resolved
+}
+
 @MainActor private func debugLogResolvedCorrespondingCount(
     scope: String,
     candidateIndex: Int,
@@ -372,6 +571,189 @@ private func clampedCorrespondingCount(
         "DEBUG",
         "[\(scope)] mode=\(mode) candidate[\(candidateIndex + 1)/\(candidateTotal)] composingCount=\(candidateComposingCount) resolvedCorrespondingCount=\(resolvedCorrespondingCount) inputCount=\(inputCount)"
     )
+}
+
+@MainActor func cursorPrefixCandidateResults(
+    mainResults: [Candidate],
+    firstClauseResults: [Candidate],
+    exactClauseResults: [Candidate] = [],
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText,
+    previewHiragana: String
+) -> [Candidate] {
+    cursorPrefixCandidateDisplayResults(
+        mainResults: mainResults,
+        firstClauseResults: firstClauseResults,
+        exactClauseResults: exactClauseResults,
+        originalComposingText: originalComposingText,
+        previewComposingText: previewComposingText,
+        previewHiragana: previewHiragana
+    ).map(\.candidate)
+}
+
+@MainActor func cursorPrefixCandidateDisplayResults(
+    mainResults: [Candidate],
+    firstClauseResults: [Candidate],
+    exactClauseResults: [Candidate] = [],
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText,
+    previewHiragana: String
+) -> [CursorPrefixCandidateResult] {
+    var resolutionCache: [String: CandidateDisplayResolution] = [:]
+    let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
+        firstClauseResults: firstClauseResults,
+        originalComposingText: originalComposingText,
+        previewComposingText: previewComposingText,
+        resolutionCache: &resolutionCache
+    )
+    return cursorPrefixCandidateDisplayResults(
+        mainResults: mainResults,
+        firstClauseResults: firstClauseResults,
+        exactClauseResults: exactClauseResults,
+        firstClauseCorrespondingCount: firstClauseCorrespondingCount,
+        originalComposingText: originalComposingText,
+        previewComposingText: previewComposingText,
+        previewHiragana: previewHiragana,
+        resolutionCache: &resolutionCache
+    )
+}
+
+@MainActor func cursorPrefixCandidateDisplayResults(
+    mainResults: [Candidate],
+    firstClauseResults: [Candidate],
+    exactClauseResults: [Candidate] = [],
+    firstClauseCorrespondingCount: Int?,
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText,
+    previewHiragana: String,
+    resolutionCache: inout [String: CandidateDisplayResolution]
+) -> [CursorPrefixCandidateResult] {
+    guard let firstClauseCorrespondingCount else {
+        return mainResults.map {
+            CursorPrefixCandidateResult(
+                candidate: $0,
+                displayText: constructCandidateString(candidate: $0, hiragana: previewHiragana)
+            )
+        }
+    }
+
+    var seenTexts = Set<String>()
+    var results: [CursorPrefixCandidateResult] = []
+
+    func appendIfNeeded(_ candidate: Candidate) {
+        let text = constructCandidateString(candidate: candidate, hiragana: previewHiragana)
+        guard seenTexts.insert(text).inserted else {
+            return
+        }
+        results.append(CursorPrefixCandidateResult(candidate: candidate, displayText: text))
+    }
+
+    func matchesFirstClauseBoundary(_ candidate: Candidate) -> Bool {
+        let correspondingCount = resolveCandidateCompositionForDisplay(
+            originalComposingText: originalComposingText,
+            previewComposingText: previewComposingText,
+            candidateComposingCount: candidate.composingCount,
+            resolutionCache: &resolutionCache
+        ).correspondingCount
+        return correspondingCount == firstClauseCorrespondingCount
+    }
+
+    for candidate in firstClauseResults {
+        guard matchesFirstClauseBoundary(candidate) else {
+            continue
+        }
+        appendIfNeeded(candidate)
+    }
+
+    for candidate in mainResults {
+        guard matchesFirstClauseBoundary(candidate) else {
+            continue
+        }
+        appendIfNeeded(candidate)
+    }
+
+    for candidate in exactClauseResults {
+        guard matchesFirstClauseBoundary(candidate) else {
+            continue
+        }
+        appendIfNeeded(candidate)
+    }
+
+    return results
+}
+
+@MainActor func cursorPrefixFirstClauseCorrespondingCount(
+    firstClauseResults: [Candidate],
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText
+) -> Int? {
+    var resolutionCache: [String: CandidateDisplayResolution] = [:]
+    return cursorPrefixFirstClauseCorrespondingCount(
+        firstClauseResults: firstClauseResults,
+        originalComposingText: originalComposingText,
+        previewComposingText: previewComposingText,
+        resolutionCache: &resolutionCache
+    )
+}
+
+@MainActor func cursorPrefixFirstClauseCorrespondingCount(
+    firstClauseResults: [Candidate],
+    originalComposingText: ComposingText,
+    previewComposingText: ComposingText,
+    resolutionCache: inout [String: CandidateDisplayResolution]
+) -> Int? {
+    let inputCount = originalComposingText.input.count
+    var splitBoundary: CursorPrefixBoundaryCandidate?
+    var fallbackBoundary: CursorPrefixBoundaryCandidate?
+
+    for (index, candidate) in firstClauseResults.enumerated() {
+        let resolution = resolveCandidateCompositionForDisplay(
+            originalComposingText: originalComposingText,
+            previewComposingText: previewComposingText,
+            candidateComposingCount: candidate.composingCount,
+            resolutionCache: &resolutionCache
+        )
+        guard resolution.correspondingCount > 0 else {
+            continue
+        }
+
+        let boundary = CursorPrefixBoundaryCandidate(
+            index: index,
+            correspondingCount: resolution.correspondingCount,
+            score: cursorPrefixBoundaryScore(
+                candidate: candidate,
+                candidateIndex: index,
+                resolution: resolution,
+                previewHiragana: previewComposingText.convertTarget
+            )
+        )
+
+        if resolution.correspondingCount < inputCount,
+           preferCursorPrefixBoundary(boundary, over: splitBoundary)
+        {
+            splitBoundary = boundary
+        }
+        if preferCursorPrefixBoundary(boundary, over: fallbackBoundary) {
+            fallbackBoundary = boundary
+        }
+    }
+
+    return splitBoundary?.correspondingCount ?? fallbackBoundary?.correspondingCount
+}
+
+@MainActor func makeCursorPrefixExactClauseComposingText(
+    prefixComposingText: ComposingText,
+    correspondingCount: Int
+) -> ComposingText {
+    var clauseComposingText = ComposingText()
+    let count = clampedCorrespondingCount(
+        composingText: prefixComposingText,
+        rawCount: correspondingCount
+    )
+    clauseComposingText.insertAtCursorPosition(
+        Array(prefixComposingText.input.prefix(count))
+    )
+    return clauseComposingText
 }
 
 @MainActor func getOptions(context: String = "") -> ConvertRequestOptions {
@@ -830,27 +1212,72 @@ func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutab
     serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates begin useZenzai=\(useZenzai) syntheticEndOfText=\(previewState.syntheticEndOfText)")
     let requestStart = ProcessInfo.processInfo.systemUptime
     let converted = converter.requestCandidates(previewPrefixComposingText, options: options)
+    var cursorPrefixResolutionCache: [String: CandidateDisplayResolution] = [:]
+    let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
+        firstClauseResults: converted.firstClauseResults,
+        originalComposingText: prefixComposingText,
+        previewComposingText: previewPrefixComposingText,
+        resolutionCache: &cursorPrefixResolutionCache
+    )
+    let preliminaryCursorPrefixResults = cursorPrefixCandidateDisplayResults(
+        mainResults: converted.mainResults,
+        firstClauseResults: converted.firstClauseResults,
+        firstClauseCorrespondingCount: firstClauseCorrespondingCount,
+        originalComposingText: prefixComposingText,
+        previewComposingText: previewPrefixComposingText,
+        previewHiragana: previewPrefixHiragana,
+        resolutionCache: &cursorPrefixResolutionCache
+    )
+    let shouldRequestExactClauseResults = preliminaryCursorPrefixResults.count < cursorPrefixExactClauseSupplementCandidateThreshold
+    var exactClauseResults: [Candidate] = []
+    if let firstClauseCorrespondingCount, shouldRequestExactClauseResults {
+        let exactClauseComposingText = makeCursorPrefixExactClauseComposingText(
+            prefixComposingText: prefixComposingText,
+            correspondingCount: firstClauseCorrespondingCount
+        )
+        let exactClausePreviewState = makeCandidatePreviewComposingText(
+            from: exactClauseComposingText
+        )
+        exactClauseResults = converter.requestCandidates(
+            exactClausePreviewState.composingText,
+            options: options
+        ).mainResults
+    }
+    let cursorPrefixResults = exactClauseResults.isEmpty
+        ? preliminaryCursorPrefixResults
+        : cursorPrefixCandidateDisplayResults(
+            mainResults: converted.mainResults,
+            firstClauseResults: converted.firstClauseResults,
+            exactClauseResults: exactClauseResults,
+            firstClauseCorrespondingCount: firstClauseCorrespondingCount,
+            originalComposingText: prefixComposingText,
+            previewComposingText: previewPrefixComposingText,
+            previewHiragana: previewPrefixHiragana,
+            resolutionCache: &cursorPrefixResolutionCache
+        )
     let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
-    serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(converted.mainResults.count) elapsed_ms=\(requestMs)")
+    serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(cursorPrefixResults.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) exactClauseCandidateCount=\(exactClauseResults.count) elapsed_ms=\(requestMs)")
     var result: [FFICandidate] = []
 
-    for i in 0..<converted.mainResults.count {
-        let candidate = converted.mainResults[i]
-        serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)/\(converted.mainResults.count)] start")
+    for i in 0..<cursorPrefixResults.count {
+        let cursorPrefixResult = cursorPrefixResults[i]
+        let candidate = cursorPrefixResult.candidate
+        serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)/\(cursorPrefixResults.count)] start")
 
-        let text = strdup(constructCandidateString(candidate: candidate, hiragana: previewPrefixHiragana))
+        let text = strdup(cursorPrefixResult.displayText)
         serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)] textReady")
         let hiragana = strdup(previewPrefixHiragana + suffixAfterCursor)
         let resolvedCandidate = resolveCandidateCompositionForDisplay(
             originalComposingText: prefixComposingText,
             previewComposingText: previewPrefixComposingText,
-            candidateComposingCount: candidate.composingCount
+            candidateComposingCount: candidate.composingCount,
+            resolutionCache: &cursorPrefixResolutionCache
         )
         let correspondingCount = resolvedCandidate.correspondingCount
         debugLogResolvedCorrespondingCount(
             scope: "GetComposedTextForCursorPrefix",
             candidateIndex: i,
-            candidateTotal: converted.mainResults.count,
+            candidateTotal: cursorPrefixResults.count,
             candidateComposingCount: candidate.composingCount,
             resolvedCorrespondingCount: correspondingCount,
             inputCount: prefixComposingText.input.count,

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -431,7 +431,7 @@ private func adjustedCorrespondingCountForDelayedSingleN(
     originalComposingText: ComposingText,
     previewComposingText: ComposingText,
     candidateComposingCount: ComposingCount
-) -> (correspondingCount: Int, remainingConvertTarget: String) {
+) -> CandidateDisplayResolution {
     let originalResolution = resolveCandidateComposition(
         composingText: originalComposingText,
         candidateComposingCount: candidateComposingCount
@@ -443,11 +443,16 @@ private func adjustedCorrespondingCountForDelayedSingleN(
 
     return (
         correspondingCount: originalResolution.correspondingCount,
-        remainingConvertTarget: previewResolution.remainingConvertTarget
+        remainingConvertTarget: previewResolution.remainingConvertTarget,
+        remainingConvertTargetCount: previewResolution.remainingConvertTarget.count
     )
 }
 
-typealias CandidateDisplayResolution = (correspondingCount: Int, remainingConvertTarget: String)
+typealias CandidateDisplayResolution = (
+    correspondingCount: Int,
+    remainingConvertTarget: String,
+    remainingConvertTargetCount: Int
+)
 
 struct CursorPrefixCandidateResult {
     let candidate: Candidate
@@ -458,6 +463,36 @@ private struct CursorPrefixBoundaryCandidate {
     let index: Int
     let correspondingCount: Int
     let score: Int
+}
+
+private struct CursorPrefixBoundaryScoringContext {
+    let previewHiragana: String
+    let previewHiraganaBoundaries: [String.Index]
+
+    init(previewHiragana: String) {
+        self.previewHiragana = previewHiragana
+
+        var boundaries = [String.Index]()
+        boundaries.append(previewHiragana.startIndex)
+
+        var index = previewHiragana.startIndex
+        while index < previewHiragana.endIndex {
+            index = previewHiragana.index(after: index)
+            boundaries.append(index)
+        }
+        self.previewHiraganaBoundaries = boundaries
+    }
+
+    var previewHiraganaCount: Int {
+        max(0, previewHiraganaBoundaries.count - 1)
+    }
+
+    func boundaryIndex(afterCharacters count: Int) -> String.Index? {
+        guard count >= 0, count < previewHiraganaBoundaries.count else {
+            return nil
+        }
+        return previewHiraganaBoundaries[count]
+    }
 }
 
 private let cursorPrefixClauseTerminalSuffixes = [
@@ -473,18 +508,46 @@ private let cursorPrefixClauseTerminalSuffixes = [
     "ない",
 ]
 
-private func candidateRubyBoundarySet(_ candidate: Candidate) -> Set<Int> {
-    var boundaries = Set<Int>()
+private func cursorPrefixHasCandidateRubyBoundary(
+    candidate: Candidate,
+    prefixSurfaceCount: Int
+) -> Bool {
     var cursor = 0
     for element in candidate.data {
         cursor += element.ruby.count
-        boundaries.insert(cursor)
+        if cursor == prefixSurfaceCount {
+            return true
+        }
+        if cursor > prefixSurfaceCount {
+            return false
+        }
     }
-    return boundaries
+    return false
 }
 
-private func cursorPrefixTerminalPhraseBonus(prefixHiragana: String) -> Int {
-    cursorPrefixClauseTerminalSuffixes.contains { prefixHiragana.hasSuffix($0) } ? 120 : 0
+private func cursorPrefixTerminalPhraseBonus(
+    context: CursorPrefixBoundaryScoringContext,
+    prefixSurfaceCount: Int
+) -> Int {
+    guard let prefixEndIndex = context.boundaryIndex(afterCharacters: prefixSurfaceCount) else {
+        return 0
+    }
+
+    for suffix in cursorPrefixClauseTerminalSuffixes {
+        let suffixCount = suffix.count
+        guard prefixSurfaceCount >= suffixCount else {
+            continue
+        }
+
+        let suffixStartIndex = context.previewHiragana.index(
+            prefixEndIndex,
+            offsetBy: -suffixCount
+        )
+        if context.previewHiragana[suffixStartIndex..<prefixEndIndex].elementsEqual(suffix) {
+            return 120
+        }
+    }
+    return 0
 }
 
 private func cursorPrefixTokenBoundaryPenalty(
@@ -497,19 +560,24 @@ private func cursorPrefixTokenBoundaryPenalty(
         return 0
     }
 
-    return candidateRubyBoundarySet(candidate).contains(prefixSurfaceCount) ? 0 : 160
+    return cursorPrefixHasCandidateRubyBoundary(
+        candidate: candidate,
+        prefixSurfaceCount: prefixSurfaceCount
+    ) ? 0 : 160
 }
 
 private func cursorPrefixBoundaryScore(
     candidate: Candidate,
     candidateIndex: Int,
     resolution: CandidateDisplayResolution,
-    previewHiragana: String
+    context: CursorPrefixBoundaryScoringContext
 ) -> Int {
-    let remainingCount = resolution.remainingConvertTarget.count
-    let prefixSurfaceCount = max(0, previewHiragana.count - remainingCount)
-    let prefixHiragana = String(previewHiragana.prefix(prefixSurfaceCount))
-    let terminalBonus = cursorPrefixTerminalPhraseBonus(prefixHiragana: prefixHiragana)
+    let remainingCount = resolution.remainingConvertTargetCount
+    let prefixSurfaceCount = max(0, context.previewHiraganaCount - remainingCount)
+    let terminalBonus = cursorPrefixTerminalPhraseBonus(
+        context: context,
+        prefixSurfaceCount: prefixSurfaceCount
+    )
     let tokenBoundaryPenalty = cursorPrefixTokenBoundaryPenalty(
         candidate: candidate,
         prefixSurfaceCount: prefixSurfaceCount
@@ -703,6 +771,9 @@ private func preferCursorPrefixBoundary(
     resolutionCache: inout [String: CandidateDisplayResolution]
 ) -> Int? {
     let inputCount = originalComposingText.input.count
+    let scoringContext = CursorPrefixBoundaryScoringContext(
+        previewHiragana: previewComposingText.convertTarget
+    )
     var splitBoundary: CursorPrefixBoundaryCandidate?
     var fallbackBoundary: CursorPrefixBoundaryCandidate?
 
@@ -724,7 +795,7 @@ private func preferCursorPrefixBoundary(
                 candidate: candidate,
                 candidateIndex: index,
                 resolution: resolution,
-                previewHiragana: previewComposingText.convertTarget
+                context: scoringContext
             )
         )
 

--- a/server-swift/Sources/azookey-server/romaji_table_compiler.swift
+++ b/server-swift/Sources/azookey-server/romaji_table_compiler.swift
@@ -26,9 +26,16 @@ func normalizeRomajiCell(_ value: String) -> String {
 }
 
 private func escapeInputTableToken(_ value: String) -> String {
-    value
-        .replacingOccurrences(of: "{", with: "{lbracket}")
-        .replacingOccurrences(of: "}", with: "{rbracket}")
+    value.map { character in
+        switch character {
+        case "{":
+            "{lbracket}"
+        case "}":
+            "{rbracket}"
+        default:
+            String(character)
+        }
+    }.joined()
 }
 
 func buildCustomRomajiTableEntries(rows: [RomajiTableRow]) -> [(key: String, value: String)] {

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -55,6 +55,28 @@ private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions 
     )
 }
 
+private func testCandidate(
+    word: String,
+    ruby: String,
+    composingCount: ComposingCount
+) -> Candidate {
+    Candidate(
+        text: word,
+        value: -1,
+        composingCount: composingCount,
+        lastMid: MIDData.一般.mid,
+        data: [
+            DicdataElement(
+                word: word,
+                ruby: ruby,
+                cid: CIDData.一般名詞.cid,
+                mid: MIDData.一般.mid,
+                value: -1
+            )
+        ]
+    )
+}
+
 @Test func supportsNextInputCarryForTsuRules() async throws {
     let map = tableMap([
         row("tt", "っ", "t"),
@@ -259,6 +281,8 @@ private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions 
 
 @Test func trailingNPreviewSupportsCustomRomajiTable() async throws {
     let rows = [
+        row("ka", "か"),
+        row("ge", "げ"),
         row("n", "ん"),
         row("na", "な"),
         row("nn", "ん"),
@@ -375,6 +399,20 @@ private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions 
     #expect(resolved.remainingConvertTarget == "ん")
 }
 
+@Test func singleNBoundaryKeepsFollowingConsonantInRemainingText() async throws {
+    let resolved = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("iikagentouitusiro", inputStyle: .roman2kana)
+        return resolveCandidateComposition(
+            composingText: source,
+            candidateComposingCount: .inputCount(8)
+        )
+    }
+
+    #expect(resolved.correspondingCount == 7)
+    #expect(resolved.remainingConvertTarget == "とういつしろ")
+}
+
 @Test func trailingNPreviewForCursorPrefixOnlyAppliesAtCompositionEnd() async throws {
     let result = await MainActor.run {
         var source = ComposingText()
@@ -417,4 +455,315 @@ private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions 
 
     #expect(preview.syntheticEndOfText == false)
     #expect(preview.composingText.convertTarget == "q")
+}
+
+@Test func cursorPrefixCandidatesSupplementFirstClauseWithMainResultsForSameBoundary() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("aruteidonagai", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let firstClause = testCandidate(
+            word: "ある程度",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        let hiragana = testCandidate(
+            word: "あるていど",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        let katakana = testCandidate(
+            word: "アルテイド",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        let fullSentence = Candidate(
+            text: "ある程度長い",
+            value: -1,
+            composingCount: .inputCount(13),
+            lastMid: MIDData.一般.mid,
+            data: [
+                DicdataElement(
+                    word: "ある程度長い",
+                    ruby: "あるていどながい",
+                    cid: CIDData.一般名詞.cid,
+                    mid: MIDData.一般.mid,
+                    value: -1
+                )
+            ]
+        )
+        return cursorPrefixCandidateResults(
+            mainResults: [fullSentence, hiragana, katakana],
+            firstClauseResults: [firstClause],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map { constructCandidateString(candidate: $0, hiragana: preview.convertTarget) }
+    }
+
+    #expect(resultTexts == ["ある程度", "あるていど", "アルテイド"])
+}
+
+@Test func cursorPrefixCandidatesDropFirstClauseResultsForDifferentBoundary() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("iikagentouitusiro", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let firstClause = testCandidate(
+            word: "いい加減",
+            ruby: "いいかげん",
+            composingCount: .inputCount(7)
+        )
+        let tooShort = testCandidate(
+            word: "いい",
+            ruby: "いい",
+            composingCount: .inputCount(2)
+        )
+        let hiragana = testCandidate(
+            word: "いいかげん",
+            ruby: "いいかげん",
+            composingCount: .inputCount(7)
+        )
+        return cursorPrefixCandidateResults(
+            mainResults: [],
+            firstClauseResults: [firstClause, tooShort, hiragana],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map { constructCandidateString(candidate: $0, hiragana: preview.convertTarget) }
+    }
+
+    #expect(resultTexts == ["いい加減", "いいかげん"])
+}
+
+@Test func cursorPrefixCandidatesUseLongestFirstClauseBoundaryWhenShorterCandidateRanksFirst() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("iikagentouitusiro", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let tooShort = testCandidate(
+            word: "いい",
+            ruby: "いい",
+            composingCount: .inputCount(2)
+        )
+        let firstClause = testCandidate(
+            word: "いい加減",
+            ruby: "いいかげん",
+            composingCount: .inputCount(7)
+        )
+        let hiragana = testCandidate(
+            word: "いいかげん",
+            ruby: "いいかげん",
+            composingCount: .inputCount(7)
+        )
+        return cursorPrefixCandidateResults(
+            mainResults: [],
+            firstClauseResults: [tooShort, firstClause, hiragana],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map { constructCandidateString(candidate: $0, hiragana: preview.convertTarget) }
+    }
+
+    #expect(resultTexts == ["いい加減", "いいかげん"])
+}
+
+@Test func cursorPrefixCandidatesPreferClauseTerminalBoundaryOverLongerNounPrefix() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("wagahaihanekodearunamaehamadanai", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let badLongBoundary = Candidate(
+            text: "吾輩は猫である名",
+            value: -1,
+            composingCount: .inputCount(20),
+            lastMid: MIDData.一般.mid,
+            data: [
+                DicdataElement(
+                    word: "吾輩は猫である名",
+                    ruby: "わがはいはねこであるな",
+                    cid: CIDData.一般名詞.cid,
+                    mid: MIDData.一般.mid,
+                    value: -1
+                )
+            ]
+        )
+        let sentenceBoundary = Candidate(
+            text: "吾輩は猫である",
+            value: -1,
+            composingCount: .inputCount(18),
+            lastMid: MIDData.一般.mid,
+            data: [
+                DicdataElement(
+                    word: "吾輩は猫である",
+                    ruby: "わがはいはねこである",
+                    cid: CIDData.一般名詞.cid,
+                    mid: MIDData.一般.mid,
+                    value: -1
+                )
+            ]
+        )
+        return cursorPrefixCandidateDisplayResults(
+            mainResults: [],
+            firstClauseResults: [badLongBoundary, sentenceBoundary],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map(\.displayText)
+    }
+
+    #expect(resultTexts == ["吾輩は猫である"])
+}
+
+@Test func cursorPrefixCandidatesPreferProperBoundaryOverFullPhraseCandidate() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("touitusiro", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let fullPhrase = testCandidate(
+            word: "統一しろ",
+            ruby: "とういつしろ",
+            composingCount: .inputCount(10)
+        )
+        let firstClause = testCandidate(
+            word: "統一",
+            ruby: "とういつ",
+            composingCount: .inputCount(6)
+        )
+        let hiragana = testCandidate(
+            word: "とういつ",
+            ruby: "とういつ",
+            composingCount: .inputCount(6)
+        )
+        let katakana = testCandidate(
+            word: "トウイツ",
+            ruby: "とういつ",
+            composingCount: .inputCount(6)
+        )
+        return cursorPrefixCandidateDisplayResults(
+            mainResults: [fullPhrase],
+            firstClauseResults: [fullPhrase, firstClause],
+            exactClauseResults: [hiragana, katakana],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map(\.displayText)
+    }
+
+    #expect(resultTexts == ["統一", "とういつ", "トウイツ"])
+}
+
+@Test func cursorPrefixCandidatesSupplementWithExactClauseResultsWhenMainResultsLackSameBoundary() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("aruteidonagaibunsetsudemo", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let firstClause = testCandidate(
+            word: "ある程度",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        let fullSentence = Candidate(
+            text: "ある程度長い文節でも",
+            value: -1,
+            composingCount: .inputCount(25),
+            lastMid: MIDData.一般.mid,
+            data: [
+                DicdataElement(
+                    word: "ある程度長い文節でも",
+                    ruby: "あるていどながいぶんせつでも",
+                    cid: CIDData.一般名詞.cid,
+                    mid: MIDData.一般.mid,
+                    value: -1
+                )
+            ]
+        )
+        let hiragana = testCandidate(
+            word: "あるていど",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        let katakana = testCandidate(
+            word: "アルテイド",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        return cursorPrefixCandidateResults(
+            mainResults: [fullSentence],
+            firstClauseResults: [firstClause],
+            exactClauseResults: [hiragana, katakana],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map { constructCandidateString(candidate: $0, hiragana: preview.convertTarget) }
+    }
+
+    #expect(resultTexts == ["ある程度", "あるていど", "アルテイド"])
+}
+
+@Test func cursorPrefixCandidatesSupplementParticleClauseWithExactClauseResults() async throws {
+    let resultTexts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("bunsetsudemofukusuunibunkatsusareru", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let firstClause = testCandidate(
+            word: "文節でも",
+            ruby: "ぶんせつでも",
+            composingCount: .inputCount(12)
+        )
+        let alternative = testCandidate(
+            word: "分節でも",
+            ruby: "ぶんせつでも",
+            composingCount: .inputCount(12)
+        )
+        let hiragana = testCandidate(
+            word: "ぶんせつでも",
+            ruby: "ぶんせつでも",
+            composingCount: .inputCount(12)
+        )
+        let katakana = testCandidate(
+            word: "ブンセツデモ",
+            ruby: "ぶんせつでも",
+            composingCount: .inputCount(12)
+        )
+        let fullSentence = Candidate(
+            text: "文節でも複数に分割される",
+            value: -1,
+            composingCount: .inputCount(35),
+            lastMid: MIDData.一般.mid,
+            data: [
+                DicdataElement(
+                    word: "文節でも複数に分割される",
+                    ruby: "ぶんせつでもふくすうにぶんかつされる",
+                    cid: CIDData.一般名詞.cid,
+                    mid: MIDData.一般.mid,
+                    value: -1
+                )
+            ]
+        )
+        return cursorPrefixCandidateResults(
+            mainResults: [fullSentence],
+            firstClauseResults: [firstClause, alternative],
+            exactClauseResults: [firstClause, alternative, hiragana, katakana],
+            originalComposingText: source,
+            previewComposingText: preview,
+            previewHiragana: preview.convertTarget
+        ).map { constructCandidateString(candidate: $0, hiragana: preview.convertTarget) }
+    }
+
+    #expect(resultTexts == ["文節でも", "分節でも", "ぶんせつでも", "ブンセツデモ"])
+}
+
+@Test func cursorPrefixExactClauseComposingTextPreservesSelectedClauseInput() async throws {
+    let clause = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("aruteidonagaibunsetsudemo", inputStyle: .roman2kana)
+        return makeCursorPrefixExactClauseComposingText(
+            prefixComposingText: source,
+            correspondingCount: 8
+        )
+    }
+
+    #expect(clause.convertTarget == "あるていど")
+    #expect(clause.input.count == 8)
 }


### PR DESCRIPTION
## Summary
- `Composition` に直積みしていた文節操作を `ClauseState` / `ClauseCommand` ベースの reducer に切り出しました。
- 初回 `← / →` で自動文節分割を開始し、以後は文節単位移動・境界調整・選択保持・確定を reducer 経由で扱うようにしました。
- cursor-prefix の文節候補品質を改善し、既存候補列の軽量スコアリングだけで「吾輩は猫である名 / 前はまだない」のような不自然な境界を避けやすくしました。

## Background
- Closes #32
- Closes #50
- PR #39 の `Composition` 直積み実装はそのまま採らず、文節操作の状態遷移を分離したうえで自動文節分割を実装します。
- リアルタイム入力経路のため、分割品質改善では新しい重い候補生成経路を追加せず、既存の cursor-prefix candidates を再評価する範囲に留めています。

## Changes
- client / composition
  - `crates/client/src/engine/composition/clause_state.rs` を追加
  - `ClauseState` / `ClauseCommand` / transition input を導入し、文節列・future 文節・split group・選択候補の更新を reducer に集約
  - `Composition` 側は TSF / IPC / UI 同期の driver として、backend 呼び出し結果を reducer に渡して write-back する構造へ整理
  - `EnsureClauseNavigationReady` を追加し、初回 `→` は auto split のみ、初回 `←` は auto split 後に最後の文節へ移動する挙動を実装
  - `Enter` は clause navigation active 時に composition 全体確定、既存の `CommitAndNextClause` / `CommitFirstClause` は互換動作を維持
- client / regression
  - single-n suffix 復元、F-key 表示維持、選択 index clamp、non-progress backend guard を reducer 周辺の invariant として回帰テスト化
  - `iikagentouitusiro` / `iikagenntouitusiro` の single-n boundary regression を追加
  - auto split 後の future 文節候補が 1 件に潰れる問題の回帰テストを追加
- server-swift
  - cursor-prefix candidate の display result を再利用し、FFI candidate の text / subtext / corresponding_count を安定化
  - exact-clause supplementation を候補不足時だけ走らせるように整理
  - cursor-prefix 境界選択に軽量スコアリングを追加
    - 文末らしい suffix を加点
    - candidate ruby token の途中で切れる境界を減点
    - 追加の `requestCandidates` は行わず、計算量は候補数 x 候補内 token 数の線形範囲

## Verification
- [x] Windows 実機確認
  - ユーザー確認済み
- [x] ローカル Windows VM test（client composition）
  - `.local/vm_test_client_composition.sh feature/issue-32-clause-state-reducer composition skip`
  - `93 passed`
  - log: `.local/logs/vm-client-test-20260517-122252.log`
- [x] ローカル Windows VM test（server-swift cursor-prefix）
  - `ALLOW_DIRTY_WORKTREE=1 SWIFT_VENDOR_REPO_URL=https://github.com/batao9/AzooKeyKanaKanjiConverter SWIFT_VENDOR_REVISION=56268957b81b004ca8231ffc3491a4af684d0e20 SWIFT_VENDOR_CACHE_DIR="$PWD/.local/cache/batao9-56268957/AzooKeyKanaKanjiConverter" bash .local/vm_test_client_composition.sh feature/issue-32-clause-state-reducer skip cursorPrefix`
  - `8 tests passed`
  - log: `.local/logs/vm-client-test-20260517-174130.log`
- [x] ローカル Windows VM build 成功
  - `.local/vm_build_master.sh feature/issue-32-clause-state-reducer`
  - artifact: `.local/artifacts/azookey-setup-feature_issue-32-clause-state-reducer-20260517-180859.exe`
  - sha256: `6805f7050db384de673f9a6ad2324623e438392c37c0dc4af9d7a5c9b5b8818c`
- [x] ローカル Windows VM install 成功
  - `.local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-feature_issue-32-clause-state-reducer-20260517-180859.exe`
  - install log: `.local/logs/win11-install-20260517-190051.log`
- [x] 差分チェック
  - `git diff --check`
- [ ] GitHub Actions build 成功
  - run: 未実行

## Checklist
- [ ] CI run URL と結果を記載した
- [x] VM / 実機確認結果を記載した
- [x] 影響範囲を確認した
- [x] リアルタイム入力経路に新しい重い候補生成を追加していないことを確認した
