### PR TITLE
fix(ui): harden candidate window IPC

### DIFF
--- a/crates/ui/src/candidate.rs
+++ b/crates/ui/src/candidate.rs
@@ -157,6 +157,9 @@ pub fn create_candidate_webview<'a>() -> Result<WebViewBuilder<'a>> {
                 <script>
                     function updateCandidates(candidates) {
                         const candidateList = document.getElementById('candidate-list');
+                        if (!candidateList || !Array.isArray(candidates)) {
+                            return;
+                        }
 
                         const existingItems = Array.from(candidateList.children);
 
@@ -177,22 +180,37 @@ pub fn create_candidate_webview<'a>() -> Result<WebViewBuilder<'a>> {
 
                     function updateSelection(index) {
                         const candidateList = document.getElementById('candidate-list');
+                        if (!candidateList || candidateList.children.length === 0) {
+                            return;
+                        }
+
+                        const childCount = candidateList.children.length;
+                        const numericIndex = Number(index);
+                        const safeIndex = Number.isFinite(numericIndex)
+                            ? Math.min(Math.max(Math.trunc(numericIndex), 0), childCount - 1)
+                            : 0;
+
                         const selected = candidateList.querySelector('[data-selected]');
                         if (selected) {
                             selected.removeAttribute('data-selected');
                         }
                         
-                        candidateList.children[index].setAttribute('data-selected', '');
+                        const target = candidateList.children[safeIndex];
+                        target.setAttribute('data-selected', '');
                         
                         const itemHeight = candidateList.children[0].offsetHeight;
+                        if (itemHeight <= 0) {
+                            return;
+                        }
                         const visibleItems = Math.floor(candidateList.clientHeight / itemHeight);
                         
                         const groupSize = 5;
-                        const groupIndex = Math.floor(index / groupSize);
+                        const groupIndex = Math.floor(safeIndex / groupSize);
                         const scrollToIndex = groupIndex * groupSize;
+                        const scrollTarget = candidateList.children[scrollToIndex];
                         
-                        if (index === scrollToIndex || !isElementInView(candidateList.children[index], candidateList)) {
-                            candidateList.children[scrollToIndex].scrollIntoView({ behavior: "instant", block: "start", inline: "start" });
+                        if (scrollTarget && (safeIndex === scrollToIndex || !isElementInView(target, candidateList))) {
+                            scrollTarget.scrollIntoView({ behavior: "instant", block: "start", inline: "start" });
                         }
                     }
                     

--- a/crates/ui/src/ipc.rs
+++ b/crates/ui/src/ipc.rs
@@ -41,52 +41,52 @@ pub struct WindowService {
     pub controller: WindowController,
 }
 
+impl WindowService {
+    async fn send_action(&self, action: WindowAction) -> Result<Response<EmptyResponse>, Status> {
+        self.controller
+            .sender
+            .send(action)
+            .await
+            .map_err(|_| Status::internal("window event channel is closed"))?;
+
+        Ok(Response::new(EmptyResponse {}))
+    }
+}
+
 #[tonic::async_trait]
 impl WindowServiceProto for WindowService {
     async fn show_window(
         &self,
         _request: Request<EmptyResponse>,
     ) -> Result<Response<EmptyResponse>, Status> {
-        self.controller
-            .sender
-            .send(WindowAction::Show)
-            .await
-            .unwrap();
-        Ok(Response::new(EmptyResponse {}))
+        self.send_action(WindowAction::Show).await
     }
 
     async fn hide_window(
         &self,
         _request: Request<EmptyResponse>,
     ) -> Result<Response<EmptyResponse>, Status> {
-        self.controller
-            .sender
-            .send(WindowAction::Hide)
-            .await
-            .unwrap();
-        Ok(Response::new(EmptyResponse {}))
+        self.send_action(WindowAction::Hide).await
     }
     async fn set_window_position(
         &self,
         request: Request<SetPositionRequest>,
     ) -> Result<Response<EmptyResponse>, Status> {
-        let position = request.into_inner().position.unwrap();
+        let position = request
+            .into_inner()
+            .position
+            .ok_or_else(|| Status::invalid_argument("position is required"))?;
         let top = position.top;
         let left = position.left;
         let bottom = position.bottom;
         let right = position.right;
-        self.controller
-            .sender
-            .send(WindowAction::SetPosition {
-                top,
-                left,
-                bottom,
-                right,
-            })
-            .await
-            .unwrap();
-
-        Ok(Response::new(EmptyResponse {}))
+        self.send_action(WindowAction::SetPosition {
+            top,
+            left,
+            bottom,
+            right,
+        })
+        .await
     }
 
     async fn set_candidate(
@@ -95,15 +95,10 @@ impl WindowServiceProto for WindowService {
     ) -> Result<Response<EmptyResponse>, Status> {
         let candidate = request.into_inner().candidates;
 
-        self.controller
-            .sender
-            .send(WindowAction::SetCandidate {
-                candidates: candidate,
-            })
-            .await
-            .unwrap();
-
-        Ok(Response::new(EmptyResponse {}))
+        self.send_action(WindowAction::SetCandidate {
+            candidates: candidate,
+        })
+        .await
     }
 
     async fn set_selection(
@@ -111,13 +106,7 @@ impl WindowServiceProto for WindowService {
         request: Request<SetSelectionRequest>,
     ) -> Result<Response<EmptyResponse>, Status> {
         let index = request.into_inner().index;
-        self.controller
-            .sender
-            .send(WindowAction::SetSelection { index })
-            .await
-            .unwrap();
-
-        Ok(Response::new(EmptyResponse {}))
+        self.send_action(WindowAction::SetSelection { index }).await
     }
 
     async fn set_input_mode(
@@ -125,12 +114,77 @@ impl WindowServiceProto for WindowService {
         request: Request<SetInputModeRequest>,
     ) -> Result<Response<EmptyResponse>, Status> {
         let mode = request.into_inner().mode;
-        self.controller
-            .sender
-            .send(WindowAction::SetInputMode(mode))
-            .await
-            .unwrap();
+        self.send_action(WindowAction::SetInputMode(mode)).await
+    }
+}
 
-        Ok(Response::new(EmptyResponse {}))
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::proto::WindowPosition;
+    use tonic::Code;
+
+    fn service_with_receiver() -> (WindowService, mpsc::Receiver<WindowAction>) {
+        let (sender, receiver) = mpsc::channel(1);
+        (
+            WindowService {
+                controller: WindowController::new(sender),
+            },
+            receiver,
+        )
+    }
+
+    #[tokio::test]
+    async fn set_window_position_without_position_returns_invalid_argument() {
+        let (service, _receiver) = service_with_receiver();
+
+        let error = service
+            .set_window_position(Request::new(SetPositionRequest { position: None }))
+            .await
+            .expect_err("missing position should be rejected");
+
+        assert_eq!(error.code(), Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn set_window_position_sends_action() {
+        let (service, mut receiver) = service_with_receiver();
+
+        service
+            .set_window_position(Request::new(SetPositionRequest {
+                position: Some(WindowPosition {
+                    top: 1,
+                    left: 2,
+                    bottom: 3,
+                    right: 4,
+                }),
+            }))
+            .await
+            .expect("valid position should be sent");
+
+        match receiver.recv().await.expect("action should be queued") {
+            WindowAction::SetPosition {
+                top,
+                left,
+                bottom,
+                right,
+            } => {
+                assert_eq!((top, left, bottom, right), (1, 2, 3, 4));
+            }
+            action => panic!("unexpected action: {action:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn closed_channel_returns_internal_status() {
+        let (service, receiver) = service_with_receiver();
+        drop(receiver);
+
+        let error = service
+            .show_window(Request::new(EmptyResponse {}))
+            .await
+            .expect_err("closed channel should be reported as a gRPC error");
+
+        assert_eq!(error.code(), Code::Internal);
     }
 }

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -1,7 +1,6 @@
 use std::cmp::max;
 use std::sync::Arc;
 
-use anyhow::Context as _;
 use azookey_server::TonicNamedPipeServer;
 use ipc::{WindowAction, WindowController, WindowService};
 use shared::proto::window_service_server::WindowServiceServer;
@@ -9,7 +8,7 @@ use tao::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 use tao::platform::windows::{EventLoopBuilderExtWindows, WindowExtWindows};
 use tao::{
     event::{Event, StartCause, WindowEvent},
-    event_loop::{ControlFlow, EventLoopBuilder},
+    event_loop::{ControlFlow, EventLoopBuilder, EventLoopProxy},
 };
 use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
@@ -49,6 +48,18 @@ fn place_candidate_windows(
         (rect.left - INDICATOR_WINDOW_LEFT_OFFSET) as f64,
         rect.bottom as f64,
     ));
+}
+
+fn send_user_event(proxy: &EventLoopProxy<UserEvent>, event: UserEvent) {
+    if let Err(error) = proxy.send_event(event) {
+        eprintln!("Warning: Failed to send UI event: {error:?}");
+    }
+}
+
+fn evaluate_script(webview: &wry::WebView, script: &str) {
+    if let Err(error) = webview.evaluate_script(script) {
+        eprintln!("Warning: Failed to evaluate WebView script: {error:?}");
+    }
 }
 
 #[derive(Debug)]
@@ -93,16 +104,14 @@ async fn main() -> anyhow::Result<()> {
     let candidate_window = candidate::create_candidate_window(&event_loop)?;
     let candidate_webview_builder = candidate::create_candidate_webview()?;
     let candidate_webview = candidate_webview_builder
-        .with_devtools(true)
+        .with_devtools(cfg!(debug_assertions))
         .with_ipc_handler(move |message| {
             if let Ok(message) = serde_json::from_str::<serde_json::Value>(message.body()) {
                 if let Some(type_value) = message.get("type") {
                     if type_value == "resize" {
                         if let Some(height) = message.get("height") {
                             let height = height.as_f64().unwrap_or(0.0);
-                            proxy_clone
-                                .send_event(UserEvent::UpdateHeight(height as i32))
-                                .unwrap();
+                            send_user_event(&proxy_clone, UserEvent::UpdateHeight(height as i32));
                         }
                     }
                 }
@@ -117,54 +126,7 @@ async fn main() -> anyhow::Result<()> {
     let proxy_clone = event_loop_proxy.clone();
     tokio::spawn(async move {
         while let Some(action) = rx.recv().await {
-            match action {
-                WindowAction::Show => {
-                    proxy_clone
-                        .send_event(UserEvent::WindowAction(WindowAction::Show))
-                        .unwrap();
-                }
-                WindowAction::Hide => {
-                    proxy_clone
-                        .send_event(UserEvent::WindowAction(WindowAction::Hide))
-                        .unwrap();
-                }
-                WindowAction::SetPosition {
-                    top,
-                    left,
-                    bottom,
-                    right,
-                } => {
-                    proxy_clone
-                        .send_event(UserEvent::WindowAction(WindowAction::SetPosition {
-                            top,
-                            left,
-                            bottom,
-                            right,
-                        }))
-                        .unwrap();
-                }
-                WindowAction::SetCandidate { candidates } => {
-                    proxy_clone
-                        .send_event(UserEvent::WindowAction(WindowAction::SetCandidate {
-                            candidates,
-                        }))
-                        .unwrap();
-                }
-                WindowAction::SetSelection { index } => {
-                    proxy_clone
-                        .send_event(UserEvent::WindowAction(WindowAction::SetSelection {
-                            index,
-                        }))
-                        .unwrap();
-                }
-                WindowAction::SetInputMode(input_method) => {
-                    proxy_clone
-                        .send_event(UserEvent::WindowAction(WindowAction::SetInputMode(
-                            input_method,
-                        )))
-                        .unwrap();
-                }
-            }
+            send_user_event(&proxy_clone, UserEvent::WindowAction(action));
         }
     });
 
@@ -183,19 +145,24 @@ async fn main() -> anyhow::Result<()> {
             } => *control_flow = ControlFlow::Exit,
             Event::UserEvent(script) => match script {
                 UserEvent::UpdateCandidates(candidates) => {
-                    candidate_webview
-                        .evaluate_script(&format!("updateCandidates({})", candidates))
-                        .unwrap();
+                    evaluate_script(
+                        &candidate_webview,
+                        &format!("updateCandidates({})", candidates),
+                    );
                 }
                 UserEvent::UpdateSelection(index) => {
-                    candidate_webview
-                        .evaluate_script(&format!("updateSelection({})", index))
-                        .unwrap();
+                    evaluate_script(&candidate_webview, &format!("updateSelection({})", index));
                 }
                 UserEvent::UpdateInputMethod(input_method) => {
-                    indicator_webview
-                        .evaluate_script(&format!("updateInputMethod(\"{}\")", input_method))
-                        .unwrap();
+                    match serde_json::to_string(&input_method) {
+                        Ok(input_method) => evaluate_script(
+                            &indicator_webview,
+                            &format!("updateInputMethod({})", input_method),
+                        ),
+                        Err(error) => {
+                            eprintln!("Warning: Failed to serialize input method: {error:?}");
+                        }
+                    }
                 }
                 UserEvent::UpdateHeight(height) => {
                     let width = candidate_window.inner_size().width as i32;
@@ -287,26 +254,29 @@ async fn main() -> anyhow::Result<()> {
                                 height as u32,
                             ));
 
-                            let candidates = serde_json::to_string(&candidates)
-                                .context("Failed to serialize candidates")
-                                .unwrap();
-
-                            event_loop_proxy
-                                .send_event(UserEvent::UpdateCandidates(candidates))
-                                .unwrap();
+                            match serde_json::to_string(&candidates) {
+                                Ok(candidates) => {
+                                    send_user_event(
+                                        &event_loop_proxy,
+                                        UserEvent::UpdateCandidates(candidates),
+                                    );
+                                }
+                                Err(error) => {
+                                    eprintln!("Warning: Failed to serialize candidates: {error:?}");
+                                }
+                            }
                             if let Some(rect) = last_candidate_rect {
                                 place_candidate_windows(&candidate_window, &indicator_window, rect);
                             }
                         }
                         WindowAction::SetSelection { index } => {
-                            event_loop_proxy
-                                .send_event(UserEvent::UpdateSelection(index))
-                                .unwrap();
+                            send_user_event(&event_loop_proxy, UserEvent::UpdateSelection(index));
                         }
                         WindowAction::SetInputMode(input_method) => {
-                            event_loop_proxy
-                                .send_event(UserEvent::UpdateInputMethod(input_method))
-                                .unwrap();
+                            send_user_event(
+                                &event_loop_proxy,
+                                UserEvent::UpdateInputMethod(input_method),
+                            );
 
                             let task_guard = task_guard.try_lock();
 

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- 候補 UI server の `unwrap()` を `tonic::Status` / warning log に置き換え、UI channel 切断や不正 request で process が落ちにくいようにしました。
- WebView への JS 呼び出しを JSON serialize 経由にし、候補選択 index と候補 0 件時の JS guard を追加しました。
- release build では candidate WebView devtools を無効化し、Tauri 設定アプリに CSP を設定しました。

## Background
- Issue: Closes #53
- 候補 UI server と WebView 更新処理に、channel close / `position: None` / `evaluate_script` 失敗で panic につながる `unwrap()` が残っていました。
- `updateInputMethod("{}")` のような文字列埋め込み型 JS 呼び出しもあり、入力モード文字列に quote などが入った場合に JS escape 問題が起きる可能性がありました。
- 設定アプリの CSP は `null` で無効化されていました。

## Changes
- ui / IPC
  - `WindowService::send_action` を追加し、UI channel close を `Status::internal` として返すように変更
  - `SetPositionRequest.position` が `None` の場合は `Status::invalid_argument` を返すように変更
  - channel close / missing position / valid position dispatch の回帰 test を追加
- ui / WebView
  - `send_event` と `evaluate_script` の失敗を warning log にして処理継続
  - `input_method` を `serde_json::to_string` で JSON literal 化してから `updateInputMethod(...)` に渡すように変更
  - candidate WebView の devtools を `cfg!(debug_assertions)` に変更
  - 候補 JS に candidate list 不在、候補 0 件、selection index 範囲外、item height 0 の guard を追加
- frontend / tauri
  - `security.csp` に `default-src 'self'` ベースの CSP を設定

## Verification
- [x] ローカル差分チェック
  - `cargo fmt --check`
  - `git diff --check`
- [x] ローカル Linux test 試行
  - `cargo test -p ui ipc::tests`
  - Linux 側の GTK/WebKit 系 `pkg-config` 不足で build 前に停止したため、Windows VM test で確認
- [x] ローカル Windows VM test（UI IPC 回帰テスト）
  - `cargo test -p ui --release ipc::tests -- --nocapture`
  - `3 passed`
- [x] ローカル Windows VM build 成功
  - `.local/vm_build_master.sh fix/issue-53`
  - artifact: `.local/artifacts/azookey-setup-fix_issue-53-20260519-192120.exe`
  - sha256: `f0fb5078f1f571a0e2420bef589ff73348a135308df100c0b2da08a5ed824355`
- [x] ローカル Windows VM install 成功
  - `SHUTDOWN_AFTER_INSTALL=0 .local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-fix_issue-53-20260519-192120.exe`
  - install log: `.local/logs/win11-install-20260519-202025.log`
- [x] Windows 実機確認
  - ユーザー確認済み
- [ ] GitHub Actions build 成功
  - run: 未実行

## Checklist
- [ ] CI run URL と結果を記載した
- [x] VM / 実機確認結果を記載した
- [x] 影響範囲を確認した
