### PR TITLE
fix(server): free Swift FFI allocations

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -124,7 +124,81 @@ unsafe extern "C" {
     fn HasActiveComposition() -> bool;
     fn GetComposedText(lengthPtr: *mut c_int) -> *mut *mut FFICandidate;
     fn GetComposedTextForCursorPrefix(lengthPtr: *mut c_int) -> *mut *mut FFICandidate;
+    fn FreeCString(ptr: *mut c_char);
+    fn FreeCandidateList(ptr: *mut *mut FFICandidate, length: c_int);
     fn LoadConfig();
+}
+
+struct OwnedFfiString {
+    ptr: *mut c_char,
+}
+
+impl OwnedFfiString {
+    unsafe fn from_raw(scope: &str, ptr: *mut c_char) -> Result<Self, String> {
+        if ptr.is_null() {
+            return Err(format!("[{scope}] Swift FFI returned null pointer"));
+        }
+
+        Ok(Self { ptr })
+    }
+
+    fn to_string_lossy(&self) -> String {
+        unsafe { CStr::from_ptr(self.ptr as *const c_char) }
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+impl Drop for OwnedFfiString {
+    fn drop(&mut self) {
+        unsafe {
+            FreeCString(self.ptr);
+        }
+    }
+}
+
+struct OwnedFfiCandidates {
+    ptr: *mut *mut FFICandidate,
+    length: c_int,
+}
+
+impl OwnedFfiCandidates {
+    unsafe fn from_raw(
+        scope: &str,
+        ptr: *mut *mut FFICandidate,
+        length: c_int,
+    ) -> Result<Self, String> {
+        if length < 0 {
+            if !ptr.is_null() {
+                FreeCandidateList(ptr, 0);
+            }
+            return Err(format!("[{scope}] invalid negative length: {length}"));
+        }
+
+        if length > 0 && ptr.is_null() {
+            return Err(format!(
+                "[{scope}] null candidate list pointer (length={length})"
+            ));
+        }
+
+        Ok(Self { ptr, length })
+    }
+
+    fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    unsafe fn candidate_ptr(&self, index: usize) -> *mut FFICandidate {
+        *self.ptr.add(index)
+    }
+}
+
+impl Drop for OwnedFfiCandidates {
+    fn drop(&mut self) {
+        unsafe {
+            FreeCandidateList(self.ptr, self.length);
+        }
+    }
 }
 
 fn next_request_id() -> u64 {
@@ -236,15 +310,8 @@ fn cstring_from_input(scope: &str, value: &str) -> Result<CString, String> {
 }
 
 fn ffi_text_result(scope: &str, result: *mut c_char) -> Result<String, String> {
-    if result.is_null() {
-        return Err(format!("[{scope}] Swift FFI returned null pointer"));
-    }
-
-    let text = unsafe { CStr::from_ptr(result as *const c_char) }
-        .to_string_lossy()
-        .into_owned();
-
-    Ok(text)
+    let result = unsafe { OwnedFfiString::from_raw(scope, result)? };
+    Ok(result.to_string_lossy())
 }
 
 fn i8_offset_from_i32(scope: &str, raw: i32) -> Result<i8, Status> {
@@ -366,93 +433,85 @@ fn update_active_composition_state(text: &str) {
 }
 
 fn get_composed_text(use_cursor_prefix: bool) -> Result<ComposedText, String> {
-    unsafe {
-        let mut length: c_int = 0;
-        let result = if use_cursor_prefix {
+    let mut length: c_int = 0;
+    let result = unsafe {
+        if use_cursor_prefix {
             GetComposedTextForCursorPrefix(&mut length)
         } else {
             GetComposedText(&mut length)
+        }
+    };
+    let call_name = if use_cursor_prefix {
+        "GetComposedTextForCursorPrefix"
+    } else {
+        "GetComposedText"
+    };
+    let candidates = unsafe { OwnedFfiCandidates::from_raw(call_name, result, length)? };
+    let length = candidates.len();
+
+    let mut suggestions = Vec::with_capacity(length);
+    let mut hiragana = None;
+    log_event_lazy!(
+        ServerLogLevel::Debug,
+        "[{call_name}] candidate_count={length}"
+    );
+
+    for index in 0..length {
+        let candidate_ptr = unsafe { candidates.candidate_ptr(index) };
+        if candidate_ptr.is_null() {
+            log_event(
+                ServerLogLevel::Warn,
+                &format!("[{call_name}] candidate[{index}] is null and skipped"),
+            );
+            continue;
+        }
+
+        let candidate = unsafe { (*candidate_ptr).clone() };
+        if candidate.text.is_null() || candidate.subtext.is_null() {
+            log_event(
+                ServerLogLevel::Warn,
+                &format!(
+                    "[{call_name}] candidate[{index}] has null text/subtext pointer and was skipped"
+                ),
+            );
+            continue;
+        }
+
+        if hiragana.is_none() && !candidate.hiragana.is_null() {
+            hiragana = Some(
+                unsafe { CStr::from_ptr(candidate.hiragana) }
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+        }
+
+        let text = unsafe { CStr::from_ptr(candidate.text) }
+            .to_string_lossy()
+            .into_owned();
+        let subtext = unsafe { CStr::from_ptr(candidate.subtext) }
+            .to_string_lossy()
+            .into_owned();
+        let corresponding_count = candidate.corresponding_count;
+
+        let suggestion = Suggestion {
+            text,
+            subtext,
+            corresponding_count,
         };
-        let call_name = if use_cursor_prefix {
-            "GetComposedTextForCursorPrefix"
-        } else {
-            "GetComposedText"
-        };
-        if length < 0 {
-            return Err(format!("[{call_name}] invalid negative length: {length}"));
+
+        if suggestions
+            .iter()
+            .any(|s: &Suggestion| s.text == suggestion.text)
+        {
+            continue;
         }
-
-        let length = length as usize;
-        if length > 0 && result.is_null() {
-            return Err(format!(
-                "[{call_name}] null candidate list pointer (length={length})"
-            ));
-        }
-
-        let mut suggestions = Vec::with_capacity(length);
-        let mut hiragana = None;
-        log_event_lazy!(
-            ServerLogLevel::Debug,
-            "[{call_name}] candidate_count={length}"
-        );
-
-        for index in 0..length {
-            let candidate_ptr = *result.add(index);
-            if candidate_ptr.is_null() {
-                log_event(
-                    ServerLogLevel::Warn,
-                    &format!("[{call_name}] candidate[{index}] is null and skipped"),
-                );
-                continue;
-            }
-
-            let candidate = (*candidate_ptr).clone();
-            if candidate.text.is_null() || candidate.subtext.is_null() {
-                log_event(
-                    ServerLogLevel::Warn,
-                    &format!(
-                        "[{call_name}] candidate[{index}] has null text/subtext pointer and was skipped"
-                    ),
-                );
-                continue;
-            }
-
-            if hiragana.is_none() && !candidate.hiragana.is_null() {
-                hiragana = Some(
-                    CStr::from_ptr(candidate.hiragana)
-                        .to_string_lossy()
-                        .into_owned(),
-                );
-            }
-
-            let text = CStr::from_ptr(candidate.text)
-                .to_string_lossy()
-                .into_owned();
-            let subtext = CStr::from_ptr(candidate.subtext)
-                .to_string_lossy()
-                .into_owned();
-            let corresponding_count = candidate.corresponding_count;
-
-            let suggestion = Suggestion {
-                text,
-                subtext,
-                corresponding_count,
-            };
-
-            if suggestions
-                .iter()
-                .any(|s: &Suggestion| s.text == suggestion.text)
-            {
-                continue;
-            }
-            suggestions.push(suggestion);
-        }
-
-        Ok(ComposedText {
-            hiragana,
-            suggestions,
-        })
+        suggestions.push(suggestion);
     }
+
+    Ok(ComposedText {
+        hiragana,
+        suggestions,
+    })
 }
 
 fn shrink_text(offset: i8) -> Result<RawComposingText, String> {

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -1191,10 +1191,51 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
     let pointer = UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?>.allocate(capacity: list.count)
     for (i, item) in list.enumerated() {
-        pointer[i] = UnsafeMutablePointer<FFICandidate>.allocate(capacity: 1)
-        pointer[i]?.pointee = item
+        let candidatePtr = UnsafeMutablePointer<FFICandidate>.allocate(capacity: 1)
+        candidatePtr.initialize(to: item)
+        pointer.advanced(by: i).initialize(to: candidatePtr)
     }
     return pointer
+}
+
+@_silgen_name("FreeCString")
+public func free_c_string(_ ptr: UnsafeMutablePointer<CChar>?) {
+    guard let ptr else {
+        return
+    }
+    free(ptr)
+}
+
+@_silgen_name("FreeCandidateList")
+public func free_candidate_list(
+    _ ptr: UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?>?,
+    _ length: Int32
+) {
+    guard let ptr else {
+        return
+    }
+
+    guard length > 0 else {
+        ptr.deinitialize(count: 0)
+        ptr.deallocate()
+        return
+    }
+
+    for index in 0..<Int(length) {
+        guard let candidatePtr = ptr[index] else {
+            continue
+        }
+
+        let candidate = candidatePtr.pointee
+        free(candidate.text)
+        free(candidate.subtext)
+        free(candidate.hiragana)
+        candidatePtr.deinitialize(count: 1)
+        candidatePtr.deallocate()
+    }
+
+    ptr.deinitialize(count: Int(length))
+    ptr.deallocate()
 }
 
 @_silgen_name("GetComposedText")

--- a/server-swift/Sources/ffi/include/ffi.h
+++ b/server-swift/Sources/ffi/include/ffi.h
@@ -3,7 +3,9 @@
 
 #include <stdio.h>
 
-#endif /* ffi_h */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct FFICandidate {
     char *text;
@@ -11,3 +13,12 @@ struct FFICandidate {
     char *hiragana;
     int correspondingCount;
 };
+
+void FreeCString(char *ptr);
+void FreeCandidateList(struct FFICandidate **ptr, int length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ffi_h */

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ffi
 import KanaKanjiConverterModule
 import Testing
 @testable import azookey_server
@@ -75,6 +76,34 @@ private func testCandidate(
             )
         ]
     )
+}
+
+@Test func ffiFreeCStringAcceptsNullAndAllocatedStrings() async throws {
+    free_c_string(nil)
+
+    let text = try #require(_strdup("azookey"))
+    free_c_string(text)
+}
+
+@Test func ffiFreeCandidateListAcceptsNullEmptyAndPopulatedLists() async throws {
+    free_candidate_list(nil, 0)
+
+    let emptyList = to_list_pointer([])
+    free_candidate_list(emptyList, 0)
+
+    let text = try #require(_strdup("candidate"))
+    let subtext = try #require(_strdup("remaining"))
+    let hiragana = try #require(_strdup("かな"))
+    let candidates = [
+        FFICandidate(
+            text: text,
+            subtext: subtext,
+            hiragana: hiragana,
+            correspondingCount: 1
+        )
+    ]
+
+    free_candidate_list(to_list_pointer(candidates), Int32(candidates.count))
 }
 
 @Test func supportsNextInputCarryForTsuRules() async throws {


### PR DESCRIPTION
## Summary
- Swift/Rust FFI で Swift 側から返す C string / candidate list に対応する free API を追加しました。
- Rust 側で FFI 戻り値を RAII wrapper で扱い、文字列・候補配列を読み終えたあと必ず解放するようにしました。
- null / 空候補 / 候補ありの free API 回帰テストを追加しました。

## Background
- Issue: Closes #51
- `AppendText` / `GetComposedText` 系は Swift 側で `_strdup` / `strdup` / `UnsafeMutablePointer.allocate` により heap allocation を返していました。
- Rust 側では `CStr::from_ptr` でコピーしていましたが、元メモリを解放する API がなく、連続入力・候補取得で unmanaged memory が増える可能性がありました。

## Changes
- server-swift / FFI
  - `FreeCString` と `FreeCandidateList` を追加
  - candidate list の top-level 配列、candidate 要素、candidate 内 `text` / `subtext` / `hiragana` を解放
  - `to_list_pointer` の candidate 初期化を `initialize(to:)` に変更
- server / Rust FFI
  - `OwnedFfiString` / `OwnedFfiCandidates` を追加
  - `Drop` で Swift 側 free API を呼び、`AppendText` / `RemoveText` / `MoveCursor` / `ShrinkText` / `GetComposedText` 系の FFI 戻り値を読み取り後に解放
  - candidate 読み取りの unsafe 範囲を wrapper 経由に整理
- tests
  - `FreeCString` の null / allocated string
  - `FreeCandidateList` の null / empty / populated list

## Verification
- [x] Windows 実機確認
  - ユーザー確認済み
- [x] ローカル Windows VM test（server-swift FFI free）
  - `SWIFT_VENDOR_REPO_URL=https://github.com/batao9/AzooKeyKanaKanjiConverter SWIFT_VENDOR_REVISION=56268957b81b004ca8231ffc3491a4af684d0e20 bash .local/vm_test_client_composition.sh fix/issue-51-ffi-free-api skip 'ffiFree'`
  - `2 tests passed`
  - log: `.local/logs/vm-client-test-20260519-080452.log`
- [x] ローカル Windows VM build 成功
  - `.local/vm_build_master.sh fix/issue-51-ffi-free-api`
  - artifact: `.local/artifacts/azookey-setup-fix_issue-51-ffi-free-api-20260519-081658.exe`
  - sha256: `c4d0f45e845c7ca30192524505295a6c853997630e730c7679217eb18a57e844`
- [x] 差分チェック
  - `cargo fmt --all --check`
  - `git diff --check`
- [ ] GitHub Actions build 成功
  - run: 未実行

## Checklist
- [ ] CI run URL と結果を記載した
- [x] VM / 実機確認結果を記載した
- [x] 影響範囲を確認した
