### PR TITLE
Reduce romaji and symbol lookup work

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+
 use crate::{
     engine::user_action::UserAction,
     extension::VKeyExt as _,
@@ -46,14 +48,134 @@ impl CompositionReducer {
         app_config: &AppConfig,
         start_temporary_latin: bool,
     ) -> Option<(CompositionState, Vec<ClientAction>)> {
-        TextServiceFactory::plan_actions_for_user_action(
+        let romaji_lookup = RomajiLookup::from_rows(&app_config.romaji_table.rows);
+        TextServiceFactory::plan_actions_for_user_action_with_lookup(
             composition,
             action,
             mode,
             is_shift_pressed,
             app_config,
+            &romaji_lookup,
             start_temporary_latin,
         )
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct RomajiLookup {
+    max_input_len: usize,
+    max_multi_char_input_len: usize,
+    prefix_set: HashSet<String>,
+    multi_char_prefix_set: HashSet<String>,
+    single_symbol_outputs: HashMap<char, String>,
+    single_symbol_output_order: HashMap<char, usize>,
+}
+
+impl RomajiLookup {
+    fn from_rows(rows: &[RomajiRule]) -> Self {
+        let mut lookup = Self::default();
+
+        for (row_index, row) in rows.iter().enumerate() {
+            let input = row.input.trim();
+            if input.is_empty() {
+                continue;
+            }
+
+            let input_len = input.chars().count();
+            lookup.max_input_len = lookup.max_input_len.max(input_len);
+            Self::insert_prefixes(input, &mut lookup.prefix_set);
+
+            if input_len > 1 {
+                lookup.max_multi_char_input_len = lookup.max_multi_char_input_len.max(input_len);
+                Self::insert_prefixes(input, &mut lookup.multi_char_prefix_set);
+            } else if row.next_input.trim().is_empty() && !row.output.is_empty() {
+                if let Some(symbol) = Self::single_char(input) {
+                    lookup
+                        .single_symbol_outputs
+                        .entry(symbol)
+                        .or_insert_with(|| row.output.clone());
+                    lookup
+                        .single_symbol_output_order
+                        .entry(symbol)
+                        .or_insert(row_index);
+                }
+            }
+        }
+
+        lookup
+    }
+
+    fn insert_prefixes(input: &str, prefixes: &mut HashSet<String>) {
+        let mut end = 0;
+        for ch in input.chars() {
+            end += ch.len_utf8();
+            prefixes.insert(input[..end].to_string());
+        }
+    }
+
+    fn single_char(input: &str) -> Option<char> {
+        let mut chars = input.chars();
+        let ch = chars.next()?;
+        chars.next().is_none().then_some(ch)
+    }
+
+    fn has_romaji_table_context(&self, raw_input_before: &str, symbol: char) -> bool {
+        self.has_context(
+            raw_input_before,
+            symbol,
+            self.max_input_len,
+            &self.prefix_set,
+        )
+    }
+
+    fn has_multi_character_romaji_context(&self, raw_input_before: &str, symbol: char) -> bool {
+        self.has_context(
+            raw_input_before,
+            symbol,
+            self.max_multi_char_input_len,
+            &self.multi_char_prefix_set,
+        )
+    }
+
+    fn has_context(
+        &self,
+        raw_input_before: &str,
+        symbol: char,
+        max_input_len: usize,
+        prefixes: &HashSet<String>,
+    ) -> bool {
+        if max_input_len == 0 || prefixes.is_empty() {
+            return false;
+        }
+
+        let mut tail: Vec<char> = raw_input_before
+            .chars()
+            .rev()
+            .take(max_input_len.saturating_sub(1))
+            .collect();
+        tail.reverse();
+
+        let mut combined = String::with_capacity(raw_input_before.len() + symbol.len_utf8());
+        for ch in tail {
+            combined.push(ch);
+        }
+        combined.push(symbol);
+
+        combined
+            .char_indices()
+            .any(|(suffix_start, _)| prefixes.contains(&combined[suffix_start..]))
+    }
+
+    fn single_symbol_output(&self, symbols: &[char]) -> Option<String> {
+        symbols
+            .iter()
+            .filter_map(|symbol| {
+                let order = self.single_symbol_output_order.get(symbol)?;
+                let output = self.single_symbol_outputs.get(symbol)?;
+                Some((*order, output))
+            })
+            .min_by_key(|(order, _)| *order)
+            .map(|(_, output)| output.clone())
     }
 }
 
@@ -353,49 +475,17 @@ impl TextServiceFactory {
         symbol: char,
         romaji_rows: &[RomajiRule],
     ) -> bool {
-        if romaji_rows.is_empty() {
-            return false;
-        }
+        let romaji_lookup = RomajiLookup::from_rows(romaji_rows);
+        Self::has_romaji_table_context_with_lookup(raw_input_before, symbol, &romaji_lookup)
+    }
 
-        let mut combined = String::with_capacity(raw_input_before.len() + symbol.len_utf8());
-        combined.push_str(raw_input_before);
-        combined.push(symbol);
-
-        let combined_chars: Vec<char> = combined.chars().collect();
-        let max_row_len = romaji_rows
-            .iter()
-            .map(|row| row.input.chars().count())
-            .max()
-            .unwrap_or(0);
-
-        if max_row_len == 0 {
-            return false;
-        }
-
-        let start_index = combined_chars.len().saturating_sub(max_row_len);
-        for suffix_start in start_index..combined_chars.len() {
-            let suffix: String = combined_chars[suffix_start..].iter().collect();
-            if suffix.is_empty() {
-                continue;
-            }
-
-            if romaji_rows
-                .iter()
-                .filter_map(|row| {
-                    let trimmed = row.input.trim();
-                    if trimmed.is_empty() {
-                        None
-                    } else {
-                        Some(trimmed)
-                    }
-                })
-                .any(|input| input.starts_with(&suffix))
-            {
-                return true;
-            }
-        }
-
-        false
+    #[inline]
+    fn has_romaji_table_context_with_lookup(
+        raw_input_before: &str,
+        symbol: char,
+        romaji_lookup: &RomajiLookup,
+    ) -> bool {
+        romaji_lookup.has_romaji_table_context(raw_input_before, symbol)
     }
 
     #[inline]
@@ -404,13 +494,23 @@ impl TextServiceFactory {
         input: &str,
         romaji_rows: &[RomajiRule],
     ) -> bool {
+        let romaji_lookup = RomajiLookup::from_rows(romaji_rows);
+        Self::should_apply_symbol_fallback_with_lookup(raw_input_before, input, &romaji_lookup)
+    }
+
+    #[inline]
+    fn should_apply_symbol_fallback_with_lookup(
+        raw_input_before: &str,
+        input: &str,
+        romaji_lookup: &RomajiLookup,
+    ) -> bool {
         let Some(symbols) = Self::single_symbol_candidates(input) else {
             return false;
         };
 
-        !symbols
-            .iter()
-            .any(|symbol| Self::has_romaji_table_context(raw_input_before, *symbol, romaji_rows))
+        !symbols.iter().any(|symbol| {
+            Self::has_romaji_table_context_with_lookup(raw_input_before, *symbol, romaji_lookup)
+        })
     }
 
     #[inline]
@@ -419,49 +519,21 @@ impl TextServiceFactory {
         symbol: char,
         romaji_rows: &[RomajiRule],
     ) -> bool {
-        if romaji_rows.is_empty() {
-            return false;
-        }
+        let romaji_lookup = RomajiLookup::from_rows(romaji_rows);
+        Self::has_multi_character_romaji_context_with_lookup(
+            raw_input_before,
+            symbol,
+            &romaji_lookup,
+        )
+    }
 
-        let mut combined = String::with_capacity(raw_input_before.len() + symbol.len_utf8());
-        combined.push_str(raw_input_before);
-        combined.push(symbol);
-
-        let combined_chars: Vec<char> = combined.chars().collect();
-        let max_row_len = romaji_rows
-            .iter()
-            .map(|row| row.input.chars().count())
-            .max()
-            .unwrap_or(0);
-
-        if max_row_len <= 1 {
-            return false;
-        }
-
-        let start_index = combined_chars.len().saturating_sub(max_row_len);
-        for suffix_start in start_index..combined_chars.len() {
-            let suffix: String = combined_chars[suffix_start..].iter().collect();
-            if suffix.is_empty() {
-                continue;
-            }
-
-            if romaji_rows
-                .iter()
-                .filter_map(|row| {
-                    let trimmed = row.input.trim();
-                    if trimmed.is_empty() || trimmed.chars().count() <= 1 {
-                        None
-                    } else {
-                        Some(trimmed)
-                    }
-                })
-                .any(|input| input.starts_with(&suffix))
-            {
-                return true;
-            }
-        }
-
-        false
+    #[inline]
+    fn has_multi_character_romaji_context_with_lookup(
+        raw_input_before: &str,
+        symbol: char,
+        romaji_lookup: &RomajiLookup,
+    ) -> bool {
+        romaji_lookup.has_multi_character_romaji_context(raw_input_before, symbol)
     }
 
     #[inline]
@@ -480,22 +552,17 @@ impl TextServiceFactory {
 
     #[inline]
     fn single_symbol_romaji_output(input: &str, romaji_rows: &[RomajiRule]) -> Option<String> {
+        let romaji_lookup = RomajiLookup::from_rows(romaji_rows);
+        Self::single_symbol_romaji_output_with_lookup(input, &romaji_lookup)
+    }
+
+    #[inline]
+    fn single_symbol_romaji_output_with_lookup(
+        input: &str,
+        romaji_lookup: &RomajiLookup,
+    ) -> Option<String> {
         let symbols = Self::single_symbol_candidates(input)?;
-
-        romaji_rows.iter().find_map(|row| {
-            if !row.next_input.trim().is_empty() || row.output.is_empty() {
-                return None;
-            }
-
-            let trimmed = row.input.trim();
-            let mut chars = trimmed.chars();
-            let symbol = chars.next()?;
-            if chars.next().is_some() {
-                return None;
-            }
-
-            symbols.contains(&symbol).then(|| row.output.clone())
-        })
+        romaji_lookup.single_symbol_output(&symbols)
     }
 
     #[inline]
@@ -504,21 +571,37 @@ impl TextServiceFactory {
         input: &str,
         app_config: &AppConfig,
     ) -> Option<String> {
+        let romaji_lookup = RomajiLookup::from_rows(&app_config.romaji_table.rows);
+        Self::resolve_symbol_input_text_with_lookup(
+            raw_input_before,
+            input,
+            app_config,
+            &romaji_lookup,
+        )
+    }
+
+    #[inline]
+    fn resolve_symbol_input_text_with_lookup(
+        raw_input_before: &str,
+        input: &str,
+        app_config: &AppConfig,
+        romaji_lookup: &RomajiLookup,
+    ) -> Option<String> {
         let symbols = Self::single_symbol_candidates(input)?;
         let is_zenzai_enabled = Self::effective_zenzai_runtime_enabled(app_config);
         if is_zenzai_enabled {
             if symbols.iter().any(|symbol| {
-                Self::has_multi_character_romaji_context(
+                Self::has_multi_character_romaji_context_with_lookup(
                     raw_input_before,
                     *symbol,
-                    &app_config.romaji_table.rows,
+                    romaji_lookup,
                 )
             }) {
                 return None;
             }
 
             if let Some(mapped) =
-                Self::single_symbol_romaji_output(input, &app_config.romaji_table.rows)
+                Self::single_symbol_romaji_output_with_lookup(input, romaji_lookup)
             {
                 return Some(mapped);
             }
@@ -531,11 +614,7 @@ impl TextServiceFactory {
             ));
         }
 
-        if Self::should_apply_symbol_fallback(
-            raw_input_before,
-            input,
-            &app_config.romaji_table.rows,
-        ) {
+        if Self::should_apply_symbol_fallback_with_lookup(raw_input_before, input, romaji_lookup) {
             return Some(convert_kana_symbol(
                 input,
                 &app_config.general,
@@ -2324,12 +2403,14 @@ impl TextServiceFactory {
         mode: &InputMode,
         raw_input_before: &str,
         app_config: &AppConfig,
+        romaji_lookup: &RomajiLookup,
     ) -> Option<String> {
         if !Self::punctuation_commit_action_target_enabled(
             action,
             mode,
             raw_input_before,
             app_config,
+            romaji_lookup,
         ) {
             return None;
         }
@@ -2337,7 +2418,11 @@ impl TextServiceFactory {
         match action {
             UserAction::Input(ch) => {
                 let input = ch.to_string();
-                Some(Self::punctuation_commit_text_for_input(&input, app_config))
+                Some(Self::punctuation_commit_text_for_input(
+                    &input,
+                    app_config,
+                    romaji_lookup,
+                ))
             }
             UserAction::NumpadSymbol(symbol) => Some(
                 Self::numpad_text_for_mode(*symbol, app_config.general.numpad_input, false)
@@ -2348,10 +2433,14 @@ impl TextServiceFactory {
     }
 
     #[inline]
-    fn punctuation_commit_text_for_input(input: &str, app_config: &AppConfig) -> String {
+    fn punctuation_commit_text_for_input(
+        input: &str,
+        app_config: &AppConfig,
+        romaji_lookup: &RomajiLookup,
+    ) -> String {
         if Self::effective_zenzai_runtime_enabled(app_config) {
             if let Some(mapped) =
-                Self::single_symbol_romaji_output(input, &app_config.romaji_table.rows)
+                Self::single_symbol_romaji_output_with_lookup(input, romaji_lookup)
             {
                 return mapped;
             }
@@ -2371,6 +2460,7 @@ impl TextServiceFactory {
         mode: &InputMode,
         raw_input_before: &str,
         app_config: &AppConfig,
+        romaji_lookup: &RomajiLookup,
     ) -> bool {
         if !app_config.general.punctuation_commit || *mode != InputMode::Kana {
             return false;
@@ -2379,18 +2469,18 @@ impl TextServiceFactory {
         match action {
             UserAction::Input(ch) => {
                 Self::punctuation_commit_target_enabled(*ch, app_config)
-                    && !Self::has_multi_character_romaji_context(
+                    && !Self::has_multi_character_romaji_context_with_lookup(
                         raw_input_before,
                         *ch,
-                        &app_config.romaji_table.rows,
+                        romaji_lookup,
                     )
             }
             UserAction::NumpadSymbol(symbol) => {
                 Self::punctuation_commit_target_enabled(*symbol, app_config)
-                    && !Self::has_multi_character_romaji_context(
+                    && !Self::has_multi_character_romaji_context_with_lookup(
                         raw_input_before,
                         *symbol,
-                        &app_config.romaji_table.rows,
+                        romaji_lookup,
                     )
             }
             _ => false,
@@ -2480,6 +2570,28 @@ impl TextServiceFactory {
         mode: &InputMode,
         is_shift_pressed: bool,
         app_config: &AppConfig,
+        start_temporary_latin: bool,
+    ) -> Option<(CompositionState, Vec<ClientAction>)> {
+        let romaji_lookup = RomajiLookup::from_rows(&app_config.romaji_table.rows);
+        Self::plan_actions_for_user_action_with_lookup(
+            composition,
+            action,
+            mode,
+            is_shift_pressed,
+            app_config,
+            &romaji_lookup,
+            start_temporary_latin,
+        )
+    }
+
+    #[inline]
+    fn plan_actions_for_user_action_with_lookup(
+        composition: &Composition,
+        action: &UserAction,
+        mode: &InputMode,
+        is_shift_pressed: bool,
+        app_config: &AppConfig,
+        romaji_lookup: &RomajiLookup,
         start_temporary_latin: bool,
     ) -> Option<(CompositionState, Vec<ClientAction>)> {
         let result = match composition.state {
@@ -2580,6 +2692,7 @@ impl TextServiceFactory {
                         mode,
                         &composition.raw_input,
                         app_config,
+                        romaji_lookup,
                     ) =>
                 {
                     let text = Self::punctuation_commit_text_for_action(
@@ -2587,6 +2700,7 @@ impl TextServiceFactory {
                         mode,
                         &composition.raw_input,
                         app_config,
+                        romaji_lookup,
                     )?;
                     Some(Self::punctuation_commit_actions(text))
                 }
@@ -2736,6 +2850,7 @@ impl TextServiceFactory {
                         mode,
                         &composition.raw_input,
                         app_config,
+                        romaji_lookup,
                     ) =>
                 {
                     let text = Self::punctuation_commit_text_for_action(
@@ -2743,6 +2858,7 @@ impl TextServiceFactory {
                         mode,
                         &composition.raw_input,
                         app_config,
+                        romaji_lookup,
                     )?;
                     Some(Self::punctuation_commit_actions(text))
                 }
@@ -3160,6 +3276,7 @@ impl TextServiceFactory {
             (composition, mode)
         };
         let app_config = Self::load_app_config_or_default();
+        let romaji_lookup = RomajiLookup::from_rows(&app_config.romaji_table.rows);
 
         let mut preview = composition.preview.clone();
         let mut suffix = composition.suffix.clone();
@@ -3232,9 +3349,12 @@ impl TextServiceFactory {
                         &mut ipc_service,
                     )?;
                     let resolved_symbol_text = match mode {
-                        InputMode::Kana => {
-                            Self::resolve_symbol_input_text(&raw_input, text, &app_config)
-                        }
+                        InputMode::Kana => Self::resolve_symbol_input_text_with_lookup(
+                            &raw_input,
+                            text,
+                            &app_config,
+                            &romaji_lookup,
+                        ),
                         InputMode::Latin => None,
                     };
                     let text = match mode {
@@ -3853,9 +3973,12 @@ impl TextServiceFactory {
                     let shrunk_raw_input =
                         Self::current_raw_input_suffix(&raw_input, corresponding_count);
                     let resolved_symbol_text = match mode {
-                        InputMode::Kana => {
-                            Self::resolve_symbol_input_text(&shrunk_raw_input, text, &app_config)
-                        }
+                        InputMode::Kana => Self::resolve_symbol_input_text_with_lookup(
+                            &shrunk_raw_input,
+                            text,
+                            &app_config,
+                            &romaji_lookup,
+                        ),
                         InputMode::Latin => None,
                     };
                     let mut updated_raw_input = shrunk_raw_input.clone();

--- a/crates/client/src/engine/composition/tests/symbol_and_width.rs
+++ b/crates/client/src/engine/composition/tests/symbol_and_width.rs
@@ -50,6 +50,20 @@ fn single_symbol_romaji_output_ignores_multi_character_rule() {
 }
 
 #[test]
+fn single_symbol_romaji_output_preserves_row_order_for_symbol_variants() {
+    let rows = vec![row("\\", "BACKSLASH", ""), row("￥", "YEN", "")];
+    let output = TextServiceFactory::single_symbol_romaji_output("￥", &rows);
+    assert_eq!(output, Some("BACKSLASH".to_string()));
+}
+
+#[test]
+fn symbol_fallback_uses_trimmed_romaji_prefix_lookup() {
+    let rows = vec![row(" z/", "・", "")];
+    let should_apply = TextServiceFactory::should_apply_symbol_fallback("z", "/", &rows);
+    assert!(!should_apply);
+}
+
+#[test]
 fn zenzai_symbol_input_prefers_explicit_single_symbol_rule() {
     let mut app_config = AppConfig::default();
     app_config.zenzai.enable = true;

--- a/crates/client/src/engine/full_width.rs
+++ b/crates/client/src/engine/full_width.rs
@@ -129,6 +129,13 @@ static HALF_FULL_CONFIGURABLE: LazyLock<HashMap<&'static str, &'static str>> =
 static SYMBOL_FULLWIDTH_DEFAULTS: LazyLock<HashMap<&'static str, bool>> =
     LazyLock::new(|| HashMap::from(CHARACTER_WIDTH_SYMBOL_DEFAULTS));
 
+static SYMBOL_FULLWIDTH_DEFAULTS_CHAR: LazyLock<HashMap<char, bool>> = LazyLock::new(|| {
+    SYMBOL_FULLWIDTH_DEFAULTS
+        .iter()
+        .filter_map(|(key, value)| single_char(key).map(|key| (key, *value)))
+        .collect()
+});
+
 static HALF_FULL: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
     HashMap::from([
         ("a", "ａ"),
@@ -160,35 +167,50 @@ static HALF_FULL: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(
     ])
 });
 
+static HALF_FULL_AZOOKEY_CHAR: LazyLock<HashMap<char, char>> =
+    LazyLock::new(|| single_char_map(&HALF_FULL_AZOOKEY));
+
+static FULL_HALF_AZOOKEY_CHAR: LazyLock<HashMap<char, char>> = LazyLock::new(|| {
+    HALF_FULL_AZOOKEY_CHAR
+        .iter()
+        .map(|(half, full)| (*full, *half))
+        .collect()
+});
+
+static HALF_FULL_CONFIGURABLE_CHAR: LazyLock<HashMap<char, char>> =
+    LazyLock::new(|| single_char_map(&HALF_FULL_CONFIGURABLE));
+
+static HALF_FULL_CHAR: LazyLock<HashMap<char, char>> =
+    LazyLock::new(|| single_char_map(&HALF_FULL));
+
+fn single_char(value: &str) -> Option<char> {
+    let mut chars = value.chars();
+    let ch = chars.next()?;
+    chars.next().is_none().then_some(ch)
+}
+
+fn single_char_map(map: &HashMap<&'static str, &'static str>) -> HashMap<char, char> {
+    map.iter()
+        .filter_map(|(half, full)| Some((single_char(half)?, single_char(full)?)))
+        .collect()
+}
+
 pub fn to_halfwidth(s: &str) -> String {
     s.chars()
-        .map(|c| {
-            let key = c.to_string();
-            if let Some((&k, _)) = HALF_FULL_AZOOKEY.iter().find(|(_, &v)| v == key) {
-                k.to_string()
-            } else {
-                c.to_string()
-            }
-        })
+        .map(|c| FULL_HALF_AZOOKEY_CHAR.get(&c).copied().unwrap_or(c))
         .collect()
 }
 
 pub fn to_fullwidth(s: &str, process_alphabet: bool) -> String {
     s.chars()
         .map(|c| {
-            let key = c.to_string();
-
             if process_alphabet {
-                if let Some(&v) = HALF_FULL.get(key.as_str()) {
-                    return v.to_string();
+                if let Some(&v) = HALF_FULL_CHAR.get(&c) {
+                    return v;
                 }
             }
 
-            if let Some(&v) = HALF_FULL_AZOOKEY.get(key.as_str()) {
-                v.to_string()
-            } else {
-                c.to_string()
-            }
+            HALF_FULL_AZOOKEY_CHAR.get(&c).copied().unwrap_or(c)
         })
         .collect()
 }
@@ -200,26 +222,19 @@ pub fn to_fullwidth_with_config(
 ) -> String {
     s.chars()
         .map(|c| {
-            let key = c.to_string();
-
             if process_alphabet {
-                if let Some(&v) = HALF_FULL.get(key.as_str()) {
-                    return v.to_string();
+                if let Some(&v) = HALF_FULL_CHAR.get(&c) {
+                    return v;
                 }
             }
 
-            if let Some(&v) = HALF_FULL_CONFIGURABLE.get(key.as_str()) {
-                let is_fullwidth = symbol_fullwidth
-                    .get(key.as_str())
-                    .copied()
-                    .or_else(|| SYMBOL_FULLWIDTH_DEFAULTS.get(key.as_str()).copied())
-                    .unwrap_or(false);
-                if is_fullwidth {
-                    return v.to_string();
+            if let Some(&v) = HALF_FULL_CONFIGURABLE_CHAR.get(&c) {
+                if symbol_fullwidth_enabled(c, symbol_fullwidth) {
+                    return v;
                 }
             }
 
-            c.to_string()
+            c
         })
         .collect()
 }
@@ -236,52 +251,52 @@ pub fn convert_kana_symbol(
         .map(|c| {
             let key = normalize_input_key(c);
 
-            let base = apply_basic_setting(&key, general)
+            let base = apply_basic_setting(key, general)
                 .map(str::to_string)
                 .unwrap_or_else(|| {
-                    legacy_fullwidth_or_half(&key, &character_width.symbol_fullwidth)
+                    legacy_fullwidth_or_half(key, &character_width.symbol_fullwidth)
                 });
 
-            apply_width_groups_with_source_key(&base, &key, groups)
+            apply_width_groups_with_source_key(&base, key, groups)
         })
         .collect::<Vec<_>>()
         .join("")
 }
 
-fn normalize_input_key(c: char) -> String {
+fn normalize_input_key(c: char) -> char {
     match c {
-        'ˆ' | '＾' => "^".to_string(),
-        '〜' | '～' => "~".to_string(),
-        '＼' | '￥' | '¥' => "\\".to_string(),
-        '，' => ",".to_string(),
-        '．' => ".".to_string(),
-        '”' => "\"".to_string(),
-        '’' => "'".to_string(),
-        _ => c.to_string(),
+        'ˆ' | '＾' => '^',
+        '〜' | '～' => '~',
+        '＼' | '￥' | '¥' => '\\',
+        '，' => ',',
+        '．' => '.',
+        '”' => '"',
+        '’' => '\'',
+        _ => c,
     }
 }
 
-fn apply_basic_setting(key: &str, general: &GeneralConfig) -> Option<&'static str> {
+fn apply_basic_setting(key: char, general: &GeneralConfig) -> Option<&'static str> {
     match key {
-        "," => Some(match general.punctuation_style {
+        ',' => Some(match general.punctuation_style {
             PunctuationStyle::ToutenKuten | PunctuationStyle::ToutenFullwidthPeriod => "、",
             PunctuationStyle::FullwidthCommaFullwidthPeriod
             | PunctuationStyle::FullwidthCommaKuten => "，",
         }),
-        "." => Some(match general.punctuation_style {
+        '.' => Some(match general.punctuation_style {
             PunctuationStyle::ToutenKuten | PunctuationStyle::FullwidthCommaKuten => "。",
             PunctuationStyle::FullwidthCommaFullwidthPeriod
             | PunctuationStyle::ToutenFullwidthPeriod => "．",
         }),
-        "[" => Some(match general.symbol_style {
+        '[' => Some(match general.symbol_style {
             SymbolStyle::CornerBracketMiddleDot | SymbolStyle::CornerBracketBackslash => "「",
             SymbolStyle::SquareBracketBackslash | SymbolStyle::SquareBracketMiddleDot => "［",
         }),
-        "]" => Some(match general.symbol_style {
+        ']' => Some(match general.symbol_style {
             SymbolStyle::CornerBracketMiddleDot | SymbolStyle::CornerBracketBackslash => "」",
             SymbolStyle::SquareBracketBackslash | SymbolStyle::SquareBracketMiddleDot => "］",
         }),
-        "/" => Some(match general.symbol_style {
+        '/' => Some(match general.symbol_style {
             SymbolStyle::CornerBracketMiddleDot | SymbolStyle::SquareBracketMiddleDot => "・",
             SymbolStyle::SquareBracketBackslash | SymbolStyle::CornerBracketBackslash => "／",
         }),
@@ -289,19 +304,26 @@ fn apply_basic_setting(key: &str, general: &GeneralConfig) -> Option<&'static st
     }
 }
 
-fn legacy_fullwidth_or_half(key: &str, symbol_fullwidth: &HashMap<String, bool>) -> String {
-    if let Some(&fullwidth) = HALF_FULL_CONFIGURABLE.get(key) {
-        let is_fullwidth = symbol_fullwidth
-            .get(key)
-            .copied()
-            .or_else(|| SYMBOL_FULLWIDTH_DEFAULTS.get(key).copied())
-            .unwrap_or(false);
-        if is_fullwidth {
+fn legacy_fullwidth_or_half(key: char, symbol_fullwidth: &HashMap<String, bool>) -> String {
+    if let Some(&fullwidth) = HALF_FULL_CONFIGURABLE_CHAR.get(&key) {
+        if symbol_fullwidth_enabled(key, symbol_fullwidth) {
             return fullwidth.to_string();
         }
     }
 
     key.to_string()
+}
+
+fn symbol_fullwidth_enabled(key: char, symbol_fullwidth: &HashMap<String, bool>) -> bool {
+    let mut buffer = [0; 4];
+    let key = key.encode_utf8(&mut buffer);
+    symbol_fullwidth
+        .get(key)
+        .copied()
+        .or_else(|| {
+            single_char(key).and_then(|key| SYMBOL_FULLWIDTH_DEFAULTS_CHAR.get(&key).copied())
+        })
+        .unwrap_or(false)
 }
 
 fn apply_width_groups(text: &str, groups: &CharacterWidthGroups) -> String {
@@ -312,10 +334,10 @@ fn apply_width_groups(text: &str, groups: &CharacterWidthGroups) -> String {
 
 fn apply_width_groups_with_source_key(
     text: &str,
-    source_key: &str,
+    source_key: char,
     groups: &CharacterWidthGroups,
 ) -> String {
-    if source_key == "/" {
+    if source_key == '/' {
         return text
             .chars()
             .map(|c| match c {
@@ -467,6 +489,23 @@ mod tests {
 
         let output = convert_kana_symbol("?", &general, &config, &rows);
         assert_eq!(output, "?");
+    }
+
+    #[test]
+    fn halfwidth_conversion_uses_reverse_symbol_lookup() {
+        assert_eq!(to_halfwidth("！？￥「」"), r"!?\[]");
+    }
+
+    #[test]
+    fn configurable_fullwidth_conversion_uses_direct_symbol_lookup() {
+        let mut symbol_fullwidth = shared::default_symbol_fullwidth_map();
+        symbol_fullwidth.insert("1".to_string(), true);
+        symbol_fullwidth.insert("!".to_string(), true);
+
+        assert_eq!(
+            to_fullwidth_with_config("a1!", true, &symbol_fullwidth),
+            "ａ１！"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- ローマ字テーブルの prefix / 最大入力長 / 単一記号出力を `RomajiLookup` として事前計算し、記号入力時の repeated row scan を減らしました。
- `CompositionReducer` / 記号入力解決の production path では lookup を 1 回作って使い回すようにしました。
- 全角/半角変換では `char -> char` の直接 lookup を追加し、1 文字 `String` 化や reverse scan を避けるようにしました。

## Background
- Issue: Closes #49
- ローマ字テーブルと記号変換の探索が、入力ごとに最大長計算・suffix 生成・テーブル走査・逆引き探索を繰り返していました。
- 実測の速度計測までは行わず、通常入力と記号/数字入力の挙動が変わらないことを重点的に確認しています。

## Changes
- client composition
  - `RomajiLookup` を追加し、trim 済み input の prefix set、multi-character prefix set、最大長、単一記号出力を構築
  - `has_romaji_table_context` / `has_multi_character_romaji_context` / `single_symbol_romaji_output` / symbol fallback 判定を lookup ベースへ変更
  - wrapper は既存テスト用の公開 surface を維持しつつ、production path は lookup を渡して使い回す構成に変更
- full_width
  - azooKey 記号、設定可能記号、英字の `char` lookup map を追加
  - `to_halfwidth` / `to_fullwidth` / `to_fullwidth_with_config` / `convert_kana_symbol` の hot path で不要な `String` 化を削減
- tests
  - 単一記号ローマ字出力の行順維持、trim 済み prefix fallback、半角逆引き、設定付き全角変換の回帰テストを追加

## Verification
- [x] 差分チェック
  - `git diff --check`
- [x] format
  - `cargo fmt`
- [x] ローカル Windows target check
  - `PROTOC=.local/tmp/protoc/bin/protoc cargo check -p azookey-windows --target x86_64-pc-windows-msvc`
- [x] ローカル Windows VM test 成功
  - `.local/vm_test_client_composition.sh feature/49-romaji-symbol-lookup composition all`
  - Cargo composition: 97 tests passed
  - Swift runner: 37 tests passed
- [x] ローカル Windows VM build 成功
  - `.local/vm_build_master.sh feature/49-romaji-symbol-lookup`
  - artifact: `.local/artifacts/azookey-setup-feature_49-romaji-symbol-lookup-20260530-133047.exe`
- [x] ローカル Windows VM install 成功
  - `SHUTDOWN_AFTER_INSTALL=0 .local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-feature_49-romaji-symbol-lookup-20260530-133047.exe`
  - install log: `.local/logs/win11-install-20260530-172817.log`
- [x] ローカル Windows VM 入力スモーク
  - Notepad + azooKey で `aiueo` -> `あいうえお` を確認
  - `z/` -> `・` を確認
  - `123!?` -> `123！？` を確認
  - `toukyou` / `kyouha` の space+enter 変換経路がコミットされることを確認
  - screenshots: `.local/vm-debug/issue49-aiueo-committed.png`, `.local/vm-debug/issue49-zslash.png`, `.local/vm-debug/issue49-symbols-digits.png`, `.local/vm-debug/issue49-toukyou-converted.png`, `.local/vm-debug/issue49-kyouha-converted.png`
- [ ] GitHub Actions build 成功
  - run: pending

## Checklist
- [ ] CI run URL と結果を記載した
- [x] VM / 実機確認結果を記載した
- [x] 影響範囲を確認した

## Notes
- Linux 上の通常 `cargo test -p azookey-windows symbol_and_width -- --nocapture` は、この crate が Windows 前提のため `windows::Win32` / named pipe 周りで compile 前に実行不能でした。Windows target check と VM test / VM smoke で確認しています。