### PR TITLE
Add desktop shortcut installer option

### DIFF
--- a/installer/Installer.iss
+++ b/installer/Installer.iss
@@ -47,6 +47,9 @@ Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 FinishedRestartLabel=Azookey の更新を完了するには、Windows の再起動が必要です。再起動後に新しいバージョンが有効になります。今すぐ再起動しますか?
 FinishedRestartMessage=Azookey の更新を完了するには、Windows の再起動が必要です。%n%n再起動後に新しいバージョンが有効になります。今すぐ再起動しますか?
 
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+
 [Files]
 Source: "../build/azookey_windows.dll"; DestDir: "{app}"; DestName: "azookey.dll"; Flags: ignoreversion regserver 64bit restartreplace uninsrestartdelete
 Source: "../build/x86/azookey_windows.dll"; DestDir: "{app}"; DestName: "azookey32.dll"; Flags: ignoreversion regserver 32bit restartreplace uninsrestartdelete
@@ -54,6 +57,9 @@ Source: "../build/{#MySettingsAppName}"; DestDir: "{app}"; Flags: ignoreversion 
 Source: "../build/*"; DestDir: "{app}"; Excludes: "{#MySettingsAppName}"; Flags: ignoreversion recursesubdirs createallsubdirs restartreplace uninsrestartdelete
 Source: "./Azookey Startup.xml"; Flags: dontcopy noencryption
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
+
+[Icons]
+Name: "{userdesktop}\{#MyAppName}"; Filename: "{app}\{#MySettingsAppName}"; WorkingDir: "{app}"; Tasks: desktopicon
 
 [InstallDelete]
 Type: files; Name: "{app}\uninstall.exe"


### PR DESCRIPTION
## Summary
- Inno Setup の追加タスクとして、デスクトップショートカット作成オプションを追加しました。
- オプション選択時に、設定アプリ `frontend.exe` を開く `Azookey.lnk` をユーザーのデスクトップへ作成するようにしました。
- ショートカット作成オプションはデフォルトでチェックありになるようにしました。

## Background
- Issue: Closes #71
- 設定アプリを起動しやすくするため、インストーラーからデスクトップショートカットを作成できる選択肢が必要でした。
- ただし不要な環境では作成しない選択もできるよう、Inno Setup の task として追加します。

## Changes
- installer
  - `[Tasks]` に `desktopicon` を追加し、追加アイコン作成のチェック項目として表示
  - `[Icons]` に `{userdesktop}\Azookey` を追加し、`desktopicon` 選択時だけ `frontend.exe` へのショートカットを作成
  - shortcut の working directory は `{app}` に設定

## Verification
- [x] 差分チェック
  - `git diff --check`
- [x] ローカル Windows VM build 成功
  - `.local/vm_build_master.sh feature/71-desktop-shortcut-option`
  - artifact: `.local/artifacts/azookey-setup-feature_71-desktop-shortcut-option-20260530-104549.exe`
- [x] ローカル Windows VM install 成功（ショートカット作成あり）
  - デフォルト task のまま install し、`C:\Users\vboxuser\Desktop\Azookey.lnk` が作成されることを確認
  - shortcut target が `C:\Users\vboxuser\AppData\Roaming\Azookey\frontend.exe` であることを確認
  - shortcut working directory が `C:\Users\vboxuser\AppData\Roaming\Azookey` であることを確認
  - shortcut から `frontend.exe` が起動することを確認
- [x] ローカル Windows VM install 成功（ショートカット作成なし）
  - `/MERGETASKS=!desktopicon` で install し、`Azookey.lnk` が作成されないことを確認
  - `frontend.exe` が install されていることを確認
- [ ] GitHub Actions build 成功
  - run: pending

## Checklist
- [ ] CI run URL と結果を記載した
- [x] VM / 実機確認結果を記載した
- [x] 影響範囲を確認した
