### PR TITLE
chore(release): prepare v0.1.0-batao.4

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,3 +1,3 @@
 {
-  "version": "0.1.0-batao.3"
+  "version": "0.1.0-batao.4"
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0-batao.3",
+  "version": "0.1.0-batao.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0-batao.3",
+      "version": "0.1.0-batao.4",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-dialog": "^1.1.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0-batao.3",
+  "version": "0.1.0-batao.4",
   "type": "module",
   "scripts": {
     "sync-version": "node ../scripts/sync-version.mjs",

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Azookey",
-  "version": "0.1.0-batao.3",
+  "version": "0.1.0-batao.4",
   "identifier": "com.azookey.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/installer/AppVersion.iss
+++ b/installer/AppVersion.iss
@@ -1,2 +1,2 @@
 ; Generated from app-version.json by scripts/sync-version.mjs.
-#define MyAppVersion "0.1.0-batao.3"
+#define MyAppVersion "0.1.0-batao.4"


### PR DESCRIPTION
## Summary
- 内部バージョンを `0.1.0-batao.4` に更新
- `app-version.json` を単一ソースとして Tauri / npm / Inno のバージョンを同期

## Release notes draft
### User-facing changes
- `← / →` による文節操作を改善し、文節操作を始めた時点で自動文節分割を行うようにしました
- 文節単位の移動・境界調整・一括確定の挙動を整理し、既存 IME に近い操作感で変換を調整しやすくしました
- 候補ウィンドウの更新をまとめて反映するようにし、古い候補や選択状態が一瞬表示される可能性を減らしました
- 設定ファイルが壊れている場合でも設定アプリを起動し、壊れたファイルを退避して既定値で復旧できるようにしました
- 設定保存の成功と、IME への反映失敗を区別して表示できるようにしました
- 設定アプリから最新版確認とアップデート実行ができるようにしました
- 更新後に再起動が必要な場合は、その旨を表示するようにしました
- 言語バーから設定画面を開く経路と、設定アプリの配置を整理しました

### Stability and internal improvements
- Swift/Rust FFI の文字列・候補配列に解放 API を追加し、連続入力や候補取得時のメモリ解放漏れを防ぐようにしました
- 候補 UI server と WebView 更新処理の panic 要因を減らし、channel 切断や不正 request、JS 呼び出し失敗時にも落ちにくくしました
- 候補ウィンドウ更新を `UpdateCandidateWindow` RPC にまとめ、入力中の IPC 回数と表示状態のずれを減らしました
- `IMEState` から TSF COM object を分離し、lock 範囲と unsafe Send/Sync の扱いを整理しました
- 文節操作の状態管理を reducer として切り出し、composition の状態遷移をテストしやすくしました
- Inno Setup を唯一の配布 installer にし、Tauri/NSIS installer を内部実行する二重 installer 構造をなくしました
- install / uninstall / legacy NSIS migration / locked-file upgrade の検証を強化しました
- updater は GitHub Releases latest から installer と `SHA256SUMS.txt` を取得し、SHA-256 が一致した場合のみ installer を起動するようにしました
- VM ビルド / test / install 検証用 script と開発運用ドキュメントを整理しました
- アプリ内バージョンとインストーラー版数を `0.1.0-batao.4` に更新

## Verification
- [x] `git diff --check`
- [x] `node.exe "$(wslpath -w frontend/node_modules/typescript/bin/tsc)" --noEmit --project "$(wslpath -w frontend/tsconfig.json)"`
- [x] `.local/vm_build_master.sh feature/release-v0.1.0-batao.4`
  - artifact: `.local/artifacts/azookey-setup-feature_release-v0.1.0-batao.4-20260529-215837.exe`
  - sha256: `35ca18070ddff1a46a3f366837c1e93073291adcd9602b556e5e24c12a2336a3`
- [ ] GitHub Actions build 成功

## Release body draft
```markdown
## Summary
- batao9/azooKey-Windows の fork release `v0.1.0-batao.4`
- こちらは fkunn1326/azooKey-Windows の fork です

## User-facing changes
- `← / →` による文節操作を改善し、文節操作を始めた時点で自動文節分割を行うようにしました
- 文節単位の移動・境界調整・一括確定の挙動を整理し、既存 IME に近い操作感で変換を調整しやすくしました
- 候補ウィンドウの更新をまとめて反映するようにし、古い候補や選択状態が一瞬表示される可能性を減らしました
- 設定ファイルが壊れている場合でも設定アプリを起動し、壊れたファイルを退避して既定値で復旧できるようにしました
- 設定保存の成功と、IME への反映失敗を区別して表示できるようにしました
- 設定アプリから最新版確認とアップデート実行ができるようにしました
- 更新後に再起動が必要な場合は、その旨を表示するようにしました
- 言語バーから設定画面を開く経路と、設定アプリの配置を整理しました

## Stability and internal improvements
- Swift/Rust FFI の文字列・候補配列に解放 API を追加し、連続入力や候補取得時のメモリ解放漏れを防ぐようにしました
- 候補 UI server と WebView 更新処理の panic 要因を減らし、channel 切断や不正 request、JS 呼び出し失敗時にも落ちにくくしました
- 候補ウィンドウ更新を `UpdateCandidateWindow` RPC にまとめ、入力中の IPC 回数と表示状態のずれを減らしました
- `IMEState` から TSF COM object を分離し、lock 範囲と unsafe Send/Sync の扱いを整理しました
- 文節操作の状態管理を reducer として切り出し、composition の状態遷移をテストしやすくしました
- Inno Setup を唯一の配布 installer にし、Tauri/NSIS installer を内部実行する二重 installer 構造をなくしました
- install / uninstall / legacy NSIS migration / locked-file upgrade の検証を強化しました
- updater は GitHub Releases latest から installer と `SHA256SUMS.txt` を取得し、SHA-256 が一致した場合のみ installer を起動するようにしました
- VM ビルド / test / install 検証用 script と開発運用ドキュメントを整理しました
- アプリ内バージョンとインストーラー版数を `0.1.0-batao.4` に更新

## Assets
- azookey-setup.exe
- SHA256SUMS.txt

## Notes
- このリリースは fork 版です
- 今回から配布 installer は Inno Setup 生成の `azookey-setup.exe` に一本化されています
- 不具合報告はこのリポジトリの Issues へお願いします
```
