### PR TITLE
chore(release): prepare v0.1.0-batao.6

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,3 +1,3 @@
 {
-  "version": "0.1.0-batao.5"
+  "version": "0.1.0-batao.6"
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0-batao.5",
+  "version": "0.1.0-batao.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0-batao.5",
+      "version": "0.1.0-batao.6",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-dialog": "^1.1.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0-batao.5",
+  "version": "0.1.0-batao.6",
   "type": "module",
   "scripts": {
     "sync-version": "node ../scripts/sync-version.mjs",

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Azookey",
-  "version": "0.1.0-batao.5",
+  "version": "0.1.0-batao.6",
   "identifier": "com.azookey.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/installer/AppVersion.iss
+++ b/installer/AppVersion.iss
@@ -1,2 +1,2 @@
 ; Generated from app-version.json by scripts/sync-version.mjs.
-#define MyAppVersion "0.1.0-batao.5"
+#define MyAppVersion "0.1.0-batao.6"


### PR DESCRIPTION
## Summary
- アプリ内バージョンとインストーラー版数を `0.1.0-batao.6` に更新しました。
- `scripts/sync-version.mjs` で frontend / Tauri / installer の派生バージョンファイルを同期しました。
- リリース本文案は `.local/release/v0.1.0-batao.6/release-body.md` に準備済みです。

## Verification
- [x] `scripts/sync-version.mjs` 再実行後に差分なし
- [x] `git diff --check`
- [x] version 対象 5 ファイルがすべて `0.1.0-batao.6`
- [x] version 対象 5 ファイルに `0.1.0-batao.5` が残っていないことを確認
- [x] リリース対象の master 差分を確認
  - `v0.1.0-batao.5..origin/master`
  - PR #79: `fix(updater): show installer UI for settings updates`
- [x] PR #79 の GitHub Actions build 成功を確認
  - https://github.com/batao9/azooKey-Windows/actions/runs/26828017231
- [x] release branch の GitHub Actions build 成功を確認
  - https://github.com/batao9/azooKey-Windows/actions/runs/26829607268

## Notes
- issue76 作業中の元 worktree は変更せず、別 worktree `/home/batao9/workspaces/azooKey-Windows-release-v0.1.0-batao.6` で作業しました。
