### PR TITLE
Add Ctrl conversion shortcuts

### DIFF
--- a/crates/client/src/engine/client_action.rs
+++ b/crates/client/src/engine/client_action.rs
@@ -37,9 +37,9 @@ pub enum SetSelectionType {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum SetTextType {
-    Hiragana,     // F6
-    Katakana,     // F7
-    HalfKatakana, // F8
-    FullLatin,    // F9
-    HalfLatin,    // F10
+    Hiragana,     // F6 / Ctrl+U
+    Katakana,     // F7 / Ctrl+I
+    HalfKatakana, // F8 / Ctrl+O
+    FullLatin,    // F9 / Ctrl+P
+    HalfLatin,    // F10 / Ctrl+T
 }

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -290,6 +290,11 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn is_alt_pressed() -> bool {
+        VK_MENU.is_pressed() || VK_LMENU.is_pressed() || VK_RMENU.is_pressed()
+    }
+
+    #[inline]
     fn is_shift_pressed() -> bool {
         VK_SHIFT.is_pressed()
     }
@@ -302,6 +307,30 @@ impl TextServiceFactory {
     #[inline]
     fn is_shift_alphabet_shortcut(wparam: WPARAM, is_shift_pressed: bool) -> bool {
         is_shift_pressed && (0x41..=0x5A).contains(&wparam.0)
+    }
+
+    #[inline]
+    fn ctrl_conversion_shortcut_function(
+        key_code: usize,
+        is_ctrl_pressed: bool,
+        is_alt_pressed: bool,
+    ) -> Option<Function> {
+        if is_ctrl_pressed && !is_alt_pressed {
+            Function::from_ctrl_shortcut_key_code(key_code)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn set_text_type_for_function(function: Function) -> SetTextType {
+        match function {
+            Function::Six => SetTextType::Hiragana,
+            Function::Seven => SetTextType::Katakana,
+            Function::Eight => SetTextType::HalfKatakana,
+            Function::Nine => SetTextType::FullLatin,
+            Function::Ten => SetTextType::HalfLatin,
+        }
     }
 
     #[inline]
@@ -2818,28 +2847,12 @@ impl TextServiceFactory {
                     CompositionState::Previewing,
                     Self::candidate_preview_actions(app_config),
                 )),
-                UserAction::Function(key) => match key {
-                    Function::Six => Some((
-                        CompositionState::Previewing,
-                        vec![ClientAction::SetTextWithType(SetTextType::Hiragana)],
-                    )),
-                    Function::Seven => Some((
-                        CompositionState::Previewing,
-                        vec![ClientAction::SetTextWithType(SetTextType::Katakana)],
-                    )),
-                    Function::Eight => Some((
-                        CompositionState::Previewing,
-                        vec![ClientAction::SetTextWithType(SetTextType::HalfKatakana)],
-                    )),
-                    Function::Nine => Some((
-                        CompositionState::Previewing,
-                        vec![ClientAction::SetTextWithType(SetTextType::FullLatin)],
-                    )),
-                    Function::Ten => Some((
-                        CompositionState::Previewing,
-                        vec![ClientAction::SetTextWithType(SetTextType::HalfLatin)],
-                    )),
-                },
+                UserAction::Function(key) => Some((
+                    CompositionState::Previewing,
+                    vec![ClientAction::SetTextWithType(
+                        Self::set_text_type_for_function(*key),
+                    )],
+                )),
                 _ => None,
             },
             CompositionState::Previewing => match action {
@@ -2971,28 +2984,12 @@ impl TextServiceFactory {
                     CompositionState::Previewing,
                     Self::candidate_preview_actions(app_config),
                 )),
-                UserAction::Function(key) => match key {
-                    Function::Six => Some((
-                        CompositionState::Previewing,
-                        vec![ClientAction::SetTextWithType(SetTextType::Hiragana)],
-                    )),
-                    Function::Seven => Some((
-                        CompositionState::Previewing,
-                        vec![ClientAction::SetTextWithType(SetTextType::Katakana)],
-                    )),
-                    Function::Eight => Some((
-                        CompositionState::Previewing,
-                        vec![ClientAction::SetTextWithType(SetTextType::HalfKatakana)],
-                    )),
-                    Function::Nine => Some((
-                        CompositionState::Previewing,
-                        vec![ClientAction::SetTextWithType(SetTextType::FullLatin)],
-                    )),
-                    Function::Ten => Some((
-                        CompositionState::Previewing,
-                        vec![ClientAction::SetTextWithType(SetTextType::HalfLatin)],
-                    )),
-                },
+                UserAction::Function(key) => Some((
+                    CompositionState::Previewing,
+                    vec![ClientAction::SetTextWithType(
+                        Self::set_text_type_for_function(*key),
+                    )],
+                )),
                 _ => None,
             },
             CompositionState::Selecting => None,
@@ -3020,10 +3017,13 @@ impl TextServiceFactory {
         }
 
         let is_ctrl_pressed = Self::is_ctrl_pressed();
+        let is_alt_pressed = Self::is_alt_pressed();
         let is_shift_pressed = Self::is_shift_pressed();
         let is_ctrl_space = is_ctrl_pressed && wparam.0 == 0x20;
         let is_ctrl_enter = is_ctrl_pressed && wparam.0 == 0x0D;
         let is_ctrl_down = is_ctrl_pressed && wparam.0 == 0x28;
+        let ctrl_conversion_function =
+            Self::ctrl_conversion_shortcut_function(wparam.0, is_ctrl_pressed, is_alt_pressed);
         let is_shift_left = is_shift_pressed && wparam.0 == 0x25;
         let is_shift_right = is_shift_pressed && wparam.0 == 0x27;
         let is_shift_key = Self::is_shift_key(wparam);
@@ -3031,7 +3031,12 @@ impl TextServiceFactory {
         let app_config = Self::load_app_config_or_default();
 
         // check shortcut keys
-        if is_ctrl_pressed && !is_ctrl_space && !is_alt_backquote && !is_ctrl_enter && !is_ctrl_down
+        if is_ctrl_pressed
+            && !is_ctrl_space
+            && !is_alt_backquote
+            && !is_ctrl_enter
+            && !is_ctrl_down
+            && ctrl_conversion_function.is_none()
         {
             self.clear_temporary_latin_shift_pending_if_needed(!Self::is_shift_key(wparam))?;
             return Ok(None);
@@ -3077,6 +3082,8 @@ impl TextServiceFactory {
             UserAction::CommitFirstClause
         } else if is_ctrl_down {
             UserAction::CommitAndNextClause
+        } else if let Some(function) = ctrl_conversion_function {
+            UserAction::Function(function)
         } else if is_shift_left {
             UserAction::AdjustClauseBoundary(-1)
         } else if is_shift_right {

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -136,6 +136,44 @@ fn delayed_candidate_window_shows_when_space_opens_preview() {
 }
 
 #[test]
+fn ctrl_conversion_shortcuts_are_handled_as_function_keys() {
+    let cases = [
+        (0x55, Function::Six, SetTextType::Hiragana),
+        (0x49, Function::Seven, SetTextType::Katakana),
+        (0x4F, Function::Eight, SetTextType::HalfKatakana),
+        (0x50, Function::Nine, SetTextType::FullLatin),
+        (0x54, Function::Ten, SetTextType::HalfLatin),
+    ];
+
+    for (key_code, function, set_text_type) in cases {
+        assert_eq!(
+            TextServiceFactory::ctrl_conversion_shortcut_function(key_code, true, false),
+            Some(function)
+        );
+        assert_eq!(
+            TextServiceFactory::set_text_type_for_function(function),
+            set_text_type
+        );
+    }
+}
+
+#[test]
+fn ctrl_conversion_shortcuts_do_not_capture_non_ctrl_or_alt_modified_keys() {
+    assert_eq!(
+        TextServiceFactory::ctrl_conversion_shortcut_function(0x55, false, false),
+        None
+    );
+    assert_eq!(
+        TextServiceFactory::ctrl_conversion_shortcut_function(0x55, true, true),
+        None
+    );
+    assert_eq!(
+        TextServiceFactory::ctrl_conversion_shortcut_function(0x41, true, false),
+        None
+    );
+}
+
+#[test]
 fn right_arrow_prepares_clause_navigation_without_initial_move() {
     let composition = Composition {
         state: CompositionState::Composing,

--- a/crates/client/src/engine/user_action.rs
+++ b/crates/client/src/engine/user_action.rs
@@ -33,7 +33,7 @@ pub enum Navigation {
     Right,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Function {
     Six,
     Seven,
@@ -42,9 +42,52 @@ pub enum Function {
     Ten,
 }
 
+impl Function {
+    pub(crate) fn from_ctrl_shortcut_key_code(key_code: usize) -> Option<Self> {
+        match key_code {
+            0x55 => Some(Self::Six),   // Ctrl+U
+            0x49 => Some(Self::Seven), // Ctrl+I
+            0x4F => Some(Self::Eight), // Ctrl+O
+            0x50 => Some(Self::Nine),  // Ctrl+P
+            0x54 => Some(Self::Ten),   // Ctrl+T
+            _ => None,
+        }
+    }
+}
+
 #[inline]
 fn is_ctrl_pressed() -> bool {
     VK_CONTROL.is_pressed() || VK_LCONTROL.is_pressed() || VK_RCONTROL.is_pressed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Function;
+
+    #[test]
+    fn ctrl_shortcut_keys_map_to_conversion_functions() {
+        assert_eq!(
+            Function::from_ctrl_shortcut_key_code(0x55),
+            Some(Function::Six)
+        );
+        assert_eq!(
+            Function::from_ctrl_shortcut_key_code(0x49),
+            Some(Function::Seven)
+        );
+        assert_eq!(
+            Function::from_ctrl_shortcut_key_code(0x4F),
+            Some(Function::Eight)
+        );
+        assert_eq!(
+            Function::from_ctrl_shortcut_key_code(0x50),
+            Some(Function::Nine)
+        );
+        assert_eq!(
+            Function::from_ctrl_shortcut_key_code(0x54),
+            Some(Function::Ten)
+        );
+        assert_eq!(Function::from_ctrl_shortcut_key_code(0x41), None);
+    }
 }
 
 fn clear_dead_key_state(key_state: &[u8; 256]) {


### PR DESCRIPTION
## Summary
- F6-F10 相当の変換操作を `Ctrl+U/I/O/P/T` からも実行できるようにしました。
- Ctrl ショートカットは既存の `UserAction::Function` / `SetTextWithType` 経路へ合流させ、F キー変換と同じ reducer path で処理します。
- `Ctrl+Alt+...` など Alt 併用のショートカットは IME 側で奪わないようにしました。

## Background
- Issue: Closes #74
- F キーのないキーボードやホームポジションから変換したいケース向けに、他の IME と同様の Ctrl 系変換ショートカットを追加します。
- 対応するショートカットは以下です。
  - `Ctrl+U` → ひらがな
  - `Ctrl+I` → 全角カタカナ
  - `Ctrl+O` → 半角カタカナ
  - `Ctrl+P` → 全角英数
  - `Ctrl+T` → 半角英数

## Changes
- client key handling
  - `Function::from_ctrl_shortcut_key_code` を追加し、Ctrl 系ショートカットを既存の F6-F10 相当の `Function` に変換
  - `process_key` の Ctrl 早期 return で、この5キーだけを IME 処理対象として許可
  - Ctrl+Alt 併用時は対象外にし、アプリ側ショートカットを不用意に奪わないように変更
- composition reducer
  - `Function` → `SetTextType` の対応を helper にまとめ、Composing / Previewing の重複 match を削減
- tests
  - Ctrl ショートカット対応表と、Alt 併用時に capture しないことの回帰テストを追加

## Verification
- [x] 差分チェック
  - `git diff --check`
- [x] format
  - `cargo fmt --all --check`
- [x] ローカル Windows VM test 成功
  - `bash .local/vm_test_client_composition.sh feature/74-conversion-shortcuts ctrl_conversion_shortcuts skip`
  - `bash .local/vm_test_client_composition.sh feature/74-conversion-shortcuts ctrl_shortcut_keys_map_to_conversion_functions skip`
- [x] ローカル Windows VM build 成功
  - `bash .local/vm_build_master.sh feature/74-conversion-shortcuts`
  - artifact: `.local/artifacts/azookey-setup-feature_74-conversion-shortcuts-20260531-090627.exe`
- [x] ローカル Windows VM install 成功
  - `SHUTDOWN_AFTER_INSTALL=0 bash .local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-feature_74-conversion-shortcuts-20260531-090627.exe`
  - install log: `.local/logs/win11-install-20260531-094725.log`
- [x] ローカル Windows VM 入力確認
  - Notepad + azooKey で `aiueo` 入力中に `Ctrl+U` → `あいうえお`
  - `Ctrl+I` → `アイウエオ`
  - `Ctrl+O` → `ｱｲｳｴｵ`
  - `Ctrl+P` → `ａｉｕｅｏ`
  - `Ctrl+T` → `aiueo`
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/26708399830/job/78713958238

## Checklist
- [x] CI run URL と結果を記載した
- [x] VM / 実機確認結果を記載した
- [x] 影響範囲を確認した
