### PR TITLE
feat(ui): batch candidate window updates

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1316,11 +1316,37 @@ impl TextServiceFactory {
         update_pos: bool,
     ) -> Result<()> {
         self.set_text(preview, suffix)?;
-        ipc_service.set_candidates(candidates.texts.clone())?;
-        ipc_service.set_selection(selection_index)?;
-        if update_pos {
-            self.update_pos()?;
-        }
+        self.sync_candidate_window_update(
+            ipc_service,
+            candidates,
+            selection_index,
+            None,
+            update_pos,
+        )?;
+        Ok(())
+    }
+
+    #[inline]
+    fn sync_candidate_window_update(
+        &self,
+        ipc_service: &mut IPCService,
+        candidates: &Candidates,
+        selection_index: i32,
+        visible: Option<bool>,
+        update_pos: bool,
+    ) -> Result<()> {
+        let position = if update_pos {
+            self.candidate_window_position()?
+        } else {
+            None
+        };
+        ipc_service.update_candidate_window(
+            visible,
+            position,
+            Some(candidates.texts.clone()),
+            Some(selection_index),
+            None,
+        )?;
         Ok(())
     }
 
@@ -1328,16 +1354,19 @@ impl TextServiceFactory {
     fn sync_candidate_window_after_text_update(
         &self,
         ipc_service: &mut IPCService,
+        candidates: &Candidates,
+        selection_index: i32,
         app_config: &AppConfig,
         transition: &CompositionState,
     ) -> Result<()> {
-        self.update_pos()?;
-        if !app_config.general.show_candidate_window_after_space
+        let visible = if !app_config.general.show_candidate_window_after_space
             && *transition != CompositionState::None
         {
-            ipc_service.show_window()?;
-        }
-        Ok(())
+            Some(true)
+        } else {
+            None
+        };
+        self.sync_candidate_window_update(ipc_service, candidates, selection_index, visible, true)
     }
 
     #[inline]
@@ -3089,8 +3118,8 @@ impl TextServiceFactory {
         let ipc_service = IMEState::ipc_service().ok().flatten();
 
         if let Some(mut ipc_service) = ipc_service {
-            let _ = ipc_service.hide_window();
-            let _ = ipc_service.set_candidates(vec![]);
+            let _ =
+                ipc_service.update_candidate_window(Some(false), None, Some(vec![]), Some(0), None);
             let _ = ipc_service.clear_text();
 
             let _ = IMEState::set_ipc_service(ipc_service);
@@ -3142,12 +3171,12 @@ impl TextServiceFactory {
                 ClientAction::StartComposition => {
                     self.start_composition()?;
                     if app_config.general.show_candidate_window_after_space {
-                        ipc_service.hide_window()?;
+                        ipc_service.update_candidate_window(Some(false), None, None, None, None)?;
                     }
                 }
                 ClientAction::ShowCandidateWindow => {
-                    self.update_pos()?;
-                    ipc_service.show_window()?;
+                    let position = self.candidate_window_position()?;
+                    ipc_service.update_candidate_window(Some(true), position, None, None, None)?;
                 }
                 ClientAction::EndComposition => {
                     self.end_composition()?;
@@ -3167,8 +3196,13 @@ impl TextServiceFactory {
                     current_clause_has_split_left_neighbor = false;
                     current_clause_split_group_id = None;
                     next_split_group_id = 0;
-                    ipc_service.hide_window()?;
-                    ipc_service.set_candidates(vec![])?;
+                    ipc_service.update_candidate_window(
+                        Some(false),
+                        None,
+                        Some(vec![]),
+                        Some(0),
+                        None,
+                    )?;
                     ipc_service.clear_text()?;
                 }
                 ClientAction::AppendText(text) => {
@@ -3202,10 +3236,10 @@ impl TextServiceFactory {
                         raw_hiragana = selected.hiragana;
 
                         self.set_text(&preview, &suffix)?;
-                        ipc_service.set_candidates(candidates.texts.clone())?;
-                        ipc_service.set_selection(selection_index)?;
                         self.sync_candidate_window_after_text_update(
                             &mut ipc_service,
+                            &candidates,
+                            selection_index,
                             &app_config,
                             &transition,
                         )?;
@@ -3231,10 +3265,10 @@ impl TextServiceFactory {
                         raw_hiragana = selected.hiragana;
 
                         self.set_text(&preview, &suffix)?;
-                        ipc_service.set_candidates(candidates.texts.clone())?;
-                        ipc_service.set_selection(selection_index)?;
                         self.sync_candidate_window_after_text_update(
                             &mut ipc_service,
+                            &candidates,
+                            selection_index,
                             &app_config,
                             &transition,
                         )?;
@@ -3261,10 +3295,10 @@ impl TextServiceFactory {
                         raw_hiragana = selected.hiragana;
 
                         self.set_text(&preview, &suffix)?;
-                        ipc_service.set_candidates(candidates.texts.clone())?;
-                        ipc_service.set_selection(selection_index)?;
                         self.sync_candidate_window_after_text_update(
                             &mut ipc_service,
+                            &candidates,
+                            selection_index,
                             &app_config,
                             &transition,
                         )?;
@@ -3296,8 +3330,13 @@ impl TextServiceFactory {
                         raw_hiragana = selected.hiragana;
 
                         self.set_text(&preview, &suffix)?;
-                        ipc_service.set_candidates(candidates.texts.clone())?;
-                        ipc_service.set_selection(selection_index)?;
+                        self.sync_candidate_window_update(
+                            &mut ipc_service,
+                            &candidates,
+                            selection_index,
+                            None,
+                            false,
+                        )?;
                     } else {
                         // Server side text is fully removed. Close TSF composition too
                         // so preedit text does not linger in an inconsistent state.
@@ -3324,8 +3363,13 @@ impl TextServiceFactory {
                             self.set_text(&committed_prefix, "")?;
                         }
                         self.end_composition()?;
-                        ipc_service.hide_window()?;
-                        ipc_service.set_candidates(vec![])?;
+                        ipc_service.update_candidate_window(
+                            Some(false),
+                            None,
+                            Some(vec![]),
+                            Some(0),
+                            None,
+                        )?;
                         ipc_service.clear_text()?;
 
                         preview.clear();
@@ -3342,9 +3386,13 @@ impl TextServiceFactory {
                         raw_hiragana = selected.hiragana;
 
                         self.set_text(&preview, &suffix)?;
-                        ipc_service.set_candidates(candidates.texts.clone())?;
-                        ipc_service.set_selection(selection_index)?;
-                        self.update_pos()?;
+                        self.sync_candidate_window_update(
+                            &mut ipc_service,
+                            &candidates,
+                            selection_index,
+                            None,
+                            true,
+                        )?;
                     }
                 }
                 ClientAction::EnsureClauseNavigationReady => {
@@ -3651,7 +3699,7 @@ impl TextServiceFactory {
                 }
                 ClientAction::SetIMEMode(mode) => {
                     self.start_composition()?;
-                    self.update_pos()?;
+                    let position = self.candidate_window_position()?;
                     self.end_composition()?;
 
                     IMEState::set_input_mode(mode.clone())?;
@@ -3664,7 +3712,7 @@ impl TextServiceFactory {
                         InputMode::Kana => "あ",
                     };
 
-                    ipc_service.set_input_mode(mode)?;
+                    ipc_service.update_candidate_window(None, position, None, None, Some(mode))?;
 
                     selection_index = 0;
                     corresponding_count = 0;
@@ -3806,9 +3854,13 @@ impl TextServiceFactory {
                         suffix = selected.sub_text.clone();
                         raw_hiragana = selected.hiragana;
 
-                        ipc_service.set_candidates(candidates.texts.clone())?;
-                        ipc_service.set_selection(selection_index)?;
-                        self.update_pos()?;
+                        self.sync_candidate_window_update(
+                            &mut ipc_service,
+                            &candidates,
+                            selection_index,
+                            None,
+                            true,
+                        )?;
                     }
 
                     transition = CompositionState::Composing;
@@ -3843,9 +3895,13 @@ impl TextServiceFactory {
                         suffix = selected.sub_text.clone();
                         raw_hiragana = selected.hiragana;
 
-                        ipc_service.set_candidates(candidates.texts.clone())?;
-                        ipc_service.set_selection(selection_index)?;
-                        self.update_pos()?;
+                        self.sync_candidate_window_update(
+                            &mut ipc_service,
+                            &candidates,
+                            selection_index,
+                            None,
+                            true,
+                        )?;
                     }
 
                     transition = CompositionState::Composing;
@@ -3880,9 +3936,13 @@ impl TextServiceFactory {
                         suffix = selected.sub_text.clone();
                         raw_hiragana = selected.hiragana;
 
-                        ipc_service.set_candidates(candidates.texts.clone())?;
-                        ipc_service.set_selection(selection_index)?;
-                        self.update_pos()?;
+                        self.sync_candidate_window_update(
+                            &mut ipc_service,
+                            &candidates,
+                            selection_index,
+                            None,
+                            true,
+                        )?;
                     }
 
                     transition = CompositionState::Composing;

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -370,6 +370,29 @@ impl IPCService {
 
         Ok(())
     }
+
+    #[tracing::instrument(skip(candidates))]
+    pub fn update_candidate_window(
+        &mut self,
+        visible: Option<bool>,
+        position: Option<shared::proto::WindowPosition>,
+        candidates: Option<Vec<String>>,
+        selected_index: Option<i32>,
+        input_mode: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let request = tonic::Request::new(shared::proto::UpdateCandidateWindowRequest {
+            visible,
+            position,
+            candidates: candidates.map(|candidates| shared::proto::CandidateList { candidates }),
+            selected_index,
+            input_mode: input_mode.map(ToString::to_string),
+        });
+        self.runtime
+            .clone()
+            .block_on(self.window_client.update_candidate_window(request))?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -14,9 +14,10 @@ use windows::{
 
 use std::{cell::Cell, mem::ManuallyDrop, rc::Rc, time::Instant};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use crate::{engine::state::IMEState, extension::StringExt as _, globals::GUID_DISPLAY_ATTRIBUTE};
+use shared::proto::WindowPosition;
 
 use super::factory::TextServiceFactory;
 
@@ -283,13 +284,15 @@ impl TextServiceFactory {
     }
 
     #[tracing::instrument]
-    pub fn update_pos(&self) -> Result<()> {
+    pub fn candidate_window_position(&self) -> Result<Option<WindowPosition>> {
         {
             let mut text_service = match self.borrow_mut() {
                 Ok(text_service) => text_service,
                 Err(error) => {
-                    tracing::warn!("Skip update_pos due to borrow conflict: {error:?}");
-                    return Ok(());
+                    tracing::warn!(
+                        "Skip candidate_window_position due to borrow conflict: {error:?}"
+                    );
+                    return Ok(None);
                 }
             };
 
@@ -297,12 +300,12 @@ impl TextServiceFactory {
                 .update_pos_state
                 .try_begin_update(Instant::now())
             {
-                tracing::debug!("Skip re-entrant update_pos call");
-                return Ok(());
+                tracing::debug!("Skip re-entrant candidate_window_position call");
+                return Ok(None);
             }
         }
 
-        let result: Result<()> = (|| {
+        let result: Result<Option<WindowPosition>> = (|| {
             let (tid, context, tip_composition) = {
                 let text_service = self.borrow()?;
                 let composition = text_service.borrow_composition()?;
@@ -314,7 +317,7 @@ impl TextServiceFactory {
             };
 
             if let Some(tip_composition) = tip_composition {
-                edit_session(
+                let position = edit_session(
                     tid,
                     context.clone(),
                     Rc::new({
@@ -324,28 +327,23 @@ impl TextServiceFactory {
                             let view = context.GetActiveView()?;
                             let range = tip_composition.GetRange()?;
 
-                            let Some(mut ipc_service) = IMEState::ipc_service()? else {
-                                return Ok(());
-                            };
-
                             let mut rect = RECT::default();
                             let mut clipped = false.into();
                             view.GetTextExt(cookie, &range, &mut rect, &mut clipped)?;
 
-                            ipc_service.set_window_position(
-                                rect.top,
-                                rect.left,
-                                rect.bottom,
-                                rect.right,
-                            )?;
-
-                            Ok(())
+                            Ok(WindowPosition {
+                                top: rect.top,
+                                left: rect.left,
+                                bottom: rect.bottom,
+                                right: rect.right,
+                            })
                         }
                     }),
                 )?;
+                Ok(position)
+            } else {
+                Ok(None)
             }
-
-            Ok(())
         })();
 
         match self.borrow_mut() {
@@ -357,10 +355,23 @@ impl TextServiceFactory {
             }
         }
 
-        if let Err(error) = result {
-            tracing::warn!("Failed to update composition window position: {error:?}");
+        match result {
+            Ok(position) => Ok(position),
+            Err(error) => {
+                tracing::warn!("Failed to obtain composition window position: {error:?}");
+                Ok(None)
+            }
         }
+    }
 
+    #[tracing::instrument]
+    pub fn update_pos(&self) -> Result<()> {
+        if let Some(position) = self.candidate_window_position()? {
+            if let Some(mut ipc_service) = IMEState::ipc_service()? {
+                ipc_service.update_candidate_window(None, Some(position), None, None, None)?;
+                IMEState::set_ipc_service(ipc_service)?;
+            }
+        }
         Ok(())
     }
 }

--- a/crates/client/src/tsf/thread_mgr_event_sink.rs
+++ b/crates/client/src/tsf/thread_mgr_event_sink.rs
@@ -17,8 +17,8 @@ impl TextServiceFactory {
         let (changed, ipc_service) = IMEState::set_keyboard_disabled_and_clone_ipc(disabled)?;
 
         if let Some(mut ipc_service) = ipc_service {
-            let _ = ipc_service.hide_window();
-            let _ = ipc_service.set_candidates(vec![]);
+            let _ =
+                ipc_service.update_candidate_window(Some(false), None, Some(vec![]), Some(0), None);
 
             IMEState::set_ipc_service(ipc_service)?;
         }

--- a/crates/shared/window.proto
+++ b/crates/shared/window.proto
@@ -20,6 +20,11 @@ message SetCandidateRequest {
   repeated string candidates = 1;
 }
 
+// 変換候補一覧を候補ウィンドウ更新に含めるためのメッセージ
+message CandidateList {
+  repeated string candidates = 1;
+}
+
 // 変換候補を選択するメッセージ
 message SetSelectionRequest {
   int32 index = 1;
@@ -27,6 +32,15 @@ message SetSelectionRequest {
 
 message SetInputModeRequest {
   string mode = 1;
+}
+
+// 候補ウィンドウの状態をまとめて更新するメッセージ
+message UpdateCandidateWindowRequest {
+  optional bool visible = 1;
+  WindowPosition position = 2;
+  CandidateList candidates = 3;
+  optional int32 selected_index = 4;
+  optional string input_mode = 5;
 }
 
 // 候補ウィンドウ制御に対する空のレスポンス
@@ -40,4 +54,5 @@ service WindowService {
   rpc SetSelection (SetSelectionRequest) returns (EmptyResponse); // 変換候補を選択
   rpc SetWindowPosition (SetPositionRequest) returns (EmptyResponse); // ウィンドウの位置を設定
   rpc SetInputMode (SetInputModeRequest) returns (EmptyResponse); // 変換モードの設定
+  rpc UpdateCandidateWindow (UpdateCandidateWindowRequest) returns (EmptyResponse); // 候補ウィンドウ状態をまとめて更新
 }

--- a/crates/ui/src/ipc.rs
+++ b/crates/ui/src/ipc.rs
@@ -1,6 +1,6 @@
 use shared::proto::{
     window_service_server::WindowService as WindowServiceProto, EmptyResponse, SetCandidateRequest,
-    SetInputModeRequest, SetPositionRequest, SetSelectionRequest,
+    SetInputModeRequest, SetPositionRequest, SetSelectionRequest, UpdateCandidateWindowRequest,
 };
 use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
@@ -34,6 +34,21 @@ pub enum WindowAction {
         candidates: Vec<String>,
     },
     SetInputMode(String),
+    UpdateCandidateWindow {
+        visible: Option<bool>,
+        position: Option<WindowPositionAction>,
+        candidates: Option<Vec<String>>,
+        selected_index: Option<i32>,
+        input_mode: Option<String>,
+    },
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct WindowPositionAction {
+    pub top: i32,
+    pub left: i32,
+    pub bottom: i32,
+    pub right: i32,
 }
 
 #[derive(Debug)]
@@ -116,6 +131,31 @@ impl WindowServiceProto for WindowService {
         let mode = request.into_inner().mode;
         self.send_action(WindowAction::SetInputMode(mode)).await
     }
+
+    async fn update_candidate_window(
+        &self,
+        request: Request<UpdateCandidateWindowRequest>,
+    ) -> Result<Response<EmptyResponse>, Status> {
+        let request = request.into_inner();
+        let position = request.position.map(|position| WindowPositionAction {
+            top: position.top,
+            left: position.left,
+            bottom: position.bottom,
+            right: position.right,
+        });
+        let candidates = request
+            .candidates
+            .map(|candidate_list| candidate_list.candidates);
+
+        self.send_action(WindowAction::UpdateCandidateWindow {
+            visible: request.visible,
+            position,
+            candidates,
+            selected_index: request.selected_index,
+            input_mode: request.input_mode,
+        })
+        .await
+    }
 }
 
 #[cfg(test)]
@@ -170,6 +210,50 @@ mod tests {
                 right,
             } => {
                 assert_eq!((top, left, bottom, right), (1, 2, 3, 4));
+            }
+            action => panic!("unexpected action: {action:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn update_candidate_window_sends_batched_action() {
+        let (service, mut receiver) = service_with_receiver();
+
+        service
+            .update_candidate_window(Request::new(UpdateCandidateWindowRequest {
+                visible: Some(true),
+                position: Some(WindowPosition {
+                    top: 1,
+                    left: 2,
+                    bottom: 3,
+                    right: 4,
+                }),
+                candidates: Some(shared::proto::CandidateList {
+                    candidates: vec!["候補".to_string()],
+                }),
+                selected_index: Some(0),
+                input_mode: Some("あ".to_string()),
+            }))
+            .await
+            .expect("batched update should be sent");
+
+        match receiver.recv().await.expect("action should be queued") {
+            WindowAction::UpdateCandidateWindow {
+                visible,
+                position,
+                candidates,
+                selected_index,
+                input_mode,
+            } => {
+                assert_eq!(visible, Some(true));
+                let position = position.expect("position should be included");
+                assert_eq!(
+                    (position.top, position.left, position.bottom, position.right),
+                    (1, 2, 3, 4)
+                );
+                assert_eq!(candidates, Some(vec!["候補".to_string()]));
+                assert_eq!(selected_index, Some(0));
+                assert_eq!(input_mode, Some("あ".to_string()));
             }
             action => panic!("unexpected action: {action:?}"),
         }

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -62,6 +62,70 @@ fn evaluate_script(webview: &wry::WebView, script: &str) {
     }
 }
 
+fn set_candidate_window_width(candidate_window: &tao::window::Window, candidates: &[String]) {
+    let max_len = candidates
+        .iter()
+        .map(|s| s.chars().count())
+        .max()
+        .unwrap_or(0) as u32;
+
+    let height = candidate_window.inner_size().height as i32;
+    candidate_window.set_inner_size(PhysicalSize::new(
+        max(225, 120 + max_len * 18),
+        height as u32,
+    ));
+}
+
+fn update_candidate_list(candidate_webview: &wry::WebView, candidates: &[String]) {
+    match serde_json::to_string(candidates) {
+        Ok(candidates) => {
+            evaluate_script(
+                candidate_webview,
+                &format!("updateCandidates({})", candidates),
+            );
+        }
+        Err(error) => {
+            eprintln!("Warning: Failed to serialize candidates: {error:?}");
+        }
+    }
+}
+
+fn update_indicator(indicator_webview: &wry::WebView, input_method: &str) {
+    match serde_json::to_string(input_method) {
+        Ok(input_method) => evaluate_script(
+            indicator_webview,
+            &format!("updateInputMethod({})", input_method),
+        ),
+        Err(error) => {
+            eprintln!("Warning: Failed to serialize input method: {error:?}");
+        }
+    }
+}
+
+fn keep_windows_topmost(candidate_window: &tao::window::Window, indicator_hwnd: isize) {
+    unsafe {
+        let _ = SetWindowPos(
+            HWND(candidate_window.hwnd() as *mut std::ffi::c_void),
+            HWND_TOPMOST,
+            0,
+            0,
+            0,
+            0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
+        );
+
+        let _ = SetWindowPos(
+            HWND(indicator_hwnd as *mut std::ffi::c_void),
+            HWND_TOPMOST,
+            0,
+            0,
+            0,
+            0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
+        );
+    }
+}
+
 #[derive(Debug)]
 pub enum UserEvent {
     UpdateHeight(i32),
@@ -154,15 +218,7 @@ async fn main() -> anyhow::Result<()> {
                     evaluate_script(&candidate_webview, &format!("updateSelection({})", index));
                 }
                 UserEvent::UpdateInputMethod(input_method) => {
-                    match serde_json::to_string(&input_method) {
-                        Ok(input_method) => evaluate_script(
-                            &indicator_webview,
-                            &format!("updateInputMethod({})", input_method),
-                        ),
-                        Err(error) => {
-                            eprintln!("Warning: Failed to serialize input method: {error:?}");
-                        }
-                    }
+                    update_indicator(&indicator_webview, &input_method);
                 }
                 UserEvent::UpdateHeight(height) => {
                     let width = candidate_window.inner_size().width as i32;
@@ -218,53 +274,12 @@ async fn main() -> anyhow::Result<()> {
                             let rect = CandidateRect::new(top, left, bottom, right);
                             last_candidate_rect = Some(rect);
 
-                            unsafe {
-                                let _ = SetWindowPos(
-                                    HWND(candidate_window.hwnd() as *mut std::ffi::c_void),
-                                    HWND_TOPMOST,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
-                                );
-
-                                let _ = SetWindowPos(
-                                    HWND(indicator_hwnd as *mut std::ffi::c_void),
-                                    HWND_TOPMOST,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
-                                );
-                            }
+                            keep_windows_topmost(&candidate_window, indicator_hwnd);
                             place_candidate_windows(&candidate_window, &indicator_window, rect);
                         }
                         WindowAction::SetCandidate { candidates } => {
-                            let max_len = candidates
-                                .iter()
-                                .map(|s| s.chars().count())
-                                .max()
-                                .unwrap_or(0) as u32;
-
-                            let height = candidate_window.inner_size().height as i32;
-                            candidate_window.set_inner_size(PhysicalSize::new(
-                                max(225, 120 + max_len * 18),
-                                height as u32,
-                            ));
-
-                            match serde_json::to_string(&candidates) {
-                                Ok(candidates) => {
-                                    send_user_event(
-                                        &event_loop_proxy,
-                                        UserEvent::UpdateCandidates(candidates),
-                                    );
-                                }
-                                Err(error) => {
-                                    eprintln!("Warning: Failed to serialize candidates: {error:?}");
-                                }
-                            }
+                            set_candidate_window_width(&candidate_window, &candidates);
+                            update_candidate_list(&candidate_webview, &candidates);
                             if let Some(rect) = last_candidate_rect {
                                 place_candidate_windows(&candidate_window, &indicator_window, rect);
                             }
@@ -273,10 +288,7 @@ async fn main() -> anyhow::Result<()> {
                             send_user_event(&event_loop_proxy, UserEvent::UpdateSelection(index));
                         }
                         WindowAction::SetInputMode(input_method) => {
-                            send_user_event(
-                                &event_loop_proxy,
-                                UserEvent::UpdateInputMethod(input_method),
-                            );
+                            update_indicator(&indicator_webview, &input_method);
 
                             let task_guard = task_guard.try_lock();
 
@@ -300,6 +312,111 @@ async fn main() -> anyhow::Result<()> {
                                         )
                                     };
                                 }));
+                            }
+                        }
+                        WindowAction::UpdateCandidateWindow {
+                            visible,
+                            position,
+                            candidates,
+                            selected_index,
+                            input_mode,
+                        } => {
+                            if let Some(ref candidates) = candidates {
+                                set_candidate_window_width(&candidate_window, candidates);
+                                update_candidate_list(&candidate_webview, candidates);
+                            }
+
+                            if let Some(index) = selected_index {
+                                evaluate_script(
+                                    &candidate_webview,
+                                    &format!("updateSelection({})", index),
+                                );
+                            }
+
+                            if let Some(position) = position {
+                                let rect = CandidateRect::new(
+                                    position.top,
+                                    position.left,
+                                    position.bottom,
+                                    position.right,
+                                );
+                                last_candidate_rect = Some(rect);
+                                keep_windows_topmost(&candidate_window, indicator_hwnd);
+                                place_candidate_windows(&candidate_window, &indicator_window, rect);
+                            } else if candidates.is_some() {
+                                if let Some(rect) = last_candidate_rect {
+                                    place_candidate_windows(
+                                        &candidate_window,
+                                        &indicator_window,
+                                        rect,
+                                    );
+                                }
+                            }
+
+                            if let Some(input_method) = input_mode {
+                                update_indicator(&indicator_webview, &input_method);
+
+                                let task_guard = task_guard.try_lock();
+
+                                if let Ok(mut task_guard) = task_guard {
+                                    if let Some(task) = task_guard.take() {
+                                        task.abort();
+                                    }
+
+                                    *task_guard = Some(tokio::spawn(async move {
+                                        let _ = unsafe {
+                                            ShowWindow(
+                                                HWND(indicator_hwnd as *mut std::ffi::c_void),
+                                                SW_SHOWNOACTIVATE,
+                                            )
+                                        };
+                                        tokio::time::sleep(std::time::Duration::from_millis(500))
+                                            .await;
+                                        let _ = unsafe {
+                                            ShowWindow(
+                                                HWND(indicator_hwnd as *mut std::ffi::c_void),
+                                                SW_HIDE,
+                                            )
+                                        };
+                                    }));
+                                }
+                            }
+
+                            if let Some(visible) = visible {
+                                if visible {
+                                    let mut task_guard = match task_guard.try_lock() {
+                                        Ok(guard) => guard,
+                                        Err(_) => {
+                                            eprintln!(
+                                                "Warning: Failed to lock task_guard, skipping cleanup"
+                                            );
+                                            return;
+                                        }
+                                    };
+                                    if let Some(task) = task_guard.take() {
+                                        task.abort();
+                                        let _ = unsafe {
+                                            ShowWindow(
+                                                HWND(indicator_hwnd as *mut std::ffi::c_void),
+                                                SW_HIDE,
+                                            )
+                                        };
+                                    }
+
+                                    let _ = unsafe {
+                                        ShowWindow(
+                                            HWND(candidate_window.hwnd() as *mut std::ffi::c_void),
+                                            SW_SHOWNOACTIVATE,
+                                        )
+                                    };
+                                } else {
+                                    let _ = unsafe {
+                                        ShowWindow(
+                                            HWND(candidate_window.hwnd() as *mut std::ffi::c_void),
+                                            SW_HIDE,
+                                        )
+                                    };
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- 候補ウィンドウ更新を `UpdateCandidateWindow` RPC にまとめ、候補一覧・選択 index・表示位置・表示状態・入力モードを 1 event で UI 側へ渡せるようにしました。
- IME DLL 側の候補更新ホットパスを、`set_candidates` / `set_selection` / `set_window_position` / `show_window` の個別 RPC 連打からバッチ更新へ寄せました。
- UI 側では既存の個別 RPC 互換を残しつつ、バッチ更新時に WebView 更新・window size・position・visible state を同じ `WindowAction` 内で反映するようにしました。

## Background
- Issue: Closes #55
- これまで候補ウィンドウ更新は `show_window` / `hide_window` / `set_window_position` / `set_candidates` / `set_selection` / `set_input_mode` に分かれており、1 回の候補更新で複数 RPC が発生していました。
- 候補一覧、選択 index、表示位置、visible state が別イベントで処理されるため、UI server が詰まった場合に古い候補や選択状態が一時的に表示される余地がありました。
- 入力ホットパスの IPC 回数を減らしつつ、既存 RPC 互換は段階的移行用に残す必要がありました。

## Changes
- shared / proto
  - `CandidateList` と `UpdateCandidateWindowRequest` を追加
  - `visible` / `selected_index` / `input_mode` は optional にし、位置だけ・候補だけ・表示だけの更新も 1 RPC で表現できるようにしました
  - 既存の `ShowWindow` / `HideWindow` / `SetCandidate` / `SetSelection` / `SetWindowPosition` / `SetInputMode` は互換用に維持
- client / IPC
  - `IPCService::update_candidate_window` を追加
  - TSF edit session から候補位置を取得する `candidate_window_position()` を追加し、位置取得と window RPC 送信を分離
  - `update_pos()` は新 RPC の position-only update を使うように変更
- client / composition
  - 候補一覧 + selection + position + show をまとめて送る helper を追加
  - append / raw append / direct append / cursor move / shrink / clause action / IME mode 切替 / composition 終了の候補 UI 同期をバッチ更新へ移行
  - keyboard disabled / disabled context recovery 時の hide + clear もバッチ更新へ移行
- ui
  - `WindowAction::UpdateCandidateWindow` を追加
  - candidate list 更新、selection 更新、window width 調整、position 更新、visible state 変更を 1 event 内で処理
  - input mode をバッチ更新に含めた場合も、従来の「あ/A」インジケーター表示タイマーを維持
  - 新 RPC が期待どおり `WindowAction` に変換される unit test を追加

## Verification
- [x] format / diff check
  - `cargo fmt --all`
  - `git diff --check`
- [x] ローカル shared unit tests
  - `PROTOC=/home/batao9/workspaces/azooKey-Windows/.local/tmp/protoc/bin/protoc cargo test -p shared`
  - `8 passed; 0 failed`
- [x] ローカル Windows VM test（client composition）
  - `bash .local/vm_test_client_composition.sh feature/55-batch-candidate-window-update composition skip`
  - `94 passed; 0 failed; 19 filtered out`
  - log: `.local/logs/vm-client-test-20260525-210518.log`
- [x] ローカル Windows VM build 成功
  - `.local/vm_build_master.sh feature/55-batch-candidate-window-update`
  - artifact: `.local/artifacts/azookey-setup-feature_55-batch-candidate-window-update-20260525-211419.exe`
- [ ] GitHub Actions build 成功
  - run: pending after `6b781b1` push

## Checklist
- [ ] CI run URL と結果を記載した
- [x] VM test / build 結果を記載した
- [x] 影響範囲を確認した
- [x] 既存 RPC 互換を残していることを確認した