### PR TITLE
fix(settings): harden settings json io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ logs/*
 *.gguf
 *.dll
 *.lib
+.codex

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,6 +1172,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
+ "tempfile",
  "tokio",
  "tonic",
  "tower 0.5.2",
@@ -3603,11 +3604,14 @@ dependencies = [
 name = "shared"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "prost",
  "serde",
  "serde_json",
+ "tempfile",
  "tonic",
  "tonic-build",
+ "windows",
 ]
 
 [[package]]

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -149,6 +149,13 @@ impl TextServiceFactory {
     const MOVE_CURSOR_POP_CLAUSE_SNAPSHOT: i32 = 127;
     const MOVE_CLAUSE_TO_LAST: i32 = i32::MAX;
 
+    fn load_app_config_or_default() -> AppConfig {
+        AppConfig::read().unwrap_or_else(|error| {
+            tracing::error!("Failed to load settings; using defaults: {error}");
+            AppConfig::default()
+        })
+    }
+
     #[inline]
     fn is_ctrl_pressed() -> bool {
         VK_CONTROL.is_pressed() || VK_LCONTROL.is_pressed() || VK_RCONTROL.is_pressed()
@@ -2856,7 +2863,7 @@ impl TextServiceFactory {
         let is_shift_right = is_shift_pressed && wparam.0 == 0x27;
         let is_shift_key = Self::is_shift_key(wparam);
         let is_alt_backquote = Self::is_alt_backquote(wparam, lparam);
-        let app_config = AppConfig::read();
+        let app_config = Self::load_app_config_or_default();
 
         // check shortcut keys
         if is_ctrl_pressed && !is_ctrl_space && !is_alt_backquote && !is_ctrl_enter && !is_ctrl_down
@@ -3103,7 +3110,7 @@ impl TextServiceFactory {
             let mode = IMEState::input_mode()?;
             (composition, mode)
         };
-        let app_config = AppConfig::read();
+        let app_config = Self::load_app_config_or_default();
 
         let mut preview = composition.preview.clone();
         let mut suffix = composition.suffix.clone();

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -4,7 +4,10 @@ use std::process::{Child, Command, Stdio};
 use std::{env, thread};
 
 fn main() -> anyhow::Result<()> {
-    let config = AppConfig::new();
+    let config = AppConfig::new().unwrap_or_else(|error| {
+        eprintln!("[launcher] Failed to load settings; using defaults: {error}");
+        AppConfig::default()
+    });
     let cpu_backend_supported = zenzai_cpu_backend_supported();
     env::set_var(
         "AZOOKEY_ZENZAI_CPU_SUPPORTED",

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -5,10 +5,17 @@ edition = "2021"
 resolver = "2"
 
 [dependencies]
+chrono = { version = "0.4.39", default-features = false, features = ["clock"] }
 prost = "0.13.4"
 tonic = "0.12.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58.0", features = ["Win32_Storage_FileSystem"] }
+
+[dev-dependencies]
+tempfile = "3.14.0"
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::HashMap,
+    env, error, fmt, fs, io,
+    path::{Path, PathBuf},
+};
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/azookey.rs"));
@@ -8,13 +12,120 @@ pub mod proto {
         tonic::include_file_descriptor_set!("azookey_service_descriptor");
 }
 
-fn get_config_root() -> PathBuf {
-    let appdata = PathBuf::from(std::env::var("APPDATA").unwrap());
-    appdata.join("Azookey")
+fn get_config_root() -> Result<PathBuf, ConfigError> {
+    let appdata = env::var_os("APPDATA").ok_or(ConfigError::MissingAppData)?;
+    Ok(PathBuf::from(appdata).join("Azookey"))
 }
 
 const SETTINGS_FILENAME: &str = "settings.json";
 const CONFIG_VERSION: &str = "0.1.2";
+
+#[derive(Debug)]
+pub enum ConfigError {
+    MissingAppData,
+    CreateDir {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Read {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    Backup {
+        from: PathBuf,
+        to: PathBuf,
+        source: io::Error,
+    },
+    Serialize {
+        source: serde_json::Error,
+    },
+    WriteTemp {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Persist {
+        from: PathBuf,
+        to: PathBuf,
+        source: io::Error,
+    },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigError::MissingAppData => write!(f, "APPDATA is not set"),
+            ConfigError::CreateDir { path, source } => {
+                write!(
+                    f,
+                    "failed to create config directory {}: {}",
+                    path.display(),
+                    source
+                )
+            }
+            ConfigError::Read { path, source } => {
+                write!(f, "failed to read config {}: {}", path.display(), source)
+            }
+            ConfigError::Parse { path, source } => {
+                write!(f, "failed to parse config {}: {}", path.display(), source)
+            }
+            ConfigError::Backup { from, to, source } => write!(
+                f,
+                "failed to back up corrupted config {} to {}: {}",
+                from.display(),
+                to.display(),
+                source
+            ),
+            ConfigError::Serialize { source } => {
+                write!(f, "failed to serialize config: {}", source)
+            }
+            ConfigError::WriteTemp { path, source } => {
+                write!(
+                    f,
+                    "failed to write temporary config {}: {}",
+                    path.display(),
+                    source
+                )
+            }
+            ConfigError::Persist { from, to, source } => write!(
+                f,
+                "failed to replace config {} with {}: {}",
+                to.display(),
+                from.display(),
+                source
+            ),
+        }
+    }
+}
+
+impl error::Error for ConfigError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            ConfigError::MissingAppData => None,
+            ConfigError::CreateDir { source, .. }
+            | ConfigError::Read { source, .. }
+            | ConfigError::Backup { source, .. }
+            | ConfigError::WriteTemp { source, .. }
+            | ConfigError::Persist { source, .. } => Some(source),
+            ConfigError::Parse { source, .. } | ConfigError::Serialize { source } => Some(source),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConfigRecovery {
+    pub original_path: PathBuf,
+    pub backup_path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct AppConfigLoadResult {
+    pub config: AppConfig,
+    pub recovery: Option<ConfigRecovery>,
+}
 
 pub const CHARACTER_WIDTH_SYMBOL_DEFAULTS: [(&str, bool); 42] = [
     ("0", false),
@@ -323,7 +434,63 @@ pub fn zenzai_cpu_backend_supported() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::GeneralConfig;
+    use super::{
+        AppConfig, ConfigError, GeneralConfig, NumpadInputMode, CONFIG_VERSION, SETTINGS_FILENAME,
+    };
+    use std::{
+        env,
+        ffi::OsString,
+        fs,
+        path::Path,
+        sync::{Mutex, MutexGuard, OnceLock},
+    };
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    struct AppDataGuard {
+        _guard: MutexGuard<'static, ()>,
+        previous: Option<OsString>,
+    }
+
+    impl AppDataGuard {
+        fn set(path: &Path) -> Self {
+            let guard = env_lock();
+            let previous = env::var_os("APPDATA");
+            unsafe {
+                env::set_var("APPDATA", path);
+            }
+            Self {
+                _guard: guard,
+                previous,
+            }
+        }
+
+        fn unset() -> Self {
+            let guard = env_lock();
+            let previous = env::var_os("APPDATA");
+            unsafe {
+                env::remove_var("APPDATA");
+            }
+            Self {
+                _guard: guard,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for AppDataGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => env::set_var("APPDATA", value),
+                    None => env::remove_var("APPDATA"),
+                }
+            }
+        }
+    }
 
     #[test]
     fn candidate_window_delay_defaults_to_off() {
@@ -347,6 +514,109 @@ mod tests {
         assert!(deserialized.punctuation_commit_punctuation);
         assert!(deserialized.punctuation_commit_exclamation);
         assert!(deserialized.punctuation_commit_question);
+    }
+
+    #[test]
+    fn new_creates_default_settings_when_file_is_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let _appdata = AppDataGuard::set(temp.path());
+
+        let result = AppConfig::new_with_recovery().unwrap();
+        let config_path = temp.path().join("Azookey").join(SETTINGS_FILENAME);
+
+        assert!(result.recovery.is_none());
+        assert_eq!(result.config.version, CONFIG_VERSION);
+        assert!(config_path.exists());
+
+        let saved: AppConfig = serde_json::from_str(&fs::read_to_string(config_path).unwrap())
+            .expect("saved default config should be valid JSON");
+        assert_eq!(saved.version, CONFIG_VERSION);
+    }
+
+    #[test]
+    fn corrupted_settings_are_backed_up_and_default_settings_are_written() {
+        let temp = tempfile::tempdir().unwrap();
+        let _appdata = AppDataGuard::set(temp.path());
+        let config_root = temp.path().join("Azookey");
+        fs::create_dir_all(&config_root).unwrap();
+        let config_path = config_root.join(SETTINGS_FILENAME);
+        fs::write(&config_path, "{not valid json").unwrap();
+
+        let result = AppConfig::new_with_recovery().unwrap();
+        let recovery = result
+            .recovery
+            .expect("broken settings should produce recovery metadata");
+
+        assert_eq!(recovery.original_path, config_path);
+        assert!(recovery.backup_path.exists());
+        assert!(recovery
+            .backup_path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("settings.json.broken-"));
+        assert_eq!(
+            fs::read_to_string(recovery.backup_path).unwrap(),
+            "{not valid json"
+        );
+
+        let saved: AppConfig = serde_json::from_str(&fs::read_to_string(config_path).unwrap())
+            .expect("recreated settings should be valid JSON");
+        assert_eq!(saved.version, CONFIG_VERSION);
+    }
+
+    #[test]
+    fn read_migrates_valid_legacy_config() {
+        let temp = tempfile::tempdir().unwrap();
+        let _appdata = AppDataGuard::set(temp.path());
+        let config_root = temp.path().join("Azookey");
+        fs::create_dir_all(&config_root).unwrap();
+        let config_path = config_root.join(SETTINGS_FILENAME);
+        let mut legacy = AppConfig::default();
+        legacy.version = "0.1.1".to_string();
+        legacy.general.numpad_input = NumpadInputMode::AlwaysHalf;
+        fs::write(&config_path, serde_json::to_string_pretty(&legacy).unwrap()).unwrap();
+
+        let migrated = AppConfig::read().unwrap();
+
+        assert_eq!(migrated.version, CONFIG_VERSION);
+        assert_eq!(migrated.general.numpad_input, NumpadInputMode::DirectInput);
+    }
+
+    #[test]
+    fn write_persists_valid_json_without_temp_file_leftover() {
+        let temp = tempfile::tempdir().unwrap();
+        let _appdata = AppDataGuard::set(temp.path());
+        let mut config = AppConfig::default();
+        config.zenzai.enable = true;
+
+        config.write().unwrap();
+
+        let config_root = temp.path().join("Azookey");
+        let saved: AppConfig =
+            serde_json::from_str(&fs::read_to_string(config_root.join(SETTINGS_FILENAME)).unwrap())
+                .expect("written settings should be valid JSON");
+        assert!(saved.zenzai.enable);
+        let temp_files = fs::read_dir(config_root)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("settings.json.tmp-")
+            })
+            .count();
+        assert_eq!(temp_files, 0);
+    }
+
+    #[test]
+    fn missing_appdata_returns_config_error() {
+        let _appdata = AppDataGuard::unset();
+
+        let error = AppConfig::read().expect_err("APPDATA absence should not panic");
+
+        assert!(matches!(error, ConfigError::MissingAppData));
     }
 }
 
@@ -484,61 +754,217 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
-    pub fn write(&self) {
-        let config_path = get_config_root().join(SETTINGS_FILENAME);
-        let config_str = serde_json::to_string_pretty(self).unwrap();
-        std::fs::write(config_path, config_str).unwrap();
-    }
+    pub fn write(&self) -> Result<(), ConfigError> {
+        let config_root = get_config_root()?;
+        ensure_config_dir(&config_root)?;
+        let config_path = config_root.join(SETTINGS_FILENAME);
+        let temp_path = temporary_config_path(&config_root);
+        let config_str = serde_json::to_string_pretty(self)
+            .map_err(|source| ConfigError::Serialize { source })?;
 
-    pub fn read() -> Self {
-        let config_path = get_config_root().join(SETTINGS_FILENAME);
-        if !config_path.exists() {
-            return AppConfig::default();
-        }
-        let config_str = std::fs::read_to_string(config_path).unwrap();
-        let mut config: AppConfig = serde_json::from_str(&config_str).unwrap();
-
-        if config.version != CONFIG_VERSION {
-            config.general.numpad_input = match config.general.numpad_input {
-                // 旧仕様との互換: always_half(直接入力) -> direct_input
-                NumpadInputMode::AlwaysHalf => NumpadInputMode::DirectInput,
-                // 旧仕様との互換: follow_input_mode(変換待ち半角) -> always_half
-                NumpadInputMode::FollowInputMode => NumpadInputMode::AlwaysHalf,
-                NumpadInputMode::DirectInput => NumpadInputMode::DirectInput,
-            };
-
-            if let Ok(value) = serde_json::from_str::<serde_json::Value>(&config_str) {
-                let legacy = value
-                    .get("character_width")
-                    .cloned()
-                    .and_then(|cw| serde_json::from_value::<LegacyCharacterWidthConfig>(cw).ok())
-                    .unwrap_or(LegacyCharacterWidthConfig {
-                        symbol_fullwidth: config.character_width.symbol_fullwidth.clone(),
-                    });
-                let legacy_groups = legacy_groups_from_symbol_fullwidth(&legacy.symbol_fullwidth);
-
-                if config.character_width.groups == legacy_groups {
-                    config.character_width.groups = CharacterWidthGroups::default();
-                }
+        write_temp_config(&temp_path, config_str.as_bytes())?;
+        replace_config_file(&temp_path, &config_path).map_err(|source| {
+            let _ = fs::remove_file(&temp_path);
+            ConfigError::Persist {
+                from: temp_path.clone(),
+                to: config_path,
+                source,
             }
+        })?;
 
-            config
-                .romaji_table
-                .rows
-                .retain(|row| !is_legacy_removed_default_row(row));
-            config.version = CONFIG_VERSION.to_string();
-        }
-
-        config
+        Ok(())
     }
 
-    pub fn new() -> Self {
-        let config_path = get_config_root();
+    pub fn read() -> Result<Self, ConfigError> {
+        let config_path = get_config_root()?.join(SETTINGS_FILENAME);
         if !config_path.exists() {
-            std::fs::create_dir_all(&config_path).unwrap();
+            return Ok(AppConfig::default());
         }
-        let config = AppConfig::read();
-        config.write();
-        config
+        let config_str = fs::read_to_string(&config_path).map_err(|source| ConfigError::Read {
+            path: config_path.clone(),
+            source,
+        })?;
+        let config = parse_config(&config_path, &config_str)?;
+
+        Ok(config)
     }
+
+    pub fn new() -> Result<Self, ConfigError> {
+        Ok(Self::new_with_recovery()?.config)
+    }
+
+    pub fn new_with_recovery() -> Result<AppConfigLoadResult, ConfigError> {
+        let config_root = get_config_root()?;
+        ensure_config_dir(&config_root)?;
+        let config_path = config_root.join(SETTINGS_FILENAME);
+
+        let (config, recovery) = if !config_path.exists() {
+            (AppConfig::default(), None)
+        } else {
+            let config_str =
+                fs::read_to_string(&config_path).map_err(|source| ConfigError::Read {
+                    path: config_path.clone(),
+                    source,
+                })?;
+
+            match parse_config(&config_path, &config_str) {
+                Ok(config) => (config, None),
+                Err(ConfigError::Parse { .. }) => {
+                    let backup_path = backup_corrupted_config(&config_path)?;
+                    (
+                        AppConfig::default(),
+                        Some(ConfigRecovery {
+                            original_path: config_path.clone(),
+                            backup_path,
+                        }),
+                    )
+                }
+                Err(error) => return Err(error),
+            }
+        };
+
+        config.write()?;
+        Ok(AppConfigLoadResult { config, recovery })
+    }
+}
+
+fn parse_config(config_path: &Path, config_str: &str) -> Result<AppConfig, ConfigError> {
+    let mut config: AppConfig =
+        serde_json::from_str(config_str).map_err(|source| ConfigError::Parse {
+            path: config_path.to_path_buf(),
+            source,
+        })?;
+
+    if config.version != CONFIG_VERSION {
+        config.general.numpad_input = match config.general.numpad_input {
+            // 旧仕様との互換: always_half(直接入力) -> direct_input
+            NumpadInputMode::AlwaysHalf => NumpadInputMode::DirectInput,
+            // 旧仕様との互換: follow_input_mode(変換待ち半角) -> always_half
+            NumpadInputMode::FollowInputMode => NumpadInputMode::AlwaysHalf,
+            NumpadInputMode::DirectInput => NumpadInputMode::DirectInput,
+        };
+
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(config_str) {
+            let legacy = value
+                .get("character_width")
+                .cloned()
+                .and_then(|cw| serde_json::from_value::<LegacyCharacterWidthConfig>(cw).ok())
+                .unwrap_or(LegacyCharacterWidthConfig {
+                    symbol_fullwidth: config.character_width.symbol_fullwidth.clone(),
+                });
+            let legacy_groups = legacy_groups_from_symbol_fullwidth(&legacy.symbol_fullwidth);
+
+            if config.character_width.groups == legacy_groups {
+                config.character_width.groups = CharacterWidthGroups::default();
+            }
+        }
+
+        config
+            .romaji_table
+            .rows
+            .retain(|row| !is_legacy_removed_default_row(row));
+        config.version = CONFIG_VERSION.to_string();
+    }
+
+    Ok(config)
+}
+
+fn ensure_config_dir(config_root: &Path) -> Result<(), ConfigError> {
+    fs::create_dir_all(config_root).map_err(|source| ConfigError::CreateDir {
+        path: config_root.to_path_buf(),
+        source,
+    })
+}
+
+fn write_temp_config(temp_path: &Path, bytes: &[u8]) -> Result<(), ConfigError> {
+    let mut file = fs::File::create(temp_path).map_err(|source| ConfigError::WriteTemp {
+        path: temp_path.to_path_buf(),
+        source,
+    })?;
+    use std::io::Write as _;
+    file.write_all(bytes)
+        .and_then(|_| file.sync_all())
+        .map_err(|source| ConfigError::WriteTemp {
+            path: temp_path.to_path_buf(),
+            source,
+        })
+}
+
+fn temporary_config_path(config_root: &Path) -> PathBuf {
+    let timestamp = chrono::Local::now().format("%Y%m%d%H%M%S%f");
+    config_root.join(format!(
+        "{SETTINGS_FILENAME}.tmp-{}-{timestamp}",
+        std::process::id()
+    ))
+}
+
+fn backup_corrupted_config(config_path: &Path) -> Result<PathBuf, ConfigError> {
+    let base_name = format!(
+        "{SETTINGS_FILENAME}.broken-{}",
+        chrono::Local::now().format("%Y%m%d%H%M%S")
+    );
+    let parent = config_path.parent().unwrap_or_else(|| Path::new("."));
+
+    for index in 0..1000 {
+        let candidate = if index == 0 {
+            parent.join(&base_name)
+        } else {
+            parent.join(format!("{base_name}-{index}"))
+        };
+
+        if candidate.exists() {
+            continue;
+        }
+
+        fs::rename(config_path, &candidate).map_err(|source| ConfigError::Backup {
+            from: config_path.to_path_buf(),
+            to: candidate.clone(),
+            source,
+        })?;
+        return Ok(candidate);
+    }
+
+    let fallback = parent.join(format!("{base_name}-overflow"));
+    fs::rename(config_path, &fallback).map_err(|source| ConfigError::Backup {
+        from: config_path.to_path_buf(),
+        to: fallback.clone(),
+        source,
+    })?;
+    Ok(fallback)
+}
+
+#[cfg(not(windows))]
+fn replace_config_file(temp_path: &Path, config_path: &Path) -> io::Result<()> {
+    fs::rename(temp_path, config_path)
+}
+
+#[cfg(windows)]
+fn replace_config_file(temp_path: &Path, config_path: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows::{
+        core::PCWSTR,
+        Win32::Storage::FileSystem::{
+            MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        },
+    };
+
+    let from: Vec<u16> = temp_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let to: Vec<u16> = config_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    unsafe {
+        MoveFileExW(
+            PCWSTR(from.as_ptr()),
+            PCWSTR(to.as_ptr()),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    }
+    .map_err(|error| io::Error::new(io::ErrorKind::Other, error.to_string()))
 }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -121,10 +121,11 @@ pub struct ConfigRecovery {
     pub backup_path: PathBuf,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AppConfigLoadResult {
     pub config: AppConfig,
     pub recovery: Option<ConfigRecovery>,
+    pub rewrite_error: Option<ConfigError>,
 }
 
 pub const CHARACTER_WIDTH_SYMBOL_DEFAULTS: [(&str, bool); 42] = [
@@ -440,7 +441,7 @@ mod tests {
     use std::{
         env,
         ffi::OsString,
-        fs,
+        fs, io,
         path::Path,
         sync::{Mutex, MutexGuard, OnceLock},
     };
@@ -581,6 +582,32 @@ mod tests {
 
         assert_eq!(migrated.version, CONFIG_VERSION);
         assert_eq!(migrated.general.numpad_input, NumpadInputMode::DirectInput);
+    }
+
+    #[test]
+    fn new_with_recovery_keeps_loaded_config_when_rewrite_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_root = temp.path().join("Azookey");
+        fs::create_dir_all(&config_root).unwrap();
+        let config_path = config_root.join(SETTINGS_FILENAME);
+        let mut config = AppConfig::default();
+        config.zenzai.enable = true;
+        fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+        let result = AppConfig::new_with_recovery_from_root(&config_root, |_| {
+            Err(ConfigError::WriteTemp {
+                path: config_root.join("settings.json.tmp-test"),
+                source: io::Error::new(io::ErrorKind::PermissionDenied, "test write failure"),
+            })
+        })
+        .unwrap();
+
+        assert!(result.config.zenzai.enable);
+        assert!(result.recovery.is_none());
+        assert!(matches!(
+            result.rewrite_error,
+            Some(ConfigError::WriteTemp { .. })
+        ));
     }
 
     #[test]
@@ -795,7 +822,14 @@ impl AppConfig {
 
     pub fn new_with_recovery() -> Result<AppConfigLoadResult, ConfigError> {
         let config_root = get_config_root()?;
-        ensure_config_dir(&config_root)?;
+        Self::new_with_recovery_from_root(&config_root, |config| config.write())
+    }
+
+    fn new_with_recovery_from_root(
+        config_root: &Path,
+        rewrite_config: impl FnOnce(&AppConfig) -> Result<(), ConfigError>,
+    ) -> Result<AppConfigLoadResult, ConfigError> {
+        ensure_config_dir(config_root)?;
         let config_path = config_root.join(SETTINGS_FILENAME);
 
         let (config, recovery) = if !config_path.exists() {
@@ -823,8 +857,12 @@ impl AppConfig {
             }
         };
 
-        config.write()?;
-        Ok(AppConfigLoadResult { config, recovery })
+        let rewrite_error = rewrite_config(&config).err();
+        Ok(AppConfigLoadResult {
+            config,
+            recovery,
+            rewrite_error,
+        })
     }
 }
 

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -35,3 +35,6 @@ version = "0.58.0"
 features = [
     "Win32_Foundation",
 ]
+
+[dev-dependencies]
+tempfile = "3.14.0"

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,17 +1,38 @@
 mod ipc;
 
 use serde::{Deserialize, Serialize};
-use shared::{AppConfig, RomajiRule};
+use shared::{AppConfig, ConfigRecovery, RomajiRule};
 use std::{path::PathBuf, sync::Mutex};
 
 #[derive(Debug)]
 pub struct AppState {
     settings: Mutex<AppConfig>,
     ipc: Mutex<Option<ipc::IPCService>>,
+    startup_notice: Mutex<Option<ConfigStartupNotice>>,
 }
 
 impl AppState {
     fn new() -> Self {
+        let (settings, startup_notice) = match AppConfig::new_with_recovery() {
+            Ok(result) => {
+                let notice = result.recovery.as_ref().map(notice_from_recovery);
+                (result.config, notice)
+            }
+            Err(error) => {
+                eprintln!("Failed to load settings; using defaults: {}", error);
+                (
+                    AppConfig::default(),
+                    Some(ConfigStartupNotice {
+                        kind: "load_error".to_string(),
+                        message: format!(
+                            "設定の読み込みに失敗したため、既定値で起動しました: {error}"
+                        ),
+                        backup_path: None,
+                    }),
+                )
+            }
+        };
+
         let ipc = match ipc::IPCService::new() {
             Ok(service) => Some(service),
             Err(error) => {
@@ -21,9 +42,32 @@ impl AppState {
         };
 
         AppState {
-            settings: Mutex::new(AppConfig::new()),
+            settings: Mutex::new(settings),
             ipc: Mutex::new(ipc),
+            startup_notice: Mutex::new(startup_notice),
         }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct ConfigStartupNotice {
+    kind: String,
+    message: String,
+    backup_path: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct UpdateConfigResponse {
+    saved: bool,
+    server_applied: bool,
+    message: Option<String>,
+}
+
+fn notice_from_recovery(recovery: &ConfigRecovery) -> ConfigStartupNotice {
+    ConfigStartupNotice {
+        kind: "recovered".to_string(),
+        message: "壊れた設定ファイルを退避し、既定値で起動しました。".to_string(),
+        backup_path: Some(recovery.backup_path.display().to_string()),
     }
 }
 
@@ -39,16 +83,51 @@ fn get_config(state: tauri::State<AppState>) -> AppConfig {
 }
 
 #[tauri::command]
-fn update_config(state: tauri::State<AppState>, new_config: AppConfig) {
-    let mut config = state.settings.lock().unwrap();
-    *config = new_config;
-    config.write();
+fn take_config_startup_notice(state: tauri::State<AppState>) -> Option<ConfigStartupNotice> {
+    state.startup_notice.lock().unwrap().take()
+}
+
+#[tauri::command]
+fn update_config(
+    state: tauri::State<AppState>,
+    new_config: AppConfig,
+) -> Result<UpdateConfigResponse, String> {
+    update_config_impl(&state, new_config)
+}
+
+fn update_config_impl(
+    state: &AppState,
+    new_config: AppConfig,
+) -> Result<UpdateConfigResponse, String> {
+    new_config.write().map_err(|error| error.to_string())?;
+
+    {
+        let mut config = state.settings.lock().unwrap();
+        *config = new_config;
+    }
 
     if let Some(ipc) = state.ipc.lock().unwrap().as_mut() {
         if let Err(error) = ipc.update_config() {
             eprintln!("Failed to notify IPC config update: {}", error);
+            return Ok(UpdateConfigResponse {
+                saved: true,
+                server_applied: false,
+                message: Some(error.to_string()),
+            });
         }
+    } else {
+        return Ok(UpdateConfigResponse {
+            saved: true,
+            server_applied: false,
+            message: Some("IPC service is not initialized".to_string()),
+        });
     }
+
+    Ok(UpdateConfigResponse {
+        saved: true,
+        server_applied: true,
+        message: None,
+    })
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -114,10 +193,122 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             greet,
             get_config,
+            take_config_startup_notice,
             update_config,
             check_capability,
             get_default_romaji_rows
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        env,
+        ffi::OsString,
+        path::Path,
+        sync::{Mutex, MutexGuard, OnceLock},
+    };
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    struct AppDataGuard {
+        _guard: MutexGuard<'static, ()>,
+        previous: Option<OsString>,
+    }
+
+    impl AppDataGuard {
+        fn set(path: &Path) -> Self {
+            let guard = env_lock();
+            let previous = env::var_os("APPDATA");
+            unsafe {
+                env::set_var("APPDATA", path);
+            }
+            Self {
+                _guard: guard,
+                previous,
+            }
+        }
+
+        fn unset() -> Self {
+            let guard = env_lock();
+            let previous = env::var_os("APPDATA");
+            unsafe {
+                env::remove_var("APPDATA");
+            }
+            Self {
+                _guard: guard,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for AppDataGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => env::set_var("APPDATA", value),
+                    None => env::remove_var("APPDATA"),
+                }
+            }
+        }
+    }
+
+    fn test_state() -> AppState {
+        AppState {
+            settings: Mutex::new(AppConfig::default()),
+            ipc: Mutex::new(None),
+            startup_notice: Mutex::new(None),
+        }
+    }
+
+    #[test]
+    fn update_config_reports_saved_when_server_is_unavailable() {
+        let temp = tempfile::tempdir().unwrap();
+        let _appdata = AppDataGuard::set(temp.path());
+        let state = test_state();
+        let mut config = AppConfig::default();
+        config.zenzai.enable = true;
+
+        let result = update_config_impl(&state, config).unwrap();
+
+        assert!(result.saved);
+        assert!(!result.server_applied);
+        assert!(result.message.is_some());
+        assert!(temp.path().join("Azookey").join("settings.json").exists());
+        assert!(state.settings.lock().unwrap().zenzai.enable);
+    }
+
+    #[test]
+    fn update_config_returns_error_when_save_fails() {
+        let _appdata = AppDataGuard::unset();
+        let state = test_state();
+
+        let error = update_config_impl(&state, AppConfig::default())
+            .expect_err("save failure should be returned to the UI");
+
+        assert!(error.contains("APPDATA"));
+        assert!(!state.settings.lock().unwrap().zenzai.enable);
+    }
+
+    #[test]
+    fn recovery_notice_includes_backup_path() {
+        let recovery = ConfigRecovery {
+            original_path: PathBuf::from("settings.json"),
+            backup_path: PathBuf::from("settings.json.broken-20260524120000"),
+        };
+
+        let notice = notice_from_recovery(&recovery);
+
+        assert_eq!(notice.kind, "recovered");
+        assert_eq!(
+            notice.backup_path.as_deref(),
+            Some("settings.json.broken-20260524120000")
+        );
+    }
 }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -99,10 +99,9 @@ fn update_config_impl(
     state: &AppState,
     new_config: AppConfig,
 ) -> Result<UpdateConfigResponse, String> {
-    new_config.write().map_err(|error| error.to_string())?;
-
     {
         let mut config = state.settings.lock().unwrap();
+        new_config.write().map_err(|error| error.to_string())?;
         *config = new_config;
     }
 

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 mod ipc;
 
 use serde::{Deserialize, Serialize};
-use shared::{AppConfig, ConfigRecovery, RomajiRule};
+use shared::{AppConfig, AppConfigLoadResult, ConfigError, ConfigRecovery, RomajiRule};
 use std::{path::PathBuf, sync::Mutex};
 
 #[derive(Debug)]
@@ -15,7 +15,10 @@ impl AppState {
     fn new() -> Self {
         let (settings, startup_notice) = match AppConfig::new_with_recovery() {
             Ok(result) => {
-                let notice = result.recovery.as_ref().map(notice_from_recovery);
+                if let Some(error) = result.rewrite_error.as_ref() {
+                    eprintln!("Failed to rewrite loaded settings: {}", error);
+                }
+                let notice = notice_from_load_result(&result);
                 (result.config, notice)
             }
             Err(error) => {
@@ -68,6 +71,36 @@ fn notice_from_recovery(recovery: &ConfigRecovery) -> ConfigStartupNotice {
         kind: "recovered".to_string(),
         message: "壊れた設定ファイルを退避し、既定値で起動しました。".to_string(),
         backup_path: Some(recovery.backup_path.display().to_string()),
+    }
+}
+
+fn notice_from_rewrite_error(error: &ConfigError) -> ConfigStartupNotice {
+    ConfigStartupNotice {
+        kind: "rewrite_error".to_string(),
+        message: format!("設定は読み込めましたが、設定ファイルの保存に失敗しました: {error}"),
+        backup_path: None,
+    }
+}
+
+fn notice_from_recovered_rewrite_error(
+    recovery: &ConfigRecovery,
+    error: &ConfigError,
+) -> ConfigStartupNotice {
+    ConfigStartupNotice {
+        kind: "recovered_rewrite_error".to_string(),
+        message: format!(
+            "壊れた設定ファイルを退避しましたが、既定値設定の保存に失敗しました: {error}"
+        ),
+        backup_path: Some(recovery.backup_path.display().to_string()),
+    }
+}
+
+fn notice_from_load_result(result: &AppConfigLoadResult) -> Option<ConfigStartupNotice> {
+    match (&result.recovery, &result.rewrite_error) {
+        (Some(recovery), Some(error)) => Some(notice_from_recovered_rewrite_error(recovery, error)),
+        (Some(recovery), None) => Some(notice_from_recovery(recovery)),
+        (None, Some(error)) => Some(notice_from_rewrite_error(error)),
+        (None, None) => None,
     }
 }
 
@@ -207,6 +240,7 @@ mod tests {
     use std::{
         env,
         ffi::OsString,
+        io,
         path::Path,
         sync::{Mutex, MutexGuard, OnceLock},
     };
@@ -309,5 +343,23 @@ mod tests {
             notice.backup_path.as_deref(),
             Some("settings.json.broken-20260524120000")
         );
+    }
+
+    #[test]
+    fn rewrite_error_notice_keeps_loaded_config_message() {
+        let result = AppConfigLoadResult {
+            config: AppConfig::default(),
+            recovery: None,
+            rewrite_error: Some(ConfigError::WriteTemp {
+                path: PathBuf::from("settings.json.tmp-test"),
+                source: io::Error::new(io::ErrorKind::PermissionDenied, "test write failure"),
+            }),
+        };
+
+        let notice = notice_from_load_result(&result).unwrap();
+
+        assert_eq!(notice.kind, "rewrite_error");
+        assert!(notice.message.contains("設定は読み込めました"));
+        assert!(notice.backup_path.is_none());
     }
 }

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,0 +1,62 @@
+import { invoke } from "@tauri-apps/api/core";
+import { toast } from "sonner";
+
+type ConfigStartupNotice = {
+    kind: string;
+    message: string;
+    backup_path?: string | null;
+};
+
+type UpdateConfigResponse = {
+    saved: boolean;
+    server_applied: boolean;
+    message?: string | null;
+};
+
+const SERVER_APPLY_WARNING =
+    "設定を保存しましたが、IME への反映に失敗しました。再起動後に反映されます。";
+
+export const showConfigStartupNoticeOnce = async () => {
+    try {
+        const notice = await invoke<ConfigStartupNotice | null>(
+            "take_config_startup_notice",
+        );
+        if (!notice) {
+            return;
+        }
+
+        toast(notice.message, {
+            description: notice.backup_path
+                ? `退避先: ${notice.backup_path}`
+                : undefined,
+            duration: 10000,
+        });
+    } catch (_error) {
+        // Startup notice is best effort; normal settings loading still handles errors.
+    }
+};
+
+export const saveConfigWithToast = async (
+    updater: (config: any) => void,
+    failureMessage = "設定の更新に失敗しました",
+) => {
+    try {
+        const data = await invoke<any>("get_config");
+        updater(data);
+        const result = await invoke<UpdateConfigResponse>("update_config", {
+            newConfig: data,
+        });
+
+        if (result.saved && !result.server_applied) {
+            toast(SERVER_APPLY_WARNING, {
+                description: result.message ?? undefined,
+                duration: 10000,
+            });
+        }
+
+        return data;
+    } catch (_error) {
+        toast(failureMessage);
+        return null;
+    }
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,6 +12,7 @@ import { Zenzai } from "@/pages/zenzai"
 import { About } from "@/pages/about"
 import { Dictionary } from "@/pages/dictionary"
 import { Toaster } from "@/components/ui/sonner"
+import { showConfigStartupNoticeOnce } from "@/lib/config"
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
@@ -34,3 +35,5 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     </SidebarProvider>
   </React.StrictMode>,
 );
+
+void showConfigStartupNoticeOnce();

--- a/frontend/src/pages/dictionary.tsx
+++ b/frontend/src/pages/dictionary.tsx
@@ -5,6 +5,7 @@ import { Plus, Save, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { saveConfigWithToast } from "@/lib/config";
 
 type DictionaryEntry = {
     reading: string;
@@ -136,10 +137,13 @@ export const Dictionary = () => {
 
         setIsSaving(true);
         try {
-            const config = await invoke<any>("get_config");
-            config.user_dictionary = config.user_dictionary ?? {};
-            config.user_dictionary.entries = normalized;
-            await invoke("update_config", { newConfig: config });
+            const config = await saveConfigWithToast((config) => {
+                config.user_dictionary = config.user_dictionary ?? {};
+                config.user_dictionary.entries = normalized;
+            }, "ユーザ辞書の保存に失敗しました");
+            if (!config) {
+                return;
+            }
             setEntries(normalized);
             toast("ユーザ辞書を保存しました");
         } catch (_error) {

--- a/frontend/src/pages/general.tsx
+++ b/frontend/src/pages/general.tsx
@@ -14,6 +14,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { saveConfigWithToast } from "@/lib/config";
 
 type WidthMode = "half" | "full";
 
@@ -292,17 +293,8 @@ export const General = () => {
         return () => cancelAnimationFrame(rafId);
     }, [isRomajiEditorOpen, pendingFocusNewRow, romajiDraftRows.length]);
 
-    const updateConfig = async (updater: (config: any) => void) => {
-        try {
-            const data = await invoke<any>("get_config");
-            updater(data);
-            await invoke("update_config", { newConfig: data });
-            return data;
-        } catch (_error) {
-            toast("設定の更新に失敗しました");
-            return null;
-        }
-    };
+    const updateConfig = (updater: (config: any) => void) =>
+        saveConfigWithToast(updater);
 
     const handleCtrlSpaceToggle = async () => {
         const nextValue = !shortcutValue.ctrlSpaceToggle;

--- a/frontend/src/pages/zenzai.tsx
+++ b/frontend/src/pages/zenzai.tsx
@@ -17,6 +17,7 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { saveConfigWithToast } from "@/lib/config";
 
 const ToolTipSelectItem = ({
     name,
@@ -82,17 +83,8 @@ export const Zenzai = () => {
         })
     }, []);
 
-    const updateConfig = async (updater: (config: any) => void) => {
-        try {
-            const data = await invoke<any>("get_config");
-            updater(data);
-            await invoke("update_config", { newConfig: data });
-            return data;
-        } catch (error) {
-            toast("設定の更新に失敗しました");
-            return null;
-        }
-    };
+    const updateConfig = (updater: (config: any) => void) =>
+        saveConfigWithToast(updater);
 
     const handleZenzaiChange = async () => {
         const data = await updateConfig((data) => {


### PR DESCRIPTION
## Summary
- `settings.json` の読み書きを `Result` ベースにし、APPDATA / read / parse / write 失敗で panic しないようにしました。
- 壊れた `settings.json` を `settings.json.broken-YYYYMMDDHHMMSS` に退避し、既定値で起動・再作成できるようにしました。
- 設定 UI で起動時復旧 notice と、保存成功 / IME server 反映失敗の toast を区別できるようにしました。

## Background
- Issue: Closes #52
- これまで `AppConfig::read/write/new` で APPDATA、JSON parse、file write などが panic し得る経路になっていました。
- 設定保存と server 反映の結果が同じ失敗扱いで、ユーザーに「保存されたが反映できなかった」状態を伝えられませんでした。

## Changes
- settings I/O
  - `ConfigError` / `ConfigRecovery` / `AppConfigLoadResult` を追加
  - `AppConfig::read/write/new` を `Result` 化し、`new_with_recovery()` を追加
  - parse 失敗時は壊れた file を backup し、default config を再作成
  - temp file と Windows `MoveFileExW(MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)` による置換保存へ変更
  - migration の既存挙動を維持
- caller behavior
  - launcher / client hot path は設定読み込み失敗時に default fallback し、panic しないように変更
  - Tauri `update_config` は保存失敗と server 反映失敗を別結果として返すように変更
  - 起動時復旧 notice を一度だけ取得する `take_config_startup_notice` command を追加
- frontend
  - 共通 helper で設定保存 toast と startup recovery toast を処理
  - General / Zenzai / Dictionary の保存処理を helper 経由に整理
- tests
  - shared の設定復旧 / migration / APPDATA 不在 / temp write unit tests を追加
  - frontend Tauri backend の保存成功 + server 未反映 / 保存失敗 / recovery notice unit tests を追加

## Verification
- [x] format / diff check
  - `cargo fmt`
  - `git diff --check`
- [x] ローカル Windows VM unit tests
  - `cargo test -p shared -- --nocapture`
  - `7 passed; 0 failed`
  - `cargo test -p frontend -- --nocapture`
  - `3 passed; 0 failed`
- [x] ローカル Windows VM build 成功
  - `bash .local/vm_build_master.sh fix/52-safe-settings-json`
  - artifact: `.local/artifacts/azookey-setup-fix_52-safe-settings-json-20260524-120744.exe`
  - frontend build in VM: `tsc && vite build`
- [ ] GitHub Actions build 成功
  - run: pending after push

## Checklist
- [ ] CI run URL と結果を記載した
- [x] VM test / build 結果を記載した
- [x] 影響範囲を確認した
