### PR TITLE
fix(updater): show installer UI for settings updates

### DIFF
--- a/frontend/src-tauri/src/updater.rs
+++ b/frontend/src-tauri/src/updater.rs
@@ -363,11 +363,13 @@ fn launch_installer_helper(
     result_path: &Path,
     install_log_path: &Path,
 ) -> Result<()> {
-    let script_path = installer_path
+    let staging_dir = installer_path
         .parent()
-        .ok_or_else(|| anyhow!("installer path has no parent"))?
-        .join("azookey-update-helper.ps1");
-    write_installer_helper_script(&script_path)?;
+        .ok_or_else(|| anyhow!("installer path has no parent"))?;
+    let helper_script_path = staging_dir.join("azookey-update-helper.ps1");
+    let launcher_script_path = staging_dir.join("azookey-update-launcher.ps1");
+    write_installer_helper_script(&helper_script_path)?;
+    write_installer_launcher_script(&launcher_script_path)?;
 
     let status = Command::new("powershell")
         .arg("-NoProfile")
@@ -376,17 +378,22 @@ fn launch_installer_helper(
         .arg("-WindowStyle")
         .arg("Hidden")
         .arg("-File")
-        .arg(&script_path)
+        .arg(&launcher_script_path)
+        .arg("-HelperPath")
+        .arg(&helper_script_path)
         .arg("-InstallerPath")
         .arg(installer_path)
         .arg("-ResultPath")
         .arg(result_path)
         .arg("-InstallLogPath")
         .arg(install_log_path)
-        .spawn()
-        .context("failed to launch updater helper")?;
+        .status()
+        .context("failed to launch updater helper launcher")?;
 
-    drop(status);
+    if !status.success() {
+        return Err(anyhow!("updater helper launcher failed: {status}"));
+    }
+
     Ok(())
 }
 
@@ -397,6 +404,60 @@ fn write_installer_helper_script(script_path: &Path) -> Result<()> {
         .with_context(|| format!("failed to write updater helper: {}", script_path.display()))?;
     Ok(())
 }
+
+fn write_installer_launcher_script(script_path: &Path) -> Result<()> {
+    let mut file = fs::File::create(script_path).with_context(|| {
+        format!(
+            "failed to create updater helper launcher: {}",
+            script_path.display()
+        )
+    })?;
+    file.write_all(INSTALLER_LAUNCHER_PS1.as_bytes())
+        .with_context(|| {
+            format!(
+                "failed to write updater helper launcher: {}",
+                script_path.display()
+            )
+        })?;
+    Ok(())
+}
+
+const INSTALLER_LAUNCHER_PS1: &str = r#"
+param(
+  [Parameter(Mandatory = $true)][string]$HelperPath,
+  [Parameter(Mandatory = $true)][string]$InstallerPath,
+  [Parameter(Mandatory = $true)][string]$ResultPath,
+  [Parameter(Mandatory = $true)][string]$InstallLogPath
+)
+
+$ErrorActionPreference = "Stop"
+
+function Quote-ProcessArgument {
+  param([Parameter(Mandatory = $true)][string]$Value)
+  '"' + ($Value -replace '"', '\"') + '"'
+}
+
+$helperArgs = @(
+  "-NoProfile",
+  "-ExecutionPolicy",
+  "Bypass",
+  "-WindowStyle",
+  "Hidden",
+  "-File",
+  (Quote-ProcessArgument $HelperPath),
+  "-InstallerPath",
+  (Quote-ProcessArgument $InstallerPath),
+  "-ResultPath",
+  (Quote-ProcessArgument $ResultPath),
+  "-InstallLogPath",
+  (Quote-ProcessArgument $InstallLogPath)
+)
+
+# Keep the long-running helper out of frontend.exe's process tree. The installer
+# intentionally stops frontend.exe before replacing files, and taskkill /T would
+# otherwise kill the updater helper and its installer child.
+Start-Process -FilePath "powershell.exe" -ArgumentList $helperArgs -WindowStyle Hidden | Out-Null
+"#;
 
 const INSTALLER_HELPER_PS1: &str = r#"
 param(
@@ -430,15 +491,28 @@ function Write-UpdateResult {
   [System.IO.File]::WriteAllText($ResultPath, $json, $utf8NoBom)
 }
 
+function Test-IsProcessElevated {
+  $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = [System.Security.Principal.WindowsPrincipal]::new($identity)
+  $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
 try {
   $installerArgs = @(
-    "/VERYSILENT",
-    "/SUPPRESSMSGBOXES",
-    "/NORESTART",
     "/RESTARTEXITCODE=3010",
     "/LOG=$InstallLogPath"
   )
-  $proc = Start-Process -FilePath $InstallerPath -ArgumentList $installerArgs -Wait -PassThru
+  $startProcessArgs = @{
+    FilePath = $InstallerPath
+    ArgumentList = $installerArgs
+    Wait = $true
+    PassThru = $true
+  }
+  if (-not (Test-IsProcessElevated)) {
+    $startProcessArgs["Verb"] = "RunAs"
+  }
+
+  $proc = Start-Process @startProcessArgs
   if ($proc.ExitCode -eq 0) {
     Write-UpdateResult -Status "success" -ExitCode $proc.ExitCode -NeedsRestart $false -Message "更新が完了しました。"
     exit 0
@@ -655,9 +729,27 @@ mod tests {
     }
 
     #[test]
-    fn helper_requests_restart_exit_code() {
-        assert!(INSTALLER_HELPER_PS1.contains(r#""/NORESTART""#));
+    fn helper_launches_installer_with_visible_ui() {
+        assert!(!INSTALLER_HELPER_PS1.contains(r#""/VERYSILENT""#));
+        assert!(!INSTALLER_HELPER_PS1.contains(r#""/SUPPRESSMSGBOXES""#));
+        assert!(!INSTALLER_HELPER_PS1.contains(r#""/NORESTART""#));
         assert!(INSTALLER_HELPER_PS1.contains(r#""/RESTARTEXITCODE=3010""#));
+        assert!(INSTALLER_HELPER_PS1.contains(r#""/LOG=$InstallLogPath""#));
+    }
+
+    #[test]
+    fn helper_elevates_installer_when_needed() {
+        assert!(INSTALLER_HELPER_PS1.contains("Test-IsProcessElevated"));
+        assert!(INSTALLER_HELPER_PS1.contains(r#"$startProcessArgs["Verb"] = "RunAs""#));
+        assert!(INSTALLER_HELPER_PS1.contains("Start-Process @startProcessArgs"));
+    }
+
+    #[test]
+    fn launcher_starts_helper_as_separate_process() {
+        assert!(INSTALLER_LAUNCHER_PS1.contains("Start-Process"));
+        assert!(INSTALLER_LAUNCHER_PS1.contains(r#""powershell.exe""#));
+        assert!(INSTALLER_LAUNCHER_PS1.contains("Quote-ProcessArgument $HelperPath"));
+        assert!(!INSTALLER_LAUNCHER_PS1.contains("-Wait"));
     }
 
     #[test]

--- a/installer/Installer.iss
+++ b/installer/Installer.iss
@@ -82,7 +82,7 @@ Filename: "icacls"; \
 
 [UninstallRun]
 Filename: "taskkill"; \
-  Parameters: "/F /T /IM ""frontend.exe"""; \
+  Parameters: "/F /IM ""frontend.exe"""; \
   RunOnceId: "StopFrontend"; \
   Flags: runhidden
 Filename: "taskkill"; \
@@ -265,11 +265,19 @@ begin
   Result := True;
 end;
 
-procedure StopAzookeyProcess(ImageName: String);
+procedure StopAzookeyProcess(ImageName: String; KillProcessTree: Boolean);
 var
+  Parameters: String;
   ResultCode: Integer;
 begin
-  Exec('taskkill', '/F /T /IM "' + ImageName + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  Parameters := '/F ';
+  if KillProcessTree then
+  begin
+    Parameters := Parameters + '/T ';
+  end;
+  Parameters := Parameters + '/IM "' + ImageName + '"';
+
+  Exec('taskkill', Parameters, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
   if ResultCode = 0 then
   begin
     Log('Stopped Azookey process before install: ' + ImageName);
@@ -282,10 +290,10 @@ end;
 
 procedure StopAzookeyProcessesBeforeInstall();
 begin
-  StopAzookeyProcess('frontend.exe');
-  StopAzookeyProcess('azookey-server.exe');
-  StopAzookeyProcess('ui.exe');
-  StopAzookeyProcess('launcher.exe');
+  StopAzookeyProcess('frontend.exe', False);
+  StopAzookeyProcess('azookey-server.exe', True);
+  StopAzookeyProcess('ui.exe', True);
+  StopAzookeyProcess('launcher.exe', True);
 end;
 
 <event('PrepareToInstall')>


### PR DESCRIPTION
## Summary
- 設定画面から起動する updater helper を `frontend.exe` の子プロセスツリーから切り離して起動するようにしました。
- updater helper が非管理者権限で動いている場合は、installer を `RunAs` で起動するようにしました。
- 設定画面からの更新でもサイレントインストールではなく、通常起動時と同じ Inno Setup GUI を表示するようにしました。

## Background
- 設定画面から更新を開始すると、installer が `frontend.exe` を停止する際に updater helper / installer まで巻き込まれる可能性がありました。
- また、サイレント実行では更新の進捗や成功可否がユーザーに見えにくく、再起動が必要な場合の案内も分かりにくい状態でした。

## Changes
- updater helper launch
  - 短命の launcher script から長命の helper script を起動し、helper を `frontend.exe` の process tree 外へ逃がすように変更
  - helper が非昇格の場合は `Start-Process -Verb RunAs` で installer を起動
- installer execution
  - updater helper から渡す installer 引数から `/VERYSILENT`、`/SUPPRESSMSGBOXES`、`/NORESTART` を削除
  - 再起動が必要な成功ケースを result に残せるよう `/RESTARTEXITCODE=3010` は維持
  - result 記録用に `/LOG=...` も維持
- installer process stop
  - installer 側で `frontend.exe` を停止するときだけ `taskkill /T` を使わないように変更
  - `azookey-server.exe`、`ui.exe`、`launcher.exe` は従来どおり process tree ごと停止
- tests
  - updater helper が visible UI で installer を起動しつつ restart exit code を維持することを確認するテストを追加
  - helper の昇格起動と launcher による process tree 切り離しを確認するテストを追加

## Verification
- [x] 差分チェック
  - `git diff --check`
- [x] format
  - `cargo fmt --all --check`
- [x] ローカル Windows VM build 成功
  - `scripts/vm_build.sh fix/updater-helper-detach`
  - artifact: `.local/artifacts/azookey-setup-fix_updater-helper-detach-20260602-202847.exe`
- [x] ローカル Windows VM GUI 更新成功
  - 一時的に `0.1.0-batao.4` としてビルドした installer を VM に staging
  - 設定画面の `最新版にアップデート` から公式 `0.1.0-batao.5` installer を起動
  - Inno Setup GUI の追加タスク選択、インストール準備完了、進捗、完了画面が表示されることを確認
  - 更新後の registry `DisplayVersion=0.1.0-batao.5` を確認
  - updater result: `status=success`, `exit_code=0`, `needs_restart=false`
- [x] 手動検証用 VM 準備
  - `Win11` VM を `0.1.0-batao.4` + 更新ボタン表示状態に戻した
- [ ] WSL 上の frontend updater test
  - `cargo test -p frontend installer --lib`
  - WSL 環境の `pkg-config` / OpenSSL 不足により `openssl-sys` build 前に失敗

## Notes
- 一時的に落とした version は戻し済みです。
  - `app-version.json`: `0.1.0-batao.5`
  - `installer/AppVersion.iss`: `0.1.0-batao.5`
  - `frontend/package.json`: `0.1.0-batao.5`
- Codex review の指摘を受け、GUI 表示を維持したまま `/RESTARTEXITCODE=3010` を戻しました。
- issue76 作業中の元 worktree は変更せず、別 worktree `/home/batao9/workspaces/azooKey-Windows-updater-helper-detach` で作業しました。