### PR TITLE
Show candidate window after auto split

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -126,6 +126,12 @@ pub struct FutureClauseSnapshot {
     candidates: Candidates,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct ClauseNavigationReadyUiSync {
+    update_pos: bool,
+    visible: Option<bool>,
+}
+
 impl ITfCompositionSink_Impl for TextServiceFactory_Impl {
     #[macros::anyhow]
     fn OnCompositionTerminated(
@@ -1313,6 +1319,7 @@ impl TextServiceFactory {
         candidates: &Candidates,
         selection_index: i32,
         ipc_service: &mut IPCService,
+        visible: Option<bool>,
         update_pos: bool,
     ) -> Result<()> {
         self.set_text(preview, suffix)?;
@@ -1320,7 +1327,7 @@ impl TextServiceFactory {
             ipc_service,
             candidates,
             selection_index,
-            None,
+            visible,
             update_pos,
         )?;
         Ok(())
@@ -2442,14 +2449,27 @@ impl TextServiceFactory {
     }
 
     #[inline]
-    fn deferred_clause_navigation_ready_sync_update_pos(
-        deferred_update_pos: Option<bool>,
+    fn clause_navigation_ready_ui_sync(
+        effect: ClauseActionEffect,
+    ) -> Option<ClauseNavigationReadyUiSync> {
+        effect.applied.then_some(ClauseNavigationReadyUiSync {
+            update_pos: effect.update_pos,
+            visible: Some(true),
+        })
+    }
+
+    #[inline]
+    fn deferred_clause_navigation_ready_ui_sync_after_move(
+        deferred_sync: Option<ClauseNavigationReadyUiSync>,
         move_effect: ClauseActionEffect,
-    ) -> Option<bool> {
+    ) -> Option<ClauseNavigationReadyUiSync> {
         if move_effect.applied {
-            None
+            deferred_sync.map(|sync| ClauseNavigationReadyUiSync {
+                update_pos: move_effect.update_pos,
+                visible: sync.visible,
+            })
         } else {
-            deferred_update_pos
+            deferred_sync
         }
     }
 
@@ -3162,7 +3182,7 @@ impl TextServiceFactory {
         let mut temporary_latin_shift_pending = composition.temporary_latin_shift_pending;
         let mut ipc_service = IMEState::ipc_service()?.context("ipc_service is None")?;
         let mut transition = transition;
-        let mut deferred_clause_navigation_ready_sync_update_pos = None;
+        let mut deferred_clause_navigation_ready_ui_sync = None;
 
         self.update_context(&preview)?;
 
@@ -3442,9 +3462,9 @@ impl TextServiceFactory {
                     if effect.applied {
                         let defer_ui_sync =
                             Self::should_defer_clause_navigation_ready_sync(actions, action_index);
+                        let ready_ui_sync = Self::clause_navigation_ready_ui_sync(effect);
                         if defer_ui_sync {
-                            deferred_clause_navigation_ready_sync_update_pos =
-                                Some(effect.update_pos);
+                            deferred_clause_navigation_ready_ui_sync = ready_ui_sync;
                             Self::log_clause_action_state(
                                 "defer",
                                 action,
@@ -3468,6 +3488,7 @@ impl TextServiceFactory {
                             &candidates,
                             selection_index,
                             &mut ipc_service,
+                            ready_ui_sync.and_then(|sync| sync.visible),
                             effect.update_pos,
                         )?;
                         Self::log_clause_action_state(
@@ -3545,9 +3566,9 @@ impl TextServiceFactory {
                         effect
                     };
 
-                    let deferred_sync_update_pos =
-                        Self::deferred_clause_navigation_ready_sync_update_pos(
-                            deferred_clause_navigation_ready_sync_update_pos.take(),
+                    let deferred_ready_ui_sync =
+                        Self::deferred_clause_navigation_ready_ui_sync_after_move(
+                            deferred_clause_navigation_ready_ui_sync.take(),
                             effect,
                         );
                     if effect.applied {
@@ -3557,6 +3578,7 @@ impl TextServiceFactory {
                             &candidates,
                             selection_index,
                             &mut ipc_service,
+                            deferred_ready_ui_sync.and_then(|sync| sync.visible),
                             effect.update_pos,
                         )?;
                         Self::log_clause_action_state(
@@ -3573,14 +3595,15 @@ impl TextServiceFactory {
                             &clause_snapshots,
                             &future_clause_snapshots,
                         );
-                    } else if let Some(update_pos) = deferred_sync_update_pos {
+                    } else if let Some(sync) = deferred_ready_ui_sync {
                         self.sync_clause_action_ui(
                             &preview,
                             &suffix,
                             &candidates,
                             selection_index,
                             &mut ipc_service,
-                            update_pos,
+                            sync.visible,
+                            sync.update_pos,
                         )?;
                         Self::log_clause_action_state(
                             "after-deferred",
@@ -3664,6 +3687,7 @@ impl TextServiceFactory {
                             &candidates,
                             selection_index,
                             &mut ipc_service,
+                            None,
                             effect.update_pos,
                         )?;
                         Self::log_clause_action_state(
@@ -3781,6 +3805,7 @@ impl TextServiceFactory {
                             &candidates,
                             selection_index,
                             &mut ipc_service,
+                            None,
                             effect.update_pos,
                         )?;
                         Self::log_clause_action_state(

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    Candidates, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut, ClauseSnapshot,
-    ClauseState, Composition, CompositionReducer, CompositionState, FutureClauseSnapshot,
-    TextServiceFactory,
+    Candidates, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut,
+    ClauseNavigationReadyUiSync, ClauseSnapshot, ClauseState, Composition, CompositionReducer,
+    CompositionState, FutureClauseSnapshot, TextServiceFactory,
 };
 use crate::engine::{
     client_action::{ClientAction, SetSelectionType, SetTextType},
@@ -171,20 +171,43 @@ fn initial_left_arrow_defers_clause_navigation_ready_ui_sync_until_last_clause()
 }
 
 #[test]
-fn skipped_move_to_last_flushes_deferred_clause_navigation_ready_ui_sync() {
+fn applied_clause_navigation_ready_sync_shows_candidate_window() {
     assert_eq!(
-        TextServiceFactory::deferred_clause_navigation_ready_sync_update_pos(
-            Some(true),
-            ClauseActionEffect::skipped()
-        ),
-        Some(true)
+        TextServiceFactory::clause_navigation_ready_ui_sync(ClauseActionEffect::applied(true)),
+        Some(ClauseNavigationReadyUiSync {
+            update_pos: true,
+            visible: Some(true),
+        })
     );
     assert_eq!(
-        TextServiceFactory::deferred_clause_navigation_ready_sync_update_pos(
-            Some(true),
-            ClauseActionEffect::applied(true)
-        ),
+        TextServiceFactory::clause_navigation_ready_ui_sync(ClauseActionEffect::skipped()),
         None
+    );
+}
+
+#[test]
+fn deferred_clause_navigation_ready_sync_preserves_candidate_window_show_request() {
+    let deferred_sync = Some(ClauseNavigationReadyUiSync {
+        update_pos: true,
+        visible: Some(true),
+    });
+
+    assert_eq!(
+        TextServiceFactory::deferred_clause_navigation_ready_ui_sync_after_move(
+            deferred_sync,
+            ClauseActionEffect::skipped()
+        ),
+        deferred_sync
+    );
+    assert_eq!(
+        TextServiceFactory::deferred_clause_navigation_ready_ui_sync_after_move(
+            deferred_sync,
+            ClauseActionEffect::applied(false)
+        ),
+        Some(ClauseNavigationReadyUiSync {
+            update_pos: false,
+            visible: Some(true),
+        })
     );
 }
 


### PR DESCRIPTION
## Summary
- Show the candidate window when automatic clause navigation split is actually applied.
- Preserve that show request through the deferred first-left-arrow path.
- Keep later clause movement and boundary adjustment from forcing visibility on their own.

Closes #69

## Verification
- `git diff --check`
- `cargo test -p azookey-windows clause_navigation_ready_sync -- --nocapture` (WSL: blocked before compile because `protoc` is not installed)
- `bash .local/vm_test_client_composition.sh feature/69-show-candidate-on-auto-split composition skip`
- `bash .local/vm_build_master.sh feature/69-show-candidate-on-auto-split`
- VM smoke: with `general.show_candidate_window_after_space = true`, typed `iikagentouitusiro`, pressed Right to trigger auto split, and confirmed the candidate window is visible in `.local/vm-debug/issue69-auto-split-candidate-window-20260530-031551.png`.
