### PR TITLE
feat(updater): add settings app update flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,9 +612,9 @@ dependencies = [
  "bitflags 2.6.0",
  "block",
  "cocoa-foundation",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -627,7 +627,7 @@ checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
 dependencies = [
  "bitflags 2.6.0",
  "block",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics-types",
  "libc",
  "objc",
@@ -670,6 +670,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
@@ -691,9 +701,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -704,7 +714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "libc",
 ]
 
@@ -994,6 +1004,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,12 +1144,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1143,6 +1171,12 @@ dependencies = [
  "quote",
  "syn 2.0.91",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1165,8 +1199,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "hyper-util",
+ "reqwest",
+ "semver",
  "serde",
  "serde_json",
+ "sha2",
  "shared",
  "tauri",
  "tauri-build",
@@ -1705,6 +1742,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +1766,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2303,6 +2371,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,6 +2740,49 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3291,25 +3419,33 @@ checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "tower 0.5.2",
  "tower-service",
@@ -3319,6 +3455,20 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3350,6 +3500,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3368,6 +3560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3402,6 +3603,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3681,7 +3905,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2",
@@ -3765,6 +3989,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3818,6 +4048,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3838,7 +4089,7 @@ checksum = "cc6b53216f32e60efc27dfa111268481e4dfba53e553e4cdebcaed9db36c11bb"
 dependencies = [
  "bitflags 2.6.0",
  "cocoa",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -4303,6 +4554,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4677,6 +4948,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4733,6 +5010,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5092,6 +5375,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5155,6 +5444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5629,6 +5927,12 @@ dependencies = [
  "syn 2.0.91",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerovec"

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -29,6 +29,9 @@ tonic = "0.12.3"
 tokio = { version = "1.42.0", features = ["rt-multi-thread"] }
 tower = "0.5.1"
 hyper-util = { version = "0.1.9", features = ["tokio"] }
+reqwest = { version = "0.12.12", features = ["json"] }
+semver = "1.0"
+sha2 = "0.10"
 
 [dependencies.windows]
 version = "0.58.0"

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod ipc;
+mod updater;
 
 use serde::{Deserialize, Serialize};
 use shared::{AppConfig, AppConfigLoadResult, ConfigError, ConfigRecovery, RomajiRule};
@@ -215,6 +216,25 @@ fn get_default_romaji_rows() -> Vec<RomajiRule> {
     shared::get_default_romaji_rows()
 }
 
+#[tauri::command]
+async fn check_for_updates() -> Result<updater::UpdateCheckResponse, String> {
+    updater::check_for_updates()
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn start_update() -> Result<updater::UpdateStartResponse, String> {
+    updater::download_and_launch_update()
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+fn take_update_install_result() -> Result<Option<updater::UpdateInstallResult>, String> {
+    updater::take_update_install_result().map_err(|error| error.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let app_state = AppState::new();
@@ -228,7 +248,10 @@ pub fn run() {
             take_config_startup_notice,
             update_config,
             check_capability,
-            get_default_romaji_rows
+            get_default_romaji_rows,
+            check_for_updates,
+            start_update,
+            take_update_install_result
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/frontend/src-tauri/src/updater.rs
+++ b/frontend/src-tauri/src/updater.rs
@@ -1,0 +1,728 @@
+use anyhow::{anyhow, Context, Result};
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    env, fs,
+    io::Write,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+const DEFAULT_RELEASE_API_URL: &str =
+    "https://api.github.com/repos/batao9/azooKey-Windows/releases/latest";
+const RELEASE_API_URL_ENV: &str = "AZOOKEY_UPDATE_RELEASE_API_URL";
+const CURRENT_VERSION_ENV: &str = "AZOOKEY_UPDATE_CURRENT_VERSION";
+const INSTALLER_ASSET_NAME: &str = "azookey-setup.exe";
+const SHA256SUMS_ASSET_NAME: &str = "SHA256SUMS.txt";
+const UPDATE_RESULT_FILENAME: &str = "update-result.json";
+const APP_VERSION_JSON: &str = include_str!("../../../app-version.json");
+
+#[derive(Debug, Deserialize)]
+struct AppVersionConfig {
+    version: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct ReleaseAsset {
+    name: String,
+    #[serde(default)]
+    browser_download_url: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct GithubRelease {
+    tag_name: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    html_url: String,
+    assets: Vec<ReleaseAsset>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct UpdateCheckResponse {
+    pub current_version: String,
+    pub latest_version: String,
+    pub latest_tag: String,
+    pub release_name: String,
+    pub release_url: String,
+    pub update_available: bool,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct UpdateStartResponse {
+    pub latest_version: String,
+    pub installer_path: String,
+    pub result_path: String,
+    pub install_log_path: String,
+    pub launched: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct UpdateInstallResult {
+    pub status: String,
+    pub exit_code: Option<i32>,
+    pub needs_restart: bool,
+    pub message: String,
+    pub completed_at: String,
+    pub installer_path: Option<String>,
+    pub install_log_path: Option<String>,
+}
+
+struct ReleaseAssets {
+    installer_url: String,
+    sha256sums_url: String,
+}
+
+pub async fn check_for_updates() -> Result<UpdateCheckResponse> {
+    let release = fetch_latest_release().await?;
+    update_check_response(&release)
+}
+
+pub async fn download_and_launch_update() -> Result<UpdateStartResponse> {
+    let release = fetch_latest_release().await?;
+    let check = update_check_response(&release)?;
+    if !check.update_available {
+        return Err(anyhow!("利用可能な更新はありません"));
+    }
+
+    let assets = select_release_assets(&release.assets)?;
+    let client = http_client()?;
+    let sha256sums = download_text(&client, &assets.sha256sums_url).await?;
+    let expected_hash = parse_sha256sum(&sha256sums, INSTALLER_ASSET_NAME)?;
+
+    let staging_dir = updater_staging_dir()?;
+    fs::create_dir_all(&staging_dir).with_context(|| {
+        format!(
+            "failed to create update staging dir: {}",
+            staging_dir.display()
+        )
+    })?;
+    let installer_path = staging_dir.join(INSTALLER_ASSET_NAME);
+    let actual_hash =
+        match download_file_with_sha256(&client, &assets.installer_url, &installer_path).await {
+            Ok(hash) => hash,
+            Err(error) => {
+                cleanup_download_paths(&installer_path);
+                return Err(error);
+            }
+        };
+    if !hashes_match(&expected_hash, &actual_hash) {
+        cleanup_download_paths(&installer_path);
+        return Err(anyhow!(
+            "installer hash mismatch: expected {}, actual {}",
+            expected_hash,
+            actual_hash
+        ));
+    }
+
+    let result_path = update_result_path()?;
+    let install_log_path = staging_dir.join("azookey-update-install.log");
+    launch_installer_helper(&installer_path, &result_path, &install_log_path)?;
+
+    Ok(UpdateStartResponse {
+        latest_version: check.latest_version,
+        installer_path: installer_path.display().to_string(),
+        result_path: result_path.display().to_string(),
+        install_log_path: install_log_path.display().to_string(),
+        launched: true,
+    })
+}
+
+pub fn take_update_install_result() -> Result<Option<UpdateInstallResult>> {
+    let path = update_result_path()?;
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let data = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read update result: {}", path.display()))?;
+    let result = serde_json::from_str(&data)
+        .with_context(|| format!("failed to parse update result: {}", path.display()))?;
+    fs::remove_file(&path)
+        .with_context(|| format!("failed to remove update result: {}", path.display()))?;
+    Ok(Some(result))
+}
+
+async fn fetch_latest_release() -> Result<GithubRelease> {
+    let url = release_api_url();
+    let client = http_client()?;
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("failed to request latest release: {url}"))?
+        .error_for_status()
+        .with_context(|| format!("latest release request failed: {url}"))?;
+
+    response
+        .json::<GithubRelease>()
+        .await
+        .context("failed to parse latest release response")
+}
+
+fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent("azookey-windows-updater")
+        .build()
+        .context("failed to build HTTP client")
+}
+
+fn release_api_url() -> String {
+    env::var(RELEASE_API_URL_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_RELEASE_API_URL.to_string())
+}
+
+fn current_version_string() -> Result<String> {
+    if let Ok(version) = env::var(CURRENT_VERSION_ENV) {
+        let trimmed = version.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    let config: AppVersionConfig =
+        serde_json::from_str(APP_VERSION_JSON).context("failed to parse app-version.json")?;
+    Ok(config.version)
+}
+
+fn update_check_response(release: &GithubRelease) -> Result<UpdateCheckResponse> {
+    let current_version = current_version_string()?;
+    let latest_version = normalize_version(&release.tag_name)?;
+    let current = parse_version(&current_version)?;
+    let latest = parse_version(&latest_version)?;
+
+    Ok(UpdateCheckResponse {
+        current_version,
+        latest_version,
+        latest_tag: release.tag_name.clone(),
+        release_name: release.name.clone(),
+        release_url: release.html_url.clone(),
+        update_available: latest > current,
+    })
+}
+
+fn normalize_version(value: &str) -> Result<String> {
+    let trimmed = value.trim();
+    let without_prefix = trimmed.strip_prefix('v').unwrap_or(trimmed);
+    parse_version(without_prefix)?;
+    Ok(without_prefix.to_string())
+}
+
+fn parse_version(value: &str) -> Result<Version> {
+    Version::parse(value.trim().strip_prefix('v').unwrap_or(value.trim()))
+        .with_context(|| format!("invalid version: {value}"))
+}
+
+fn select_release_assets(assets: &[ReleaseAsset]) -> Result<ReleaseAssets> {
+    let installer = find_asset_download_url(assets, INSTALLER_ASSET_NAME)?;
+    let sha256sums = find_asset_download_url(assets, SHA256SUMS_ASSET_NAME)?;
+    Ok(ReleaseAssets {
+        installer_url: installer.to_string(),
+        sha256sums_url: sha256sums.to_string(),
+    })
+}
+
+fn find_asset_download_url<'a>(assets: &'a [ReleaseAsset], name: &str) -> Result<&'a str> {
+    let asset = assets
+        .iter()
+        .find(|asset| asset.name == name)
+        .ok_or_else(|| anyhow!("release asset not found: {name}"))?;
+    if asset.browser_download_url.trim().is_empty() {
+        return Err(anyhow!("release asset has no download URL: {name}"));
+    }
+    Ok(&asset.browser_download_url)
+}
+
+async fn download_text(client: &reqwest::Client, url: &str) -> Result<String> {
+    client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("failed to download {url}"))?
+        .error_for_status()
+        .with_context(|| format!("download failed: {url}"))?
+        .text()
+        .await
+        .with_context(|| format!("failed to read text response: {url}"))
+}
+
+async fn download_file_with_sha256(
+    client: &reqwest::Client,
+    url: &str,
+    destination: &Path,
+) -> Result<String> {
+    cleanup_download_paths(destination);
+    let bytes = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("failed to download {url}"))?
+        .error_for_status()
+        .with_context(|| format!("download failed: {url}"))?
+        .bytes()
+        .await
+        .with_context(|| format!("failed to read binary response: {url}"))?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let digest = hasher.finalize();
+    let hash = format_sha256(&digest);
+    let partial = partial_download_path(destination);
+    fs::write(&partial, &bytes)
+        .with_context(|| format!("failed to write installer: {}", partial.display()))?;
+    fs::rename(&partial, destination).with_context(|| {
+        format!(
+            "failed to move installer into place: {}",
+            destination.display()
+        )
+    })?;
+    Ok(hash)
+}
+
+fn cleanup_download_paths(destination: &Path) {
+    let _ = fs::remove_file(destination);
+    let _ = fs::remove_file(partial_download_path(destination));
+}
+
+fn partial_download_path(destination: &Path) -> PathBuf {
+    let file_name = destination
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "download".into());
+    destination.with_file_name(format!("{file_name}.part"))
+}
+
+fn parse_sha256sum(contents: &str, filename: &str) -> Result<String> {
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let mut parts = trimmed.split_whitespace();
+        let Some(hash) = parts.next() else {
+            continue;
+        };
+        let Some(name) = parts.next() else {
+            continue;
+        };
+        if name.trim_start_matches('*') == filename {
+            if hash.len() == 64 && hash.chars().all(|ch| ch.is_ascii_hexdigit()) {
+                return Ok(hash.to_ascii_lowercase());
+            }
+            return Err(anyhow!("invalid SHA-256 hash for {filename}"));
+        }
+    }
+
+    Err(anyhow!("SHA-256 hash not found for {filename}"))
+}
+
+fn hashes_match(expected: &str, actual: &str) -> bool {
+    expected.eq_ignore_ascii_case(actual)
+}
+
+fn format_sha256(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn app_data_dir() -> Result<PathBuf> {
+    let appdata = env::var_os("APPDATA").ok_or_else(|| anyhow!("APPDATA is not set"))?;
+    Ok(PathBuf::from(appdata).join("Azookey"))
+}
+
+fn update_result_path() -> Result<PathBuf> {
+    let dir = app_data_dir()?;
+    fs::create_dir_all(&dir)
+        .with_context(|| format!("failed to create app data dir: {}", dir.display()))?;
+    Ok(dir.join(UPDATE_RESULT_FILENAME))
+}
+
+fn updater_staging_dir() -> Result<PathBuf> {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before UNIX epoch")?
+        .as_secs();
+    Ok(env::temp_dir().join(format!("azookey-update-{nonce}")))
+}
+
+fn launch_installer_helper(
+    installer_path: &Path,
+    result_path: &Path,
+    install_log_path: &Path,
+) -> Result<()> {
+    let script_path = installer_path
+        .parent()
+        .ok_or_else(|| anyhow!("installer path has no parent"))?
+        .join("azookey-update-helper.ps1");
+    write_installer_helper_script(&script_path)?;
+
+    let status = Command::new("powershell")
+        .arg("-NoProfile")
+        .arg("-ExecutionPolicy")
+        .arg("Bypass")
+        .arg("-WindowStyle")
+        .arg("Hidden")
+        .arg("-File")
+        .arg(&script_path)
+        .arg("-InstallerPath")
+        .arg(installer_path)
+        .arg("-ResultPath")
+        .arg(result_path)
+        .arg("-InstallLogPath")
+        .arg(install_log_path)
+        .spawn()
+        .context("failed to launch updater helper")?;
+
+    drop(status);
+    Ok(())
+}
+
+fn write_installer_helper_script(script_path: &Path) -> Result<()> {
+    let mut file = fs::File::create(script_path)
+        .with_context(|| format!("failed to create updater helper: {}", script_path.display()))?;
+    file.write_all(INSTALLER_HELPER_PS1.as_bytes())
+        .with_context(|| format!("failed to write updater helper: {}", script_path.display()))?;
+    Ok(())
+}
+
+const INSTALLER_HELPER_PS1: &str = r#"
+param(
+  [Parameter(Mandatory = $true)][string]$InstallerPath,
+  [Parameter(Mandatory = $true)][string]$ResultPath,
+  [Parameter(Mandatory = $true)][string]$InstallLogPath
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-UpdateResult {
+  param(
+    [Parameter(Mandatory = $true)][string]$Status,
+    [object]$ExitCode,
+    [Parameter(Mandatory = $true)][bool]$NeedsRestart,
+    [Parameter(Mandatory = $true)][string]$Message
+  )
+
+  $resultDir = Split-Path -Parent $ResultPath
+  New-Item -ItemType Directory -Force -Path $resultDir | Out-Null
+  $json = [PSCustomObject]@{
+    status = $Status
+    exit_code = $ExitCode
+    needs_restart = $NeedsRestart
+    message = $Message
+    completed_at = (Get-Date).ToUniversalTime().ToString("o")
+    installer_path = $InstallerPath
+    install_log_path = $InstallLogPath
+  } | ConvertTo-Json -Depth 3
+  $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+  [System.IO.File]::WriteAllText($ResultPath, $json, $utf8NoBom)
+}
+
+try {
+  $installerArgs = @(
+    "/VERYSILENT",
+    "/SUPPRESSMSGBOXES",
+    "/NORESTART",
+    "/LOG=$InstallLogPath"
+  )
+  $proc = Start-Process -FilePath $InstallerPath -ArgumentList $installerArgs -Wait -PassThru
+  if ($proc.ExitCode -eq 0) {
+    Write-UpdateResult -Status "success" -ExitCode $proc.ExitCode -NeedsRestart $false -Message "更新が完了しました。"
+    exit 0
+  }
+  if ($proc.ExitCode -eq 3010) {
+    Write-UpdateResult -Status "success" -ExitCode $proc.ExitCode -NeedsRestart $true -Message "更新が完了しました。Windows の再起動が必要です。"
+    exit 0
+  }
+
+  Write-UpdateResult -Status "failed" -ExitCode $proc.ExitCode -NeedsRestart $false -Message "更新に失敗しました。終了コード: $($proc.ExitCode)"
+  exit 1
+} catch {
+  Write-UpdateResult -Status "failed" -ExitCode $null -NeedsRestart $false -Message $_.Exception.Message
+  exit 1
+}
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        ffi::OsString,
+        sync::{Mutex, MutexGuard, OnceLock},
+    };
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    struct EnvGuard {
+        _guard: MutexGuard<'static, ()>,
+        release_api_url: Option<OsString>,
+        current_version: Option<OsString>,
+        appdata: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            let guard = env_lock();
+            Self {
+                _guard: guard,
+                release_api_url: env::var_os(RELEASE_API_URL_ENV),
+                current_version: env::var_os(CURRENT_VERSION_ENV),
+                appdata: env::var_os("APPDATA"),
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.release_api_url {
+                    Some(value) => env::set_var(RELEASE_API_URL_ENV, value),
+                    None => env::remove_var(RELEASE_API_URL_ENV),
+                }
+                match &self.current_version {
+                    Some(value) => env::set_var(CURRENT_VERSION_ENV, value),
+                    None => env::remove_var(CURRENT_VERSION_ENV),
+                }
+                match &self.appdata {
+                    Some(value) => env::set_var("APPDATA", value),
+                    None => env::remove_var("APPDATA"),
+                }
+            }
+        }
+    }
+
+    fn release(tag_name: &str) -> GithubRelease {
+        GithubRelease {
+            tag_name: tag_name.to_string(),
+            name: format!("Release {tag_name}"),
+            html_url: "https://example.test/release".to_string(),
+            assets: vec![
+                ReleaseAsset {
+                    name: INSTALLER_ASSET_NAME.to_string(),
+                    browser_download_url: "https://example.test/azookey-setup.exe".to_string(),
+                },
+                ReleaseAsset {
+                    name: SHA256SUMS_ASSET_NAME.to_string(),
+                    browser_download_url: "https://example.test/SHA256SUMS.txt".to_string(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn compares_versions_with_v_prefix() {
+        let _env = EnvGuard::new();
+        unsafe {
+            env::set_var(CURRENT_VERSION_ENV, "0.1.0-batao.2");
+        }
+
+        let response = update_check_response(&release("v0.1.0-batao.3")).unwrap();
+
+        assert!(response.update_available);
+        assert_eq!(response.latest_version, "0.1.0-batao.3");
+    }
+
+    #[test]
+    fn reports_no_update_for_same_version() {
+        let _env = EnvGuard::new();
+        unsafe {
+            env::set_var(CURRENT_VERSION_ENV, "0.1.0-batao.3");
+        }
+
+        let response = update_check_response(&release("v0.1.0-batao.3")).unwrap();
+
+        assert!(!response.update_available);
+    }
+
+    #[test]
+    fn compares_prerelease_suffixes_as_semver() {
+        let _env = EnvGuard::new();
+        unsafe {
+            env::set_var(CURRENT_VERSION_ENV, "0.1.0-batao.2");
+        }
+
+        let response = update_check_response(&release("v0.1.0-batao.10")).unwrap();
+
+        assert!(response.update_available);
+    }
+
+    #[test]
+    fn selects_required_release_assets() {
+        let assets = select_release_assets(&release("v0.1.0").assets).unwrap();
+
+        assert_eq!(
+            assets.installer_url,
+            "https://example.test/azookey-setup.exe"
+        );
+        assert_eq!(assets.sha256sums_url, "https://example.test/SHA256SUMS.txt");
+    }
+
+    #[test]
+    fn rejects_missing_release_asset() {
+        let err = select_release_assets(&[]).unwrap_err();
+
+        assert!(err.to_string().contains(INSTALLER_ASSET_NAME));
+    }
+
+    #[test]
+    fn rejects_missing_hash_asset() {
+        let assets = vec![ReleaseAsset {
+            name: INSTALLER_ASSET_NAME.to_string(),
+            browser_download_url: "https://example.test/azookey-setup.exe".to_string(),
+        }];
+
+        let err = select_release_assets(&assets).unwrap_err();
+
+        assert!(err.to_string().contains(SHA256SUMS_ASSET_NAME));
+    }
+
+    #[test]
+    fn rejects_similar_installer_asset_name() {
+        let assets = vec![
+            ReleaseAsset {
+                name: "azookey-setup-old.exe".to_string(),
+                browser_download_url: "https://example.test/azookey-setup-old.exe".to_string(),
+            },
+            ReleaseAsset {
+                name: SHA256SUMS_ASSET_NAME.to_string(),
+                browser_download_url: "https://example.test/SHA256SUMS.txt".to_string(),
+            },
+        ];
+
+        let err = select_release_assets(&assets).unwrap_err();
+
+        assert!(err.to_string().contains(INSTALLER_ASSET_NAME));
+    }
+
+    #[test]
+    fn parses_sha256sum_for_installer() {
+        let hash = "F36FCAE86160DBEA7FD605CCD7355E3DAFE51F04BE10C2FA95E25AA01F60C475";
+        let contents = format!("{hash}  {INSTALLER_ASSET_NAME}\n");
+
+        let parsed = parse_sha256sum(&contents, INSTALLER_ASSET_NAME).unwrap();
+
+        assert_eq!(parsed, hash.to_ascii_lowercase());
+    }
+
+    #[test]
+    fn rejects_hash_mismatch() {
+        assert!(!hashes_match(
+            "a".repeat(64).as_str(),
+            "b".repeat(64).as_str()
+        ));
+    }
+
+    #[test]
+    fn partial_download_path_stays_out_of_final_installer_name() {
+        let path = PathBuf::from(r"C:\Temp\azookey-setup.exe");
+
+        let partial = partial_download_path(&path);
+
+        assert_eq!(
+            partial.file_name().and_then(|name| name.to_str()),
+            Some("azookey-setup.exe.part")
+        );
+    }
+
+    #[test]
+    fn cleanup_removes_final_and_partial_downloads() {
+        let temp = tempfile::tempdir().unwrap();
+        let installer = temp.path().join(INSTALLER_ASSET_NAME);
+        let partial = partial_download_path(&installer);
+        fs::write(&installer, b"final").unwrap();
+        fs::write(&partial, b"partial").unwrap();
+
+        cleanup_download_paths(&installer);
+
+        assert!(!installer.exists());
+        assert!(!partial.exists());
+    }
+
+    #[test]
+    fn env_overrides_are_used() {
+        let _env = EnvGuard::new();
+        unsafe {
+            env::set_var(RELEASE_API_URL_ENV, "http://127.0.0.1:7777/latest.json");
+            env::set_var(CURRENT_VERSION_ENV, "0.0.1");
+        }
+
+        assert_eq!(release_api_url(), "http://127.0.0.1:7777/latest.json");
+        assert_eq!(current_version_string().unwrap(), "0.0.1");
+    }
+
+    #[test]
+    fn update_result_is_taken_once() {
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().unwrap();
+        unsafe {
+            env::set_var("APPDATA", temp.path());
+        }
+        let path = update_result_path().unwrap();
+        fs::write(
+            &path,
+            r#"{
+  "status": "success",
+  "exit_code": 3010,
+  "needs_restart": true,
+  "message": "restart required",
+  "completed_at": "2026-05-27T00:00:00Z",
+  "installer_path": "installer.exe",
+  "install_log_path": "install.log"
+}"#,
+        )
+        .unwrap();
+
+        let result = take_update_install_result().unwrap().unwrap();
+
+        assert_eq!(result.exit_code, Some(3010));
+        assert!(result.needs_restart);
+        assert!(take_update_install_result().unwrap().is_none());
+    }
+
+    #[test]
+    fn update_result_preserves_success_exit_zero() {
+        let result: UpdateInstallResult = serde_json::from_str(
+            r#"{
+  "status": "success",
+  "exit_code": 0,
+  "needs_restart": false,
+  "message": "updated",
+  "completed_at": "2026-05-27T00:00:00Z",
+  "installer_path": "installer.exe",
+  "install_log_path": "install.log"
+}"#,
+        )
+        .unwrap();
+
+        assert_eq!(result.status, "success");
+        assert_eq!(result.exit_code, Some(0));
+        assert!(!result.needs_restart);
+    }
+
+    #[test]
+    fn update_result_preserves_failed_exit_code() {
+        let result: UpdateInstallResult = serde_json::from_str(
+            r#"{
+  "status": "failed",
+  "exit_code": 42,
+  "needs_restart": false,
+  "message": "failed",
+  "completed_at": "2026-05-27T00:00:00Z",
+  "installer_path": "installer.exe",
+  "install_log_path": "install.log"
+}"#,
+        )
+        .unwrap();
+
+        assert_eq!(result.status, "failed");
+        assert_eq!(result.exit_code, Some(42));
+        assert!(!result.needs_restart);
+    }
+}

--- a/frontend/src-tauri/src/updater.rs
+++ b/frontend/src-tauri/src/updater.rs
@@ -257,24 +257,32 @@ async fn download_file_with_sha256(
     destination: &Path,
 ) -> Result<String> {
     cleanup_download_paths(destination);
-    let bytes = client
+    let mut response = client
         .get(url)
         .send()
         .await
         .with_context(|| format!("failed to download {url}"))?
         .error_for_status()
-        .with_context(|| format!("download failed: {url}"))?
-        .bytes()
-        .await
-        .with_context(|| format!("failed to read binary response: {url}"))?;
-
+        .with_context(|| format!("download failed: {url}"))?;
+    let partial = partial_download_path(destination);
+    let mut file = fs::File::create(&partial)
+        .with_context(|| format!("failed to create installer: {}", partial.display()))?;
     let mut hasher = Sha256::new();
-    hasher.update(&bytes);
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .with_context(|| format!("failed to read binary response: {url}"))?
+    {
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .with_context(|| format!("failed to write installer: {}", partial.display()))?;
+    }
+    file.flush()
+        .with_context(|| format!("failed to flush installer: {}", partial.display()))?;
+    drop(file);
+
     let digest = hasher.finalize();
     let hash = format_sha256(&digest);
-    let partial = partial_download_path(destination);
-    fs::write(&partial, &bytes)
-        .with_context(|| format!("failed to write installer: {}", partial.display()))?;
     fs::rename(&partial, destination).with_context(|| {
         format!(
             "failed to move installer into place: {}",
@@ -427,6 +435,7 @@ try {
     "/VERYSILENT",
     "/SUPPRESSMSGBOXES",
     "/NORESTART",
+    "/RESTARTEXITCODE=3010",
     "/LOG=$InstallLogPath"
   )
   $proc = Start-Process -FilePath $InstallerPath -ArgumentList $installerArgs -Wait -PassThru
@@ -643,6 +652,12 @@ mod tests {
 
         assert!(!installer.exists());
         assert!(!partial.exists());
+    }
+
+    #[test]
+    fn helper_requests_restart_exit_code() {
+        assert!(INSTALLER_HELPER_PS1.contains(r#""/NORESTART""#));
+        assert!(INSTALLER_HELPER_PS1.contains(r#""/RESTARTEXITCODE=3010""#));
     }
 
     #[test]

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -13,6 +13,16 @@ type UpdateConfigResponse = {
     message?: string | null;
 };
 
+type UpdateInstallResult = {
+    status: string;
+    exit_code?: number | null;
+    needs_restart: boolean;
+    message: string;
+    completed_at: string;
+    installer_path?: string | null;
+    install_log_path?: string | null;
+};
+
 const SERVER_APPLY_WARNING =
     "設定を保存しましたが、IME への反映に失敗しました。再起動後に反映されます。";
 
@@ -33,6 +43,30 @@ export const showConfigStartupNoticeOnce = async () => {
         });
     } catch (_error) {
         // Startup notice is best effort; normal settings loading still handles errors.
+    }
+};
+
+export const showUpdateInstallResultOnce = async () => {
+    try {
+        const result = await invoke<UpdateInstallResult | null>(
+            "take_update_install_result",
+        );
+        if (!result) {
+            return;
+        }
+
+        toast(result.message, {
+            description: result.needs_restart
+                ? "再起動後に新しいバージョンが有効になります"
+                : result.status === "failed"
+                  ? result.install_log_path
+                      ? `ログ: ${result.install_log_path}`
+                      : undefined
+                  : undefined,
+            duration: result.status === "failed" || result.needs_restart ? 12000 : 6000,
+        });
+    } catch (_error) {
+        // Update result notification is best effort.
     }
 };
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,7 +12,7 @@ import { Zenzai } from "@/pages/zenzai"
 import { About } from "@/pages/about"
 import { Dictionary } from "@/pages/dictionary"
 import { Toaster } from "@/components/ui/sonner"
-import { showConfigStartupNoticeOnce } from "@/lib/config"
+import { showConfigStartupNoticeOnce, showUpdateInstallResultOnce } from "@/lib/config"
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
@@ -37,3 +37,4 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 );
 
 void showConfigStartupNoticeOnce();
+void showUpdateInstallResultOnce();

--- a/frontend/src/pages/general.tsx
+++ b/frontend/src/pages/general.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
-import { ExternalLink, Keyboard, RefreshCcw, Table2, Trash2 } from "lucide-react";
+import { Download, Keyboard, RefreshCcw, Table2, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -49,6 +49,23 @@ type RomajiRow = {
     output: string;
     next_input: string;
 };
+
+type UpdateCheckResponse = {
+    current_version: string;
+    latest_version: string;
+    latest_tag: string;
+    release_name: string;
+    release_url: string;
+    update_available: boolean;
+};
+
+type UpdateStatus =
+    | "idle"
+    | "checking"
+    | "available"
+    | "not_available"
+    | "starting"
+    | "error";
 
 const DEFAULT_GENERAL_CONFIG: GeneralConfigState = {
     punctuation_style: "touten_kuten",
@@ -235,7 +252,11 @@ export const General = () => {
     const [romajiDraftRows, setRomajiDraftRows] = useState<RomajiRow[]>([]);
     const [defaultRomajiRows, setDefaultRomajiRows] = useState<RomajiRow[]>([]);
     const [appVersion, setAppVersion] = useState<string | null>(null);
+    const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("idle");
+    const [updateCheck, setUpdateCheck] = useState<UpdateCheckResponse | null>(null);
+    const [updateError, setUpdateError] = useState<string | null>(null);
     const [pendingFocusNewRow, setPendingFocusNewRow] = useState(false);
+    const didCheckUpdatesOnStartup = useRef(false);
     const romajiEditorScrollRef = useRef<HTMLDivElement | null>(null);
     const romajiInputRefs = useRef<Array<HTMLInputElement | null>>([]);
 
@@ -269,6 +290,11 @@ export const General = () => {
             .catch(() => {
                 setAppVersion(null);
             });
+
+        if (!didCheckUpdatesOnStartup.current) {
+            didCheckUpdatesOnStartup.current = true;
+            void checkUpdates(false);
+        }
     }, []);
 
     useEffect(() => {
@@ -295,6 +321,85 @@ export const General = () => {
 
     const updateConfig = (updater: (config: any) => void) =>
         saveConfigWithToast(updater);
+
+    const checkUpdates = async (showToast: boolean) => {
+        setUpdateStatus("checking");
+        setUpdateError(null);
+        try {
+            const data = await invoke<UpdateCheckResponse>("check_for_updates");
+            setUpdateCheck(data);
+            setUpdateStatus(data.update_available ? "available" : "not_available");
+            if (showToast) {
+                toast(
+                    data.update_available
+                        ? `v${data.latest_version} にアップデートできます`
+                        : "最新版を利用中です",
+                );
+            }
+            return data;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            setUpdateError(message);
+            setUpdateStatus("error");
+            if (showToast) {
+                toast("更新の確認に失敗しました", {
+                    description: message,
+                });
+            }
+            return null;
+        }
+    };
+
+    const startUpdate = async () => {
+        setUpdateStatus("starting");
+        setUpdateError(null);
+        try {
+            await invoke("start_update");
+            toast("アップデートを開始しました");
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            setUpdateError(message);
+            setUpdateStatus(updateCheck?.update_available ? "available" : "error");
+            toast("アップデートを開始できませんでした", {
+                description: message,
+            });
+        }
+    };
+
+    const handleUpdateButton = async () => {
+        if (updateStatus === "available") {
+            await startUpdate();
+            return;
+        }
+
+        await checkUpdates(true);
+    };
+
+    const updateButtonLabel = (() => {
+        if (updateStatus === "checking") {
+            return "確認中";
+        }
+        if (updateStatus === "starting") {
+            return "アップデートを開始中";
+        }
+        if (updateStatus === "available") {
+            return "最新版にアップデート";
+        }
+        return "更新を確認";
+    })();
+
+    const updateDescription = (() => {
+        if (updateStatus === "available" && updateCheck) {
+            return `v${updateCheck.latest_version} が利用できます`;
+        }
+        if (updateStatus === "not_available") {
+            return "最新版を利用中です";
+        }
+        if (updateStatus === "error") {
+            return "更新を確認できませんでした";
+        }
+        return null;
+    })();
 
     const handleCtrlSpaceToggle = async () => {
         const nextValue = !shortcutValue.ctrlSpaceToggle;
@@ -477,17 +582,24 @@ export const General = () => {
                             <p className="text-sm font-medium leading-none">
                                 {appVersion ? `v${appVersion}` : "v-"}
                             </p>
+                            {updateDescription ? (
+                                <p className="text-xs text-muted-foreground">
+                                    {updateDescription}
+                                </p>
+                            ) : null}
+                            {updateError ? (
+                                <p className="text-xs text-destructive">
+                                    {updateError}
+                                </p>
+                            ) : null}
                         </div>
-                        <Button variant="secondary">
-                            <a
-                                href="https://github.com/batao9/azooKey-Windows/releases"
-                                className="flex items-center gap-x-2"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                <ExternalLink />
-                                更新を確認する
-                            </a>
+                        <Button
+                            variant={updateStatus === "available" ? "default" : "secondary"}
+                            onClick={() => void handleUpdateButton()}
+                            disabled={updateStatus === "checking" || updateStatus === "starting"}
+                        >
+                            {updateStatus === "available" ? <Download /> : <RefreshCcw />}
+                            {updateButtonLabel}
                         </Button>
                     </div>
                 </section>

--- a/scripts/vm_test_updater.sh
+++ b/scripts/vm_test_updater.sh
@@ -232,7 +232,7 @@ function Test-ReleaseDownload {
 
   if ($RunInstaller) {
     $logPath = Join-Path $WorkDir "$Prefix-install.log"
-    $proc = Start-Process -FilePath $installerPath -ArgumentList @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/LOG=$logPath") -Wait -PassThru
+    $proc = Start-Process -FilePath $installerPath -ArgumentList @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/RESTARTEXITCODE=3010", "/LOG=$logPath") -Wait -PassThru
     if (($proc.ExitCode -ne 0) -and ($proc.ExitCode -ne 3010)) {
       throw "$Prefix installer failed: exit=$($proc.ExitCode)"
     }

--- a/scripts/vm_test_updater.sh
+++ b/scripts/vm_test_updater.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# Windows VM 上で updater の download/hash/install 起動経路を検証するスクリプトです。
+# 詳細出力は .local/logs にリダイレクトして使うことを想定しています。
+
+set -euo pipefail
+
+VM_NAME="${VM_NAME:-}"
+SNAPSHOT_NAME="${SNAPSHOT_NAME:-}"
+SSH_USER="${SSH_USER:-}"
+SSH_PORT="${SSH_PORT:-}"
+SSH_KEY="${SSH_KEY:-}"
+VBOX_MANAGE="${VBOX_MANAGE:-}"
+PSEUDO_RELEASE_PORT="${PSEUDO_RELEASE_PORT:-$((18000 + RANDOM % 1000))}"
+SHUTDOWN_AFTER_TEST="${SHUTDOWN_AFTER_TEST:-1}"
+
+if [[ -z "$VBOX_MANAGE" ]]; then
+  if command -v VBoxManage >/dev/null 2>&1; then
+    VBOX_MANAGE="$(command -v VBoxManage)"
+  elif [[ -x "/mnt/c/Program Files/Oracle/VirtualBox/VBoxManage.exe" ]]; then
+    VBOX_MANAGE="/mnt/c/Program Files/Oracle/VirtualBox/VBoxManage.exe"
+  fi
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACT_DIR="$REPO_ROOT/.local/artifacts"
+LOG_DIR="$REPO_ROOT/.local/logs"
+PSEUDO_ROOT="$REPO_ROOT/.local/updater-release"
+mkdir -p "$ARTIFACT_DIR" "$LOG_DIR" "$PSEUDO_ROOT"
+
+DEFAULT_GATEWAY_IP="$(ip route | awk '/default/ {print $3; exit}' || true)"
+HOST_IP="${SSH_HOST:-${DEFAULT_GATEWAY_IP:-127.0.0.1}}"
+FALLBACK_HOST=""
+if [[ "$HOST_IP" == "127.0.0.1" && -n "$DEFAULT_GATEWAY_IP" ]]; then
+  FALLBACK_HOST="$DEFAULT_GATEWAY_IP"
+elif [[ "$HOST_IP" != "127.0.0.1" ]]; then
+  FALLBACK_HOST="127.0.0.1"
+fi
+ACTIVE_HOST="$HOST_IP"
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+LOG_FILE="$LOG_DIR/vm-updater-$TIMESTAMP.log"
+REMOTE_TMP_WIN="C:\\Users\\$SSH_USER\\AppData\\Local\\Temp"
+REMOTE_PS_WIN="$REMOTE_TMP_WIN\\azookey-updater-smoke.ps1"
+REMOTE_PS_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-updater-smoke.ps1"
+TMP_REMOTE_PS=""
+
+SSH_OPTS=(-i "$SSH_KEY" -p "$SSH_PORT" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=8)
+SCP_OPTS=(-i "$SSH_KEY" -P "$SSH_PORT" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=8)
+
+exec > >(tee "$LOG_FILE") 2>&1
+
+log() {
+  printf '[vm-updater] %s\n' "$*"
+}
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    log "環境変数 $name を設定してください"
+    exit 1
+  fi
+}
+
+vbox() {
+  "$VBOX_MANAGE" "$@"
+}
+
+matches_fixed() {
+  if command -v rg >/dev/null 2>&1; then
+    rg -F "$1" -q
+  else
+    grep -F "$1" -q
+  fi
+}
+
+is_vm_running() {
+  vbox list runningvms | matches_fixed "\"$VM_NAME\""
+}
+
+ssh_run() {
+  ssh "${SSH_OPTS[@]}" "$SSH_USER@$ACTIVE_HOST" "$@"
+}
+
+scp_to_vm() {
+  scp "${SCP_OPTS[@]}" "$1" "$SSH_USER@$ACTIVE_HOST:$2"
+}
+
+wait_for_ssh() {
+  local tries=120
+  local hosts=("$HOST_IP")
+  if [[ -n "$FALLBACK_HOST" && "$FALLBACK_HOST" != "$HOST_IP" ]]; then
+    hosts+=("$FALLBACK_HOST")
+  fi
+
+  for ((i=1; i<=tries; i++)); do
+    local host
+    for host in "${hosts[@]}"; do
+      if timeout 10s ssh "${SSH_OPTS[@]}" "$SSH_USER@$host" "echo ready" >/dev/null 2>&1; then
+        ACTIVE_HOST="$host"
+        log "SSH 接続確認: OK (host=$ACTIVE_HOST, try $i/$tries)"
+        return 0
+      fi
+    done
+    sleep 2
+  done
+  return 1
+}
+
+wait_for_vm_poweroff() {
+  local tries=60
+  for ((i=1; i<=tries; i++)); do
+    if ! is_vm_running; then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+shutdown_vm() {
+  if [[ "$SHUTDOWN_AFTER_TEST" != "1" ]] || ! is_vm_running; then
+    return 0
+  fi
+  log "VM を停止します: $VM_NAME"
+  vbox controlvm "$VM_NAME" acpipowerbutton >/dev/null || true
+  if ! wait_for_vm_poweroff; then
+    vbox controlvm "$VM_NAME" poweroff >/dev/null || true
+  fi
+}
+
+cleanup() {
+  local rc=$?
+  set +e
+  rm -f "${TMP_REMOTE_PS:-}"
+  shutdown_vm
+  trap - EXIT
+  exit "$rc"
+}
+
+find_installer() {
+  local arg="${1:-latest}"
+  if [[ "$arg" != "latest" ]]; then
+    realpath "$arg"
+    return 0
+  fi
+
+  local latest
+  latest="$(ls -t "$ARTIFACT_DIR"/azookey-setup-*.exe 2>/dev/null | head -n 1 || true)"
+  if [[ -z "$latest" ]]; then
+    log "インストーラーが見つかりません。先に VM build を実行してください。"
+    exit 1
+  fi
+  realpath "$latest"
+}
+
+ensure_preconditions() {
+  require_env VM_NAME
+  require_env SNAPSHOT_NAME
+  require_env SSH_USER
+  require_env SSH_PORT
+  require_env SSH_KEY
+  if [[ ! -x "$VBOX_MANAGE" ]]; then
+    log "VBoxManage が見つかりません。VBOX_MANAGE を設定してください: ${VBOX_MANAGE:-<unset>}"
+    exit 1
+  fi
+  if [[ ! -f "$SSH_KEY" ]]; then
+    log "SSH 秘密鍵が見つかりません: $SSH_KEY"
+    exit 1
+  fi
+}
+
+create_smoke_ps1() {
+  local ps1="$1"
+  cat > "$ps1" <<'PS1'
+param(
+  [Parameter(Mandatory = $true)][string]$LocalInstallerPath,
+  [Parameter(Mandatory = $true)][int]$PseudoReleasePort,
+  [Parameter(Mandatory = $true)][string]$WorkDir
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+function Get-AssetUrl {
+  param(
+    [Parameter(Mandatory = $true)]$Release,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  $asset = @($Release.assets | Where-Object { $_.name -eq $Name })[0]
+  if ($null -eq $asset -or [string]::IsNullOrWhiteSpace($asset.browser_download_url)) {
+    throw "asset not found: $Name"
+  }
+  $asset.browser_download_url
+}
+
+function Save-Url {
+  param(
+    [Parameter(Mandatory = $true)][string]$Url,
+    [Parameter(Mandatory = $true)][string]$OutFile
+  )
+  & curl.exe -fsSL -H "User-Agent: azookey-updater-smoke" -o $OutFile $Url
+  if ($LASTEXITCODE -ne 0) {
+    throw "curl failed: exit=$LASTEXITCODE url=$Url"
+  }
+}
+
+function Test-ReleaseDownload {
+  param(
+    [Parameter(Mandatory = $true)][string]$ReleaseApiUrl,
+    [Parameter(Mandatory = $true)][string]$Prefix,
+    [switch]$RunInstaller
+  )
+
+  New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+  $releasePath = Join-Path $WorkDir "$Prefix-release.json"
+  Save-Url -Url $ReleaseApiUrl -OutFile $releasePath
+  $release = Get-Content -LiteralPath $releasePath -Raw | ConvertFrom-Json
+  $installerUrl = Get-AssetUrl -Release $release -Name "azookey-setup.exe"
+  $shaUrl = Get-AssetUrl -Release $release -Name "SHA256SUMS.txt"
+
+  $shaPath = Join-Path $WorkDir "$Prefix-SHA256SUMS.txt"
+  $installerPath = Join-Path $WorkDir "$Prefix-azookey-setup.exe"
+  Save-Url -Url $shaUrl -OutFile $shaPath
+  Save-Url -Url $installerUrl -OutFile $installerPath
+
+  $expected = ((Get-Content -LiteralPath $shaPath | Where-Object { $_ -match "azookey-setup\.exe" }) -split "\s+")[0].ToLowerInvariant()
+  $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $installerPath).Hash.ToLowerInvariant()
+  if ($expected -ne $actual) {
+    throw "$Prefix hash mismatch: expected=$expected actual=$actual"
+  }
+
+  if ($RunInstaller) {
+    $logPath = Join-Path $WorkDir "$Prefix-install.log"
+    $proc = Start-Process -FilePath $installerPath -ArgumentList @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/LOG=$logPath") -Wait -PassThru
+    if (($proc.ExitCode -ne 0) -and ($proc.ExitCode -ne 3010)) {
+      throw "$Prefix installer failed: exit=$($proc.ExitCode)"
+    }
+    Write-Host "$Prefix installer exit code: $($proc.ExitCode)"
+  }
+}
+
+function Start-LocalPseudoRelease {
+  param(
+    [Parameter(Mandatory = $true)][string]$InstallerPath,
+    [Parameter(Mandatory = $true)][int]$Port
+  )
+
+  if (!(Test-Path -LiteralPath $InstallerPath)) {
+    throw "local installer not found: $InstallerPath"
+  }
+
+  New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+  $pseudoDir = Join-Path $WorkDir "pseudo-release"
+  New-Item -ItemType Directory -Force -Path $pseudoDir | Out-Null
+  $pseudoInstaller = Join-Path $pseudoDir "azookey-setup.exe"
+  $pseudoSha = Join-Path $pseudoDir "SHA256SUMS.txt"
+  $pseudoJson = Join-Path $pseudoDir "latest.json"
+
+  Copy-Item -LiteralPath $InstallerPath -Destination $pseudoInstaller -Force
+  $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $pseudoInstaller).Hash.ToLowerInvariant()
+  Set-Content -LiteralPath $pseudoSha -Encoding ASCII -Value "$hash  azookey-setup.exe"
+
+  $baseUrl = "http://127.0.0.1:$Port"
+  @"
+{
+  "tag_name": "v999.0.0-updater-smoke",
+  "name": "Updater smoke release",
+  "html_url": "$baseUrl/",
+  "assets": [
+    {
+      "name": "azookey-setup.exe",
+      "browser_download_url": "$baseUrl/azookey-setup.exe"
+    },
+    {
+      "name": "SHA256SUMS.txt",
+      "browser_download_url": "$baseUrl/SHA256SUMS.txt"
+    }
+  ]
+}
+"@ | Set-Content -LiteralPath $pseudoJson -Encoding UTF8
+
+  $job = Start-Job -ArgumentList $pseudoDir, $Port -ScriptBlock {
+    param([string]$Root, [int]$ListenPort)
+    $listener = [System.Net.HttpListener]::new()
+    $listener.Prefixes.Add("http://127.0.0.1:$ListenPort/")
+    $listener.Start()
+    try {
+      while ($true) {
+        $context = $listener.GetContext()
+        $name = [System.IO.Path]::GetFileName($context.Request.Url.AbsolutePath)
+        if ([string]::IsNullOrWhiteSpace($name)) {
+          $name = "latest.json"
+        }
+        $path = Join-Path $Root $name
+        if (!(Test-Path -LiteralPath $path)) {
+          $context.Response.StatusCode = 404
+          $context.Response.Close()
+          continue
+        }
+        $bytes = [System.IO.File]::ReadAllBytes($path)
+        $context.Response.ContentLength64 = $bytes.Length
+        $context.Response.OutputStream.Write($bytes, 0, $bytes.Length)
+        $context.Response.Close()
+      }
+    } finally {
+      $listener.Stop()
+    }
+  }
+
+  Start-Sleep -Seconds 2
+  [PSCustomObject]@{
+    Job = $job
+    ApiUrl = "$baseUrl/latest.json"
+  }
+}
+
+Test-ReleaseDownload -ReleaseApiUrl "https://api.github.com/repos/batao9/azooKey-Windows/releases/latest" -Prefix "official"
+$pseudo = Start-LocalPseudoRelease -InstallerPath $LocalInstallerPath -Port $PseudoReleasePort
+try {
+  Test-ReleaseDownload -ReleaseApiUrl $pseudo.ApiUrl -Prefix "pseudo" -RunInstaller
+} finally {
+  Stop-Job -Job $pseudo.Job -ErrorAction SilentlyContinue
+  Remove-Job -Job $pseudo.Job -Force -ErrorAction SilentlyContinue
+}
+PS1
+}
+
+main() {
+  if [[ $# -gt 1 ]]; then
+    echo "Usage: $0 [installer-path|latest]"
+    exit 1
+  fi
+
+  local installer
+  installer="$(find_installer "${1:-latest}")"
+  ensure_preconditions
+  trap cleanup EXIT
+
+  log "疑似 release は VM 内 localhost に準備します: $(basename "$installer")"
+
+  log "検証用 VM にインストーラーを事前インストールします"
+  SHUTDOWN_AFTER_INSTALL=0 "$REPO_ROOT/scripts/vm_stage_for_manual_test.sh" "$installer"
+  if ! wait_for_ssh; then
+    log "VM への SSH 接続に失敗しました"
+    exit 1
+  fi
+
+  TMP_REMOTE_PS="$(mktemp /tmp/azookey-updater-smoke.XXXXXX.ps1)"
+  create_smoke_ps1 "$TMP_REMOTE_PS"
+  scp_to_vm "$TMP_REMOTE_PS" "$REMOTE_PS_SCP"
+
+  local remote_work_dir="$REMOTE_TMP_WIN\\azookey-updater-smoke-$TIMESTAMP"
+  log "VM 上で official latest download/hash と疑似 release install を検証します"
+  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -LocalInstallerPath \"$REMOTE_TMP_WIN\\azookey-setup-under-test.exe\" -PseudoReleasePort $PSEUDO_RELEASE_PORT -WorkDir \"$remote_work_dir\""
+  log "updater smoke が完了しました"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- 設定アプリから GitHub Releases latest を確認し、更新ありの場合に installer を download / SHA-256 検証 / 起動できる updater を追加しました。
- installer 実行は PowerShell helper に委譲し、`frontend.exe` が installer に停止されても `%APPDATA%\Azookey\update-result.json` から次回起動時に結果 toast を表示できるようにしました。
- 公式 latest が #61 前の installer である点を踏まえ、official latest の download/hash smoke と、VM 内 localhost 疑似 release からの installer 起動 smoke を分けて検証する script を追加しました。

## Background
- Issue: Closes #64
- 本番では GitHub Releases `/releases/latest` の `azookey-setup.exe` と `SHA256SUMS.txt` を使う想定です。
- 現在の latest release は installer 一本化前のため、受け入れ検証では official latest は download/hash までに留め、#61 後構成の current branch installer を疑似 release として配信して update 起動を確認しました。
- updater の network / download / hash verification は frontend fetch ではなく Tauri command 側に閉じ、CSP に外部 GitHub URL を追加しない構成にしました。

## Changes
- Tauri updater
  - default endpoint を `https://api.github.com/repos/batao9/azooKey-Windows/releases/latest` にし、VM/integration 用に `AZOOKEY_UPDATE_RELEASE_API_URL` / `AZOOKEY_UPDATE_CURRENT_VERSION` override を追加
  - release tag の `v` prefix を許容し、`semver::Version` で prerelease も含めて比較
  - installer asset は `azookey-setup.exe`、hash asset は `SHA256SUMS.txt` の固定名で厳密に選択
  - `SHA256SUMS.txt` 由来の SHA-256 と一致した場合だけ installer helper を起動
  - download は temp staging directory の `.part` に保存し、失敗 / hash mismatch 時は partial と final path を削除
- installer helper / result handling
  - installer を `{app}` 配下ではなく temp staging directory から起動
  - helper が installer exit code を待ち、`0` / `3010` / その他を `update-result.json` に保存
  - `3010` は更新成功かつ再起動必要として扱い、次回設定アプリ起動時に明示
- frontend
  - 設定画面起動時の自動確認、手動確認、更新あり時の「最新版にアップデート」、失敗 toast を追加
  - update result を起動時に一度だけ読み取り、成功 / 再起動必要 / 失敗を toast 表示
- VM verification
  - `scripts/vm_test_updater.sh` を追加し、official latest の download/hash と local pseudo release installer 実行を分けて検証できるようにしました。

## Verification
- `git diff --check`
- `node.exe "$(wslpath -w frontend/node_modules/typescript/bin/tsc)" --noEmit --project "$(wslpath -w frontend/tsconfig.json)"`
- `bash -n scripts/vm_test_updater.sh`
- VM build: `.local/vm_build_master.sh feature/64-app-updater > .local/logs/vm-build-64-cleanup.log 2>&1`
  - artifact: `.local/artifacts/azookey-setup-feature_64-app-updater-20260528-074349.exe`
- VM updater smoke: `scripts/vm_test_updater.sh .local/artifacts/azookey-setup-feature_64-app-updater-20260528-074349.exe > .local/logs/vm-updater-64-cleanup.log 2>&1`
  - official latest release metadata / `SHA256SUMS.txt` / `azookey-setup.exe` download と hash 検証を確認
  - VM 内 localhost 疑似 release から installer download / hash 検証 / 起動を確認
  - `pseudo installer exit code: 0`
- Note: local WSL の `cargo test -p frontend updater --lib` は Tauri GTK 系依存の `pkg-config` 不在で実行前に停止しました。Windows VM build では Tauri/Rust 側の compile は通過しています。