### PR TITLE
fix(settings): add server restart controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,6 +2166,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "shared",
+ "tokio",
+ "windows",
 ]
 
 [[package]]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -16,7 +16,7 @@ windows-core = "0.58.0"
 shared = { path = "../shared" }
 macros = { path = "../macros" }
 tonic = "0.12.3"
-tokio = { version = "1.42.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.42.0", features = ["rt-multi-thread", "net", "time", "io-util"] }
 tower = "0.5.1"
 hyper-util = { version = "0.1.9", features = ["tokio"] }
 tracing = "0.1.41"

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -3,15 +3,21 @@ use std::{
     os::windows::ffi::OsStrExt as _,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU32, Ordering},
+    time::{Duration, Instant},
 };
 
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::windows::named_pipe::{ClientOptions, NamedPipeClient},
+    time,
+};
 use windows::{
     core::{w, IUnknown, Interface as _, BSTR, GUID, PCWSTR},
     Win32::{
         Foundation::{
             GetLastError, BOOL, ERROR_CLASS_ALREADY_EXISTS, ERROR_FILE_NOT_FOUND,
-            ERROR_PATH_NOT_FOUND, ERROR_SUCCESS, E_INVALIDARG, HINSTANCE, HWND, LPARAM, LRESULT,
-            POINT, RECT, WPARAM,
+            ERROR_PATH_NOT_FOUND, ERROR_PIPE_BUSY, ERROR_SUCCESS, E_INVALIDARG, HINSTANCE, HWND,
+            LPARAM, LRESULT, POINT, RECT, WPARAM,
         },
         System::{
             Ole::CONNECT_E_CANNOTCONNECT,
@@ -60,8 +66,14 @@ const INFO: TF_LANGBARITEMINFO = TF_LANGBARITEMINFO {
 };
 
 const SETTINGS_MENU_ID: usize = 1;
+const RESTART_SERVER_MENU_ID: usize = 2;
 const SETTINGS_APP_DIRNAME: &str = "Azookey";
 const SETTINGS_APP_FILENAME: &str = "frontend.exe";
+const LAUNCHER_PIPE_PATH: &str = r"\\.\pipe\azookey_launcher";
+const LAUNCHER_RESTART_COMMAND: &[u8] = b"restart-server\n";
+const LAUNCHER_CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
+const LAUNCHER_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+const LAUNCHER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
 const SETTINGS_APP_INNO_UNINSTALL_SUBKEY: PCWSTR = w!(
     r"Software\Microsoft\Windows\CurrentVersion\Uninstall\{80B746D4-D74D-4345-8F81-47E06BCAB515}_is1"
 );
@@ -92,6 +104,9 @@ impl TextServiceFactory_Impl {
         match show_settings_menu(pt) {
             Ok(Some(command)) if command == SETTINGS_MENU_ID as u32 => {
                 launch_settings_app_with_logging();
+            }
+            Ok(Some(command)) if command == RESTART_SERVER_MENU_ID as u32 => {
+                restart_server_with_logging();
             }
             Ok(_) => {}
             Err(error) => {
@@ -207,6 +222,78 @@ impl ITfLangBarItemButton_Impl for TextServiceFactory_Impl {
     }
 }
 
+fn restart_server_with_logging() {
+    if let Err(error) = request_launcher_restart() {
+        tracing::warn!(?error, "Failed to restart server from language bar");
+    }
+}
+
+fn request_launcher_restart() -> Result<()> {
+    let runtime = tokio::runtime::Runtime::new()?;
+    runtime.block_on(async {
+        let mut client = open_launcher_pipe()
+            .await?
+            .context("Launcher restart pipe is not available")?;
+
+        client
+            .write_all(LAUNCHER_RESTART_COMMAND)
+            .await
+            .context("Failed to write launcher restart request")?;
+        client
+            .flush()
+            .await
+            .context("Failed to flush launcher restart request")?;
+
+        let mut response = [0u8; 512];
+        let size = time::timeout(LAUNCHER_RESPONSE_TIMEOUT, client.read(&mut response))
+            .await
+            .context("Timed out waiting for launcher restart response")?
+            .context("Failed to read launcher restart response")?;
+        parse_launcher_response(&response[..size])
+    })
+}
+
+async fn open_launcher_pipe() -> Result<Option<NamedPipeClient>> {
+    let started_at = Instant::now();
+
+    loop {
+        match ClientOptions::new().open(LAUNCHER_PIPE_PATH) {
+            Ok(client) => return Ok(Some(client)),
+            Err(error) if launcher_pipe_missing(error.raw_os_error()) => return Ok(None),
+            Err(error)
+                if error.raw_os_error() == Some(ERROR_PIPE_BUSY.0 as i32)
+                    && started_at.elapsed() < LAUNCHER_CONNECT_TIMEOUT =>
+            {
+                time::sleep(LAUNCHER_RETRY_INTERVAL).await;
+            }
+            Err(error) => {
+                return Err(error).context("Failed to connect launcher restart pipe");
+            }
+        }
+    }
+}
+
+fn launcher_pipe_missing(raw_os_error: Option<i32>) -> bool {
+    raw_os_error == Some(ERROR_FILE_NOT_FOUND.0 as i32)
+        || raw_os_error == Some(ERROR_PATH_NOT_FOUND.0 as i32)
+}
+
+fn parse_launcher_response(bytes: &[u8]) -> Result<()> {
+    let response = std::str::from_utf8(bytes)
+        .context("Launcher restart response is not UTF-8")?
+        .trim();
+
+    if response == "ok" {
+        return Ok(());
+    }
+
+    if let Some(message) = response.strip_prefix("error:") {
+        anyhow::bail!("Launcher failed to restart server: {}", message.trim());
+    }
+
+    anyhow::bail!("Unexpected launcher restart response: {response}");
+}
+
 fn launch_settings_app_with_logging() {
     if let Err(error) = launch_settings_app() {
         tracing::warn!(?error, "Failed to launch settings app");
@@ -243,6 +330,12 @@ fn show_settings_menu(pt: &POINT) -> Result<Option<u32>> {
         let owner = create_menu_owner_window()?;
         let menu = PopupMenu(CreatePopupMenu()?);
         AppendMenuW(menu.0, MF_STRING, SETTINGS_MENU_ID, w!("設定"))?;
+        AppendMenuW(
+            menu.0,
+            MF_STRING,
+            RESTART_SERVER_MENU_ID,
+            w!("サーバー再起動"),
+        )?;
 
         let _ = SetForegroundWindow(owner.hwnd);
 
@@ -680,8 +773,8 @@ impl ITfSource_Impl for TextServiceFactory_Impl {
 #[cfg(test)]
 mod tests {
     use super::{
-        resolve_settings_app_path_from_install_location, select_existing_settings_app_path,
-        trim_registry_string, SettingsAppPath,
+        parse_launcher_response, resolve_settings_app_path_from_install_location,
+        select_existing_settings_app_path, trim_registry_string, SettingsAppPath,
     };
     use std::path::PathBuf;
 
@@ -768,5 +861,16 @@ mod tests {
         assert!(error
             .to_string()
             .contains("no install metadata or LOCALAPPDATA fallback candidate is available"));
+    }
+
+    #[test]
+    fn parse_launcher_response_accepts_ok() {
+        parse_launcher_response(b"ok\n").unwrap();
+    }
+
+    #[test]
+    fn parse_launcher_response_rejects_launcher_error() {
+        let error = parse_launcher_response(b"error:denied\n").unwrap_err();
+        assert!(error.to_string().contains("denied"));
     }
 }

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -11,5 +11,7 @@ tokio = { version = "1.42.0", features = ["rt-multi-thread", "net", "io-util"] }
 [dependencies.windows]
 version = "0.58.0"
 features = [
+    "Win32_Foundation",
     "Win32_Security_Authorization",
+    "Win32_System_Threading",
 ]

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -6,3 +6,10 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 shared = { path = "../shared" }
+tokio = { version = "1.42.0", features = ["rt-multi-thread", "net", "io-util"] }
+
+[dependencies.windows]
+version = "0.58.0"
+features = [
+    "Win32_Security_Authorization",
+]

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -1,13 +1,35 @@
 use shared::{zenzai_cpu_backend_supported, AppConfig};
+use std::collections::VecDeque;
+use std::ffi::c_void;
 use std::io::{BufRead, BufReader};
-use std::process::{Child, Command, Stdio};
+use std::path::Path;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::ptr::addr_of_mut;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::time::{Duration, Instant};
 use std::{env, thread};
 
+use anyhow::Context as _;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+use windows::{
+    core::w,
+    Win32::Security::{
+        Authorization::{ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION},
+        PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
+    },
+};
+
+const SERVER_RESTART_DELAY: Duration = Duration::from_secs(1);
+const SERVER_RESTART_WINDOW: Duration = Duration::from_secs(60);
+const SERVER_RESTART_BURST_LIMIT: usize = 5;
+const SERVER_RESTART_COOLDOWN: Duration = Duration::from_secs(30);
+const SERVER_WATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const LAUNCHER_PIPE_PATH: &str = r"\\.\pipe\azookey_launcher";
+const LAUNCHER_RESTART_COMMAND: &str = "restart-server";
+const LAUNCHER_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+
 fn main() -> anyhow::Result<()> {
-    let config = AppConfig::new().unwrap_or_else(|error| {
-        eprintln!("[launcher] Failed to load settings; using defaults: {error}");
-        AppConfig::default()
-    });
     let cpu_backend_supported = zenzai_cpu_backend_supported();
     env::set_var(
         "AZOOKEY_ZENZAI_CPU_SUPPORTED",
@@ -15,66 +37,378 @@ fn main() -> anyhow::Result<()> {
     );
 
     let exe_path = env::current_exe()?.parent().unwrap().to_path_buf();
-    let backend_dir = match config.zenzai.backend.as_str() {
-        "cpu" => "llama_cpu",
-        "cuda" => "llama_cuda",
-        "vulkan" => "llama_vulkan",
-        _ => "llama_cpu",
-    };
+    let (command_tx, command_rx) = mpsc::channel();
+    start_launcher_command_listener(command_tx);
 
-    let backend_path = exe_path.join(backend_dir);
-    let backend_path_str = backend_path.to_string_lossy();
+    let server_exe_path = exe_path.clone();
+    let server_handle = thread::spawn(move || {
+        if let Err(error) =
+            watch_server_process(&server_exe_path, cpu_backend_supported, command_rx)
+        {
+            eprintln!("[launcher] server watchdog stopped: {error:?}");
+        }
+    });
 
-    let mut new_path = env::var("PATH").unwrap_or_else(|_| String::new());
-    new_path = format!("{};{}", backend_path_str, new_path);
-    env::set_var("PATH", &new_path);
+    let mut ui = start_ui_process(&exe_path)?;
+    let ui_status = ui.wait().context("Failed to wait for ui.exe")?;
+    eprintln!("[launcher] ui.exe exited: {ui_status}");
+
+    let _ = server_handle.join();
+
+    Ok(())
+}
+
+fn watch_server_process(
+    install_dir: &Path,
+    cpu_backend_supported: bool,
+    command_rx: Receiver<LauncherCommand>,
+) -> anyhow::Result<()> {
+    let mut recent_restarts = VecDeque::new();
+
+    loop {
+        let mut server = start_server_process(install_dir, cpu_backend_supported)?;
+        let status = wait_for_server_exit_or_restart_request(&mut server, &command_rx)?;
+        match status {
+            ServerExit::Exited(status) => {
+                eprintln!("[launcher] azookey-server.exe exited: {status}");
+            }
+            ServerExit::RestartRequested(status) => {
+                eprintln!("[launcher] azookey-server.exe restarted by request: {status}");
+            }
+        }
+
+        let now = Instant::now();
+        recent_restarts.push_back(now);
+        while recent_restarts
+            .front()
+            .is_some_and(|started| now.duration_since(*started) > SERVER_RESTART_WINDOW)
+        {
+            recent_restarts.pop_front();
+        }
+
+        if recent_restarts.len() >= SERVER_RESTART_BURST_LIMIT {
+            eprintln!(
+                "[launcher] azookey-server.exe restarted too often; cooling down for {} seconds",
+                SERVER_RESTART_COOLDOWN.as_secs()
+            );
+            thread::sleep(SERVER_RESTART_COOLDOWN);
+            recent_restarts.clear();
+        } else {
+            thread::sleep(SERVER_RESTART_DELAY);
+        }
+    }
+}
+
+fn start_server_process(install_dir: &Path, cpu_backend_supported: bool) -> anyhow::Result<Child> {
+    let config = load_config();
 
     if config.zenzai.enable && config.zenzai.backend == "cpu" && !cpu_backend_supported {
         eprintln!("[launcher] CPU backend requires AVX support. Zenzai will fall back to standard conversion.");
     }
 
-    let server_process = start_process("azookey-server.exe", "[server]");
-    let ui_process = start_process("ui.exe", "[ui]");
+    let mut command = process_command_with_backend(install_dir, "azookey-server.exe", &config);
+    command.env(
+        "AZOOKEY_ZENZAI_CPU_SUPPORTED",
+        if cpu_backend_supported { "1" } else { "0" },
+    );
 
-    if let (Some(mut server), Some(mut ui)) = (server_process, ui_process) {
-        let server_handle = thread::spawn(move || server.wait());
-        let ui_handle = thread::spawn(move || ui.wait());
+    spawn_process(command, "azookey-server.exe", "[server]")
+}
 
-        let _ = server_handle.join();
-        let _ = ui_handle.join();
+fn start_ui_process(install_dir: &Path) -> anyhow::Result<Child> {
+    let config = load_config();
+    let command = process_command_with_backend(install_dir, "ui.exe", &config);
+    spawn_process(command, "ui.exe", "[ui]")
+}
+
+fn process_command_with_backend(install_dir: &Path, exe: &str, config: &AppConfig) -> Command {
+    let backend_path = install_dir.join(backend_dir(config));
+    let mut command = process_command(install_dir, exe);
+    command.env("PATH", prepend_to_path(&backend_path));
+    command
+}
+
+fn process_command(install_dir: &Path, exe: &str) -> Command {
+    let exe_path = install_dir.join(exe);
+    let mut command = if exe_path.is_file() {
+        Command::new(&exe_path)
+    } else {
+        Command::new(exe)
+    };
+    command.current_dir(install_dir);
+    command
+}
+
+fn spawn_process(mut command: Command, exe: &str, prefix: &str) -> anyhow::Result<Child> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("Failed to start {exe}"))?;
+
+    if let Some(stdout) = child.stdout.take() {
+        let stdout_reader = BufReader::new(stdout);
+        let prefix_stdout = prefix.to_string();
+        thread::spawn(move || {
+            for line in stdout_reader.lines() {
+                if let Ok(line) = line {
+                    println!("{}: {}", prefix_stdout, line);
+                }
+            }
+        });
     }
+
+    if let Some(stderr) = child.stderr.take() {
+        let stderr_reader = BufReader::new(stderr);
+        let prefix_stderr = prefix.to_string();
+        thread::spawn(move || {
+            for line in stderr_reader.lines() {
+                if let Ok(line) = line {
+                    eprintln!("{}: {}", prefix_stderr, line);
+                }
+            }
+        });
+    }
+
+    Ok(child)
+}
+
+fn wait_for_server_exit_or_restart_request(
+    server: &mut Child,
+    command_rx: &Receiver<LauncherCommand>,
+) -> anyhow::Result<ServerExit> {
+    loop {
+        if let Some(status) = server
+            .try_wait()
+            .context("Failed to check azookey-server.exe status")?
+        {
+            return Ok(ServerExit::Exited(status));
+        }
+
+        match command_rx.recv_timeout(SERVER_WATCH_POLL_INTERVAL) {
+            Ok(LauncherCommand::RestartServer { reply }) => {
+                let result = terminate_server_child(server);
+                let reply_result = result
+                    .as_ref()
+                    .map(|_| ())
+                    .map_err(|error| error.to_string());
+                let _ = reply.send(reply_result);
+                return result.map(ServerExit::RestartRequested);
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => {
+                let status = server
+                    .wait()
+                    .context("Failed to wait for azookey-server.exe")?;
+                return Ok(ServerExit::Exited(status));
+            }
+        }
+    }
+}
+
+fn terminate_server_child(server: &mut Child) -> anyhow::Result<ExitStatus> {
+    if let Some(status) = server
+        .try_wait()
+        .context("Failed to check azookey-server.exe status")?
+    {
+        return Ok(status);
+    }
+
+    server
+        .kill()
+        .context("Failed to terminate azookey-server.exe")?;
+    server
+        .wait()
+        .context("Failed to wait for azookey-server.exe after restart request")
+}
+
+fn start_launcher_command_listener(command_tx: Sender<LauncherCommand>) {
+    thread::spawn(move || {
+        if let Err(error) = run_launcher_command_listener(command_tx) {
+            eprintln!("[launcher] command listener stopped: {error:?}");
+        }
+    });
+}
+
+fn run_launcher_command_listener(command_tx: Sender<LauncherCommand>) -> anyhow::Result<()> {
+    let runtime = tokio::runtime::Runtime::new()?;
+    runtime.block_on(async move {
+        let mut security_descriptor = PSECURITY_DESCRIPTOR::default();
+
+        unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                w!("D:(A;;GA;;;AC)(A;;GA;;;RC)(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;BU)S:(ML;;NW;;;LW)"),
+                SDDL_REVISION,
+                &mut security_descriptor,
+                None,
+            )
+            .context("Failed to create launcher pipe security descriptor")?;
+        }
+
+        let mut security_attributes = UnsafeSecurityAttributes(SECURITY_ATTRIBUTES {
+            nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: security_descriptor.0,
+            bInheritHandle: false.into(),
+        });
+
+        let mut first_pipe_instance = true;
+        loop {
+            let mut pipe =
+                create_launcher_command_pipe(&mut security_attributes, first_pipe_instance)?;
+            first_pipe_instance = false;
+            pipe.connect()
+                .await
+                .context("Failed to connect launcher command pipe")?;
+
+            if let Err(error) = handle_launcher_command(&mut pipe, &command_tx).await {
+                eprintln!("[launcher] command failed: {error:?}");
+            }
+        }
+    })
+}
+
+fn create_launcher_command_pipe(
+    security_attributes: &mut UnsafeSecurityAttributes,
+    first_pipe_instance: bool,
+) -> anyhow::Result<NamedPipeServer> {
+    let mut options = ServerOptions::new();
+    if first_pipe_instance {
+        options.first_pipe_instance(true);
+    }
+
+    unsafe {
+        options
+            .create_with_security_attributes_raw(
+                LAUNCHER_PIPE_PATH,
+                addr_of_mut!(security_attributes.0) as *mut c_void,
+            )
+            .context("Failed to create launcher command pipe")
+    }
+}
+
+async fn handle_launcher_command(
+    pipe: &mut NamedPipeServer,
+    command_tx: &Sender<LauncherCommand>,
+) -> anyhow::Result<()> {
+    let mut buffer = [0u8; 256];
+    let size = pipe
+        .read(&mut buffer)
+        .await
+        .context("Failed to read launcher command")?;
+
+    let result = match parse_launcher_command(&buffer[..size]) {
+        Ok(LauncherCommandKind::RestartServer) => request_server_restart(command_tx),
+        Err(error) => Err(error),
+    };
+    let response = launcher_response(result);
+
+    pipe.write_all(response.as_bytes())
+        .await
+        .context("Failed to write launcher command response")?;
+    pipe.flush()
+        .await
+        .context("Failed to flush launcher command response")?;
 
     Ok(())
 }
 
-fn start_process(exe: &str, prefix: &str) -> Option<Child> {
-    let mut child = Command::new(exe)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect(&format!("Failed to start {}", exe));
+fn parse_launcher_command(bytes: &[u8]) -> anyhow::Result<LauncherCommandKind> {
+    match std::str::from_utf8(bytes)
+        .context("Launcher command is not UTF-8")?
+        .trim()
+    {
+        LAUNCHER_RESTART_COMMAND => Ok(LauncherCommandKind::RestartServer),
+        command => anyhow::bail!("Unknown launcher command: {command}"),
+    }
+}
 
-    let stdout = child.stdout.take().expect("Failed to capture stdout");
-    let stdout_reader = BufReader::new(stdout);
-    let prefix_stdout = prefix.to_string();
-    thread::spawn(move || {
-        for line in stdout_reader.lines() {
-            if let Ok(line) = line {
-                println!("{}: {}", prefix_stdout, line);
-            }
+fn request_server_restart(command_tx: &Sender<LauncherCommand>) -> anyhow::Result<()> {
+    let (reply_tx, reply_rx) = mpsc::channel();
+    command_tx
+        .send(LauncherCommand::RestartServer { reply: reply_tx })
+        .context("Server watchdog is not running")?;
+
+    match reply_rx.recv_timeout(LAUNCHER_COMMAND_TIMEOUT) {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(message)) => anyhow::bail!(message),
+        Err(RecvTimeoutError::Timeout) => anyhow::bail!("Timed out waiting for server restart"),
+        Err(RecvTimeoutError::Disconnected) => {
+            anyhow::bail!("Server watchdog stopped before restart completed")
         }
-    });
+    }
+}
 
-    let stderr = child.stderr.take().expect("Failed to capture stderr");
-    let stderr_reader = BufReader::new(stderr);
-    let prefix_stderr = prefix.to_string();
-    thread::spawn(move || {
-        for line in stderr_reader.lines() {
-            if let Ok(line) = line {
-                eprintln!("{}: {}", prefix_stderr, line);
-            }
-        }
-    });
+fn launcher_response(result: anyhow::Result<()>) -> String {
+    match result {
+        Ok(()) => "ok\n".to_string(),
+        Err(error) => format!("error:{error}\n"),
+    }
+}
 
-    Some(child)
+fn load_config() -> AppConfig {
+    AppConfig::new().unwrap_or_else(|error| {
+        eprintln!("[launcher] Failed to load settings; using defaults: {error}");
+        AppConfig::default()
+    })
+}
+
+fn backend_dir(config: &AppConfig) -> &'static str {
+    match config.zenzai.backend.as_str() {
+        "cuda" => "llama_cuda",
+        "vulkan" => "llama_vulkan",
+        _ => "llama_cpu",
+    }
+}
+
+fn prepend_to_path(path: &Path) -> String {
+    let existing = env::var("PATH").unwrap_or_default();
+    format!("{};{}", path.to_string_lossy(), existing)
+}
+
+#[derive(Debug)]
+enum ServerExit {
+    Exited(ExitStatus),
+    RestartRequested(ExitStatus),
+}
+
+enum LauncherCommand {
+    RestartServer {
+        reply: Sender<std::result::Result<(), String>>,
+    },
+}
+
+enum LauncherCommandKind {
+    RestartServer,
+}
+
+struct UnsafeSecurityAttributes(SECURITY_ATTRIBUTES);
+
+unsafe impl Send for UnsafeSecurityAttributes {}
+unsafe impl Sync for UnsafeSecurityAttributes {}
+
+#[cfg(test)]
+mod tests {
+    use super::{launcher_response, parse_launcher_command, LauncherCommandKind};
+
+    #[test]
+    fn parse_launcher_command_accepts_restart_server() {
+        assert!(matches!(
+            parse_launcher_command(b"restart-server\n").unwrap(),
+            LauncherCommandKind::RestartServer
+        ));
+    }
+
+    #[test]
+    fn parse_launcher_command_rejects_unknown_command() {
+        assert!(parse_launcher_command(b"stop-server\n").is_err());
+    }
+
+    #[test]
+    fn launcher_response_encodes_success_and_error() {
+        assert_eq!(launcher_response(Ok(())), "ok\n");
+        assert_eq!(
+            launcher_response(Err(anyhow::anyhow!("denied"))),
+            "error:denied\n"
+        );
+    }
 }

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -13,10 +13,18 @@ use anyhow::Context as _;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
 use windows::{
-    core::w,
-    Win32::Security::{
-        Authorization::{ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION},
-        PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
+    core::{PCWSTR, PWSTR},
+    Win32::{
+        Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL},
+        Security::{
+            Authorization::{
+                ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW,
+                SDDL_REVISION,
+            },
+            GetTokenInformation, TokenUser, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, TOKEN_QUERY,
+            TOKEN_USER,
+        },
+        System::Threading::{GetCurrentProcess, OpenProcessToken},
     },
 };
 
@@ -248,17 +256,7 @@ fn start_launcher_command_listener(command_tx: Sender<LauncherCommand>) {
 fn run_launcher_command_listener(command_tx: Sender<LauncherCommand>) -> anyhow::Result<()> {
     let runtime = tokio::runtime::Runtime::new()?;
     runtime.block_on(async move {
-        let mut security_descriptor = PSECURITY_DESCRIPTOR::default();
-
-        unsafe {
-            ConvertStringSecurityDescriptorToSecurityDescriptorW(
-                w!("D:(A;;GA;;;AC)(A;;GA;;;RC)(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;BU)S:(ML;;NW;;;LW)"),
-                SDDL_REVISION,
-                &mut security_descriptor,
-                None,
-            )
-            .context("Failed to create launcher pipe security descriptor")?;
-        }
+        let security_descriptor = create_launcher_pipe_security_descriptor()?;
 
         let mut security_attributes = UnsafeSecurityAttributes(SECURITY_ATTRIBUTES {
             nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
@@ -280,6 +278,73 @@ fn run_launcher_command_listener(command_tx: Sender<LauncherCommand>) -> anyhow:
             }
         }
     })
+}
+
+fn create_launcher_pipe_security_descriptor() -> anyhow::Result<PSECURITY_DESCRIPTOR> {
+    let user_sid = current_user_sid_string()?;
+    let sddl = launcher_pipe_sddl(&user_sid);
+    let sddl_wide = sddl.encode_utf16().chain(Some(0)).collect::<Vec<_>>();
+    let mut security_descriptor = PSECURITY_DESCRIPTOR::default();
+
+    unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            PCWSTR(sddl_wide.as_ptr()),
+            SDDL_REVISION,
+            &mut security_descriptor,
+            None,
+        )
+        .context("Failed to create launcher pipe security descriptor")?;
+    }
+
+    Ok(security_descriptor)
+}
+
+fn launcher_pipe_sddl(user_sid: &str) -> String {
+    format!("D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;{user_sid})S:(ML;;NW;;;ME)")
+}
+
+fn current_user_sid_string() -> anyhow::Result<String> {
+    unsafe {
+        let mut token = HANDLE::default();
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token)
+            .context("Failed to open current process token")?;
+
+        let result = user_sid_string_from_token(token);
+        let _ = CloseHandle(token);
+        result
+    }
+}
+
+fn user_sid_string_from_token(token: HANDLE) -> anyhow::Result<String> {
+    unsafe {
+        let mut token_info_length = 0;
+        let _ = GetTokenInformation(token, TokenUser, None, 0, &mut token_info_length);
+        anyhow::ensure!(
+            token_info_length > 0,
+            "Failed to get current user token SID size"
+        );
+
+        let mut token_info = vec![0u8; token_info_length as usize];
+        GetTokenInformation(
+            token,
+            TokenUser,
+            Some(token_info.as_mut_ptr().cast()),
+            token_info_length,
+            &mut token_info_length,
+        )
+        .context("Failed to get current user token SID")?;
+
+        let token_user = &*(token_info.as_ptr() as *const TOKEN_USER);
+        let mut sid_string = PWSTR::null();
+        ConvertSidToStringSidW(token_user.User.Sid, &mut sid_string)
+            .context("Failed to convert current user SID to string")?;
+
+        let result = sid_string
+            .to_string()
+            .context("Failed to decode current user SID string");
+        let _ = LocalFree(HLOCAL(sid_string.as_ptr().cast()));
+        result
+    }
 }
 
 fn create_launcher_command_pipe(
@@ -404,9 +469,9 @@ unsafe impl Sync for UnsafeSecurityAttributes {}
 #[cfg(test)]
 mod tests {
     use super::{
-        launcher_response, parse_launcher_command, restart_delay_after_server_exit,
-        LauncherCommandKind, SERVER_RESTART_BURST_LIMIT, SERVER_RESTART_COOLDOWN,
-        SERVER_RESTART_DELAY,
+        launcher_pipe_sddl, launcher_response, parse_launcher_command,
+        restart_delay_after_server_exit, LauncherCommandKind, SERVER_RESTART_BURST_LIMIT,
+        SERVER_RESTART_COOLDOWN, SERVER_RESTART_DELAY,
     };
     use std::collections::VecDeque;
     use std::time::{Duration, Instant};
@@ -431,6 +496,20 @@ mod tests {
             launcher_response(Err(anyhow::anyhow!("denied"))),
             "error:denied\n"
         );
+    }
+
+    #[test]
+    fn launcher_pipe_sddl_is_limited_to_current_user_and_medium_integrity() {
+        let sddl = launcher_pipe_sddl("S-1-5-21-1-2-3-1001");
+
+        assert!(sddl.contains("(A;;GA;;;SY)"));
+        assert!(sddl.contains("(A;;GA;;;BA)"));
+        assert!(sddl.contains("(A;;GA;;;S-1-5-21-1-2-3-1001)"));
+        assert!(sddl.contains("S:(ML;;NW;;;ME)"));
+        assert!(!sddl.contains(";;;BU)"));
+        assert!(!sddl.contains(";;;AC)"));
+        assert!(!sddl.contains(";;;RC)"));
+        assert!(!sddl.contains(";;;LW)"));
     }
 
     #[test]

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -68,34 +68,49 @@ fn watch_server_process(
     loop {
         let mut server = start_server_process(install_dir, cpu_backend_supported)?;
         let status = wait_for_server_exit_or_restart_request(&mut server, &command_rx)?;
-        match status {
+        let restart_delay = match status {
             ServerExit::Exited(status) => {
                 eprintln!("[launcher] azookey-server.exe exited: {status}");
+                restart_delay_after_server_exit(&mut recent_restarts, false, Instant::now())
             }
             ServerExit::RestartRequested(status) => {
                 eprintln!("[launcher] azookey-server.exe restarted by request: {status}");
+                restart_delay_after_server_exit(&mut recent_restarts, true, Instant::now())
             }
-        }
+        };
 
-        let now = Instant::now();
-        recent_restarts.push_back(now);
-        while recent_restarts
-            .front()
-            .is_some_and(|started| now.duration_since(*started) > SERVER_RESTART_WINDOW)
-        {
-            recent_restarts.pop_front();
+        if let Some(delay) = restart_delay {
+            thread::sleep(delay);
         }
+    }
+}
 
-        if recent_restarts.len() >= SERVER_RESTART_BURST_LIMIT {
-            eprintln!(
-                "[launcher] azookey-server.exe restarted too often; cooling down for {} seconds",
-                SERVER_RESTART_COOLDOWN.as_secs()
-            );
-            thread::sleep(SERVER_RESTART_COOLDOWN);
-            recent_restarts.clear();
-        } else {
-            thread::sleep(SERVER_RESTART_DELAY);
-        }
+fn restart_delay_after_server_exit(
+    recent_restarts: &mut VecDeque<Instant>,
+    restart_requested: bool,
+    now: Instant,
+) -> Option<Duration> {
+    if restart_requested {
+        return None;
+    }
+
+    recent_restarts.push_back(now);
+    while recent_restarts
+        .front()
+        .is_some_and(|started| now.duration_since(*started) > SERVER_RESTART_WINDOW)
+    {
+        recent_restarts.pop_front();
+    }
+
+    if recent_restarts.len() >= SERVER_RESTART_BURST_LIMIT {
+        eprintln!(
+            "[launcher] azookey-server.exe restarted too often; cooling down for {} seconds",
+            SERVER_RESTART_COOLDOWN.as_secs()
+        );
+        recent_restarts.clear();
+        Some(SERVER_RESTART_COOLDOWN)
+    } else {
+        Some(SERVER_RESTART_DELAY)
     }
 }
 
@@ -388,7 +403,13 @@ unsafe impl Sync for UnsafeSecurityAttributes {}
 
 #[cfg(test)]
 mod tests {
-    use super::{launcher_response, parse_launcher_command, LauncherCommandKind};
+    use super::{
+        launcher_response, parse_launcher_command, restart_delay_after_server_exit,
+        LauncherCommandKind, SERVER_RESTART_BURST_LIMIT, SERVER_RESTART_COOLDOWN,
+        SERVER_RESTART_DELAY,
+    };
+    use std::collections::VecDeque;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn parse_launcher_command_accepts_restart_server() {
@@ -410,5 +431,55 @@ mod tests {
             launcher_response(Err(anyhow::anyhow!("denied"))),
             "error:denied\n"
         );
+    }
+
+    #[test]
+    fn requested_restarts_do_not_count_toward_crash_cooldown() {
+        let mut recent_restarts = VecDeque::new();
+        let start = Instant::now();
+
+        for offset in 0..SERVER_RESTART_BURST_LIMIT {
+            assert_eq!(
+                restart_delay_after_server_exit(
+                    &mut recent_restarts,
+                    true,
+                    start + Duration::from_secs(offset as u64)
+                ),
+                None
+            );
+        }
+
+        assert!(recent_restarts.is_empty());
+        assert_eq!(
+            restart_delay_after_server_exit(&mut recent_restarts, false, start),
+            Some(SERVER_RESTART_DELAY)
+        );
+    }
+
+    #[test]
+    fn unexpected_restarts_trigger_crash_cooldown() {
+        let mut recent_restarts = VecDeque::new();
+        let start = Instant::now();
+
+        for offset in 0..SERVER_RESTART_BURST_LIMIT - 1 {
+            assert_eq!(
+                restart_delay_after_server_exit(
+                    &mut recent_restarts,
+                    false,
+                    start + Duration::from_secs(offset as u64)
+                ),
+                Some(SERVER_RESTART_DELAY)
+            );
+        }
+
+        assert_eq!(
+            restart_delay_after_server_exit(
+                &mut recent_restarts,
+                false,
+                start + Duration::from_secs(SERVER_RESTART_BURST_LIMIT as u64)
+            ),
+            Some(SERVER_RESTART_COOLDOWN)
+        );
+        assert!(recent_restarts.is_empty());
     }
 }

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1"
 tauri-plugin-fs = "2"
 shared = { path = "../../crates/shared" }
 tonic = "0.12.3"
-tokio = { version = "1.42.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.42.0", features = ["rt-multi-thread", "net", "time", "io-util"] }
 tower = "0.5.1"
 hyper-util = { version = "0.1.9", features = ["tokio"] }
 reqwest = { version = "0.12.12", features = ["json"] }
@@ -37,6 +37,8 @@ sha2 = "0.10"
 version = "0.58.0"
 features = [
     "Win32_Foundation",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Threading",
 ]
 
 [dev-dependencies]

--- a/frontend/src-tauri/src/ipc.rs
+++ b/frontend/src-tauri/src/ipc.rs
@@ -1,11 +1,17 @@
 use anyhow::Result;
 use hyper_util::rt::TokioIo;
 use shared::proto::azookey_service_client::AzookeyServiceClient;
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio::{net::windows::named_pipe::ClientOptions, time};
 use tonic::transport::Endpoint;
 use tower::service_fn;
-use windows::Win32::Foundation::ERROR_PIPE_BUSY;
+use windows::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, ERROR_PIPE_BUSY};
+
+const SERVER_PIPE_PATH: &str = r"\\.\pipe\azookey_server";
+const IPC_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 
 // connect to kkc server
 #[derive(Debug, Clone)]
@@ -17,19 +23,45 @@ pub struct IPCService {
 
 impl IPCService {
     pub fn new() -> Result<Self> {
+        Self::new_with_timeout(Duration::ZERO)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test() -> Self {
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime should be created");
+        let server_channel = {
+            let _runtime_guard = runtime.enter();
+            Endpoint::from_static("http://[::]:50051").connect_lazy()
+        };
+        let azookey_client = AzookeyServiceClient::new(server_channel);
+
+        Self {
+            azookey_client,
+            runtime: Arc::new(runtime),
+        }
+    }
+
+    pub fn new_with_timeout(timeout: Duration) -> Result<Self> {
         let runtime = tokio::runtime::Runtime::new()?;
 
         let server_channel = runtime.block_on(
             Endpoint::try_from("http://[::]:50051")?.connect_with_connector(service_fn(
-                |_| async {
+                move |_| async move {
+                    let started_at = Instant::now();
                     let client = loop {
-                        match ClientOptions::new().open(r"\\.\pipe\azookey_server") {
+                        match ClientOptions::new().open(SERVER_PIPE_PATH) {
                             Ok(client) => break client,
                             Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY.0 as i32) => (),
+                            Err(e)
+                                if should_retry_missing_pipe(
+                                    e.raw_os_error(),
+                                    started_at,
+                                    timeout,
+                                ) => {}
                             Err(e) => return Err(e),
                         }
 
-                        time::sleep(Duration::from_millis(50)).await;
+                        time::sleep(IPC_RETRY_INTERVAL).await;
                     };
 
                     Ok::<_, std::io::Error>(TokioIo::new(client))
@@ -44,6 +76,19 @@ impl IPCService {
             runtime: Arc::new(runtime),
         })
     }
+}
+
+fn should_retry_missing_pipe(
+    raw_os_error: Option<i32>,
+    started_at: Instant,
+    timeout: Duration,
+) -> bool {
+    if started_at.elapsed() >= timeout {
+        return false;
+    }
+
+    raw_os_error == Some(ERROR_FILE_NOT_FOUND.0 as i32)
+        || raw_os_error == Some(ERROR_PATH_NOT_FOUND.0 as i32)
 }
 
 // implement methods to interact with kkc server

--- a/frontend/src-tauri/src/ipc.rs
+++ b/frontend/src-tauri/src/ipc.rs
@@ -51,9 +51,8 @@ impl IPCService {
                     let client = loop {
                         match ClientOptions::new().open(SERVER_PIPE_PATH) {
                             Ok(client) => break client,
-                            Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY.0 as i32) => (),
                             Err(e)
-                                if should_retry_missing_pipe(
+                                if should_retry_pipe_connect_error(
                                     e.raw_os_error(),
                                     started_at,
                                     timeout,
@@ -78,7 +77,7 @@ impl IPCService {
     }
 }
 
-fn should_retry_missing_pipe(
+fn should_retry_pipe_connect_error(
     raw_os_error: Option<i32>,
     started_at: Instant,
     timeout: Duration,
@@ -89,6 +88,7 @@ fn should_retry_missing_pipe(
 
     raw_os_error == Some(ERROR_FILE_NOT_FOUND.0 as i32)
         || raw_os_error == Some(ERROR_PATH_NOT_FOUND.0 as i32)
+        || raw_os_error == Some(ERROR_PIPE_BUSY.0 as i32)
 }
 
 // implement methods to interact with kkc server
@@ -100,5 +100,61 @@ impl IPCService {
             .block_on(self.azookey_client.update_config(request))?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        should_retry_pipe_connect_error, ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND,
+        ERROR_PIPE_BUSY,
+    };
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn retries_missing_and_busy_pipe_errors_before_timeout() {
+        let started_at = Instant::now();
+        let timeout = Duration::from_secs(10);
+
+        assert!(should_retry_pipe_connect_error(
+            Some(ERROR_FILE_NOT_FOUND.0 as i32),
+            started_at,
+            timeout
+        ));
+        assert!(should_retry_pipe_connect_error(
+            Some(ERROR_PATH_NOT_FOUND.0 as i32),
+            started_at,
+            timeout
+        ));
+        assert!(should_retry_pipe_connect_error(
+            Some(ERROR_PIPE_BUSY.0 as i32),
+            started_at,
+            timeout
+        ));
+    }
+
+    #[test]
+    fn stops_retrying_busy_pipe_after_timeout() {
+        let timeout = Duration::from_secs(10);
+        let started_at = Instant::now() - timeout;
+
+        assert!(!should_retry_pipe_connect_error(
+            Some(ERROR_PIPE_BUSY.0 as i32),
+            started_at,
+            timeout
+        ));
+    }
+
+    #[test]
+    fn does_not_retry_other_pipe_errors() {
+        let started_at = Instant::now();
+        let timeout = Duration::from_secs(10);
+
+        assert!(!should_retry_pipe_connect_error(
+            Some(5),
+            started_at,
+            timeout
+        ));
+        assert!(!should_retry_pipe_connect_error(None, started_at, timeout));
     }
 }

--- a/frontend/src-tauri/src/ipc.rs
+++ b/frontend/src-tauri/src/ipc.rs
@@ -23,7 +23,7 @@ pub struct IPCService {
 
 impl IPCService {
     pub fn new() -> Result<Self> {
-        Self::new_with_timeout(Duration::ZERO)
+        Self::new_inner(None)
     }
 
     #[cfg(test)]
@@ -42,6 +42,10 @@ impl IPCService {
     }
 
     pub fn new_with_timeout(timeout: Duration) -> Result<Self> {
+        Self::new_inner(Some(timeout))
+    }
+
+    fn new_inner(timeout: Option<Duration>) -> Result<Self> {
         let runtime = tokio::runtime::Runtime::new()?;
 
         let server_channel = runtime.block_on(
@@ -80,10 +84,12 @@ impl IPCService {
 fn should_retry_pipe_connect_error(
     raw_os_error: Option<i32>,
     started_at: Instant,
-    timeout: Duration,
+    timeout: Option<Duration>,
 ) -> bool {
-    if started_at.elapsed() >= timeout {
-        return false;
+    match timeout {
+        Some(timeout) if started_at.elapsed() >= timeout => return false,
+        Some(_) => {}
+        None => return raw_os_error == Some(ERROR_PIPE_BUSY.0 as i32),
     }
 
     raw_os_error == Some(ERROR_FILE_NOT_FOUND.0 as i32)
@@ -114,7 +120,7 @@ mod tests {
     #[test]
     fn retries_missing_and_busy_pipe_errors_before_timeout() {
         let started_at = Instant::now();
-        let timeout = Duration::from_secs(10);
+        let timeout = Some(Duration::from_secs(10));
 
         assert!(should_retry_pipe_connect_error(
             Some(ERROR_FILE_NOT_FOUND.0 as i32),
@@ -141,14 +147,41 @@ mod tests {
         assert!(!should_retry_pipe_connect_error(
             Some(ERROR_PIPE_BUSY.0 as i32),
             started_at,
-            timeout
+            Some(timeout)
+        ));
+    }
+
+    #[test]
+    fn retries_busy_pipe_without_timeout() {
+        let started_at = Instant::now();
+
+        assert!(should_retry_pipe_connect_error(
+            Some(ERROR_PIPE_BUSY.0 as i32),
+            started_at,
+            None
+        ));
+    }
+
+    #[test]
+    fn does_not_retry_missing_pipe_without_timeout() {
+        let started_at = Instant::now();
+
+        assert!(!should_retry_pipe_connect_error(
+            Some(ERROR_FILE_NOT_FOUND.0 as i32),
+            started_at,
+            None
+        ));
+        assert!(!should_retry_pipe_connect_error(
+            Some(ERROR_PATH_NOT_FOUND.0 as i32),
+            started_at,
+            None
         ));
     }
 
     #[test]
     fn does_not_retry_other_pipe_errors() {
         let started_at = Instant::now();
-        let timeout = Duration::from_secs(10);
+        let timeout = Some(Duration::from_secs(10));
 
         assert!(!should_retry_pipe_connect_error(
             Some(5),

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,9 +1,12 @@
 mod ipc;
+mod server_process;
 mod updater;
 
 use serde::{Deserialize, Serialize};
 use shared::{AppConfig, AppConfigLoadResult, ConfigError, ConfigRecovery, RomajiRule};
-use std::{path::PathBuf, sync::Mutex};
+use std::{path::PathBuf, sync::Mutex, time::Duration};
+
+use anyhow::Context as _;
 
 #[derive(Debug)]
 pub struct AppState {
@@ -163,6 +166,23 @@ fn update_config_impl(
     })
 }
 
+#[tauri::command]
+fn restart_server(state: tauri::State<AppState>) -> Result<(), String> {
+    restart_server_impl(&state).map_err(|error| error.to_string())
+}
+
+fn restart_server_impl(state: &AppState) -> Result<(), anyhow::Error> {
+    let config = state.settings.lock().unwrap().clone();
+
+    server_process::restart_server(&config)?;
+
+    let ipc = ipc::IPCService::new_with_timeout(Duration::from_secs(10))
+        .context("Server restarted, but IPC reconnect failed")?;
+    *state.ipc.lock().unwrap() = Some(ipc);
+
+    Ok(())
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 struct Capability {
     cpu: bool,
@@ -251,26 +271,28 @@ pub fn run() {
             get_default_romaji_rows,
             check_for_updates,
             start_update,
-            take_update_install_result
+            take_update_install_result,
+            restart_server
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
 
 #[cfg(test)]
+pub(crate) fn test_env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
-    use std::{
-        env,
-        ffi::OsString,
-        io,
-        path::Path,
-        sync::{Mutex, MutexGuard, OnceLock},
-    };
+    use std::{env, ffi::OsString, io, path::Path, sync::MutexGuard};
 
     fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+        crate::test_env_lock()
     }
 
     struct AppDataGuard {
@@ -350,6 +372,20 @@ mod tests {
 
         assert!(error.contains("APPDATA"));
         assert!(!state.settings.lock().unwrap().zenzai.enable);
+    }
+
+    #[test]
+    fn restart_server_keeps_existing_ipc_when_restart_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let _appdata = AppDataGuard::set(temp.path());
+        let state = test_state();
+        *state.ipc.lock().unwrap() = Some(ipc::IPCService::new_for_test());
+
+        let error =
+            restart_server_impl(&state).expect_err("missing server exe should fail restart");
+
+        assert!(error.to_string().contains("Server executable not found"));
+        assert!(state.ipc.lock().unwrap().is_some());
     }
 
     #[test]

--- a/frontend/src-tauri/src/server_process.rs
+++ b/frontend/src-tauri/src/server_process.rs
@@ -1,0 +1,323 @@
+use anyhow::{Context as _, Result};
+use shared::AppConfig;
+use std::{
+    ffi::OsString,
+    os::windows::ffi::OsStringExt as _,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::windows::named_pipe::{ClientOptions, NamedPipeClient},
+    time,
+};
+use windows::{
+    core::PWSTR,
+    Win32::{
+        Foundation::{
+            CloseHandle, ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, ERROR_PIPE_BUSY,
+            WAIT_OBJECT_0, WAIT_TIMEOUT,
+        },
+        System::{
+            Diagnostics::ToolHelp::{
+                CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+                TH32CS_SNAPPROCESS,
+            },
+            Threading::{
+                OpenProcess, QueryFullProcessImageNameW, TerminateProcess, WaitForSingleObject,
+                PROCESS_ACCESS_RIGHTS, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION,
+                PROCESS_TERMINATE,
+            },
+        },
+    },
+};
+
+const SERVER_EXE_NAME: &str = "azookey-server.exe";
+const LAUNCHER_PIPE_PATH: &str = r"\\.\pipe\azookey_launcher";
+const LAUNCHER_RESTART_COMMAND: &[u8] = b"restart-server\n";
+const LAUNCHER_CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
+const LAUNCHER_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+const LAUNCHER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
+const PROCESS_SYNCHRONIZE: PROCESS_ACCESS_RIGHTS = PROCESS_ACCESS_RIGHTS(0x0010_0000);
+const SERVER_EXIT_TIMEOUT_MS: u32 = 5_000;
+const WATCHDOG_RESTART_WAIT: Duration = Duration::from_millis(2_500);
+
+pub fn restart_server(config: &AppConfig) -> Result<()> {
+    if request_launcher_restart()? {
+        return Ok(());
+    }
+
+    restart_server_direct(config)
+}
+
+fn restart_server_direct(config: &AppConfig) -> Result<()> {
+    let server_path = resolve_server_path()?;
+    let target = normalize_path(&server_path);
+
+    let process_ids = matching_server_process_ids(&target)?;
+    for process_id in process_ids {
+        terminate_process(process_id)
+            .with_context(|| format!("Failed to terminate {SERVER_EXE_NAME} pid={process_id}"))?;
+    }
+
+    // Give launcher watchdog a chance to restart its own child first. If the
+    // settings app is running without launcher, fall back to starting the server.
+    thread::sleep(WATCHDOG_RESTART_WAIT);
+
+    if matching_server_process_ids(&target)?.is_empty() {
+        start_server(&server_path, config)?;
+    }
+
+    Ok(())
+}
+
+fn request_launcher_restart() -> Result<bool> {
+    let runtime = tokio::runtime::Runtime::new()?;
+    runtime.block_on(async {
+        let Some(mut client) = open_launcher_pipe().await? else {
+            return Ok(false);
+        };
+
+        client
+            .write_all(LAUNCHER_RESTART_COMMAND)
+            .await
+            .context("Failed to write launcher restart request")?;
+        client
+            .flush()
+            .await
+            .context("Failed to flush launcher restart request")?;
+
+        let mut response = [0u8; 512];
+        let size = time::timeout(LAUNCHER_RESPONSE_TIMEOUT, client.read(&mut response))
+            .await
+            .context("Timed out waiting for launcher restart response")?
+            .context("Failed to read launcher restart response")?;
+        parse_launcher_response(&response[..size])?;
+
+        Ok(true)
+    })
+}
+
+async fn open_launcher_pipe() -> Result<Option<NamedPipeClient>> {
+    let started_at = Instant::now();
+
+    loop {
+        match ClientOptions::new().open(LAUNCHER_PIPE_PATH) {
+            Ok(client) => return Ok(Some(client)),
+            Err(error) if launcher_pipe_missing(error.raw_os_error()) => return Ok(None),
+            Err(error)
+                if error.raw_os_error() == Some(ERROR_PIPE_BUSY.0 as i32)
+                    && started_at.elapsed() < LAUNCHER_CONNECT_TIMEOUT =>
+            {
+                time::sleep(LAUNCHER_RETRY_INTERVAL).await;
+            }
+            Err(error) => {
+                return Err(error).context("Failed to connect launcher restart pipe");
+            }
+        }
+    }
+}
+
+fn launcher_pipe_missing(raw_os_error: Option<i32>) -> bool {
+    raw_os_error == Some(ERROR_FILE_NOT_FOUND.0 as i32)
+        || raw_os_error == Some(ERROR_PATH_NOT_FOUND.0 as i32)
+}
+
+fn parse_launcher_response(bytes: &[u8]) -> Result<()> {
+    let response = std::str::from_utf8(bytes)
+        .context("Launcher restart response is not UTF-8")?
+        .trim();
+
+    if response == "ok" {
+        return Ok(());
+    }
+
+    if let Some(message) = response.strip_prefix("error:") {
+        anyhow::bail!("Launcher failed to restart server: {}", message.trim());
+    }
+
+    anyhow::bail!("Unexpected launcher restart response: {response}");
+}
+
+fn resolve_server_path() -> Result<PathBuf> {
+    let current_exe = std::env::current_exe()?;
+    let install_dir = current_exe
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .context("Failed to resolve settings app directory")?;
+    Ok(install_dir.join(SERVER_EXE_NAME))
+}
+
+fn matching_server_process_ids(target: &str) -> Result<Vec<u32>> {
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)? };
+    let _snapshot_guard = HandleGuard(snapshot);
+
+    let mut entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+
+    let mut process_ids = Vec::new();
+    let mut has_entry = unsafe { Process32FirstW(snapshot, &mut entry).is_ok() };
+
+    while has_entry {
+        if wide_null_terminated_to_string(&entry.szExeFile).eq_ignore_ascii_case(SERVER_EXE_NAME) {
+            let process_id = entry.th32ProcessID;
+            if process_image_path(process_id)
+                .map(|path| normalize_path(&path) == target)
+                .unwrap_or(false)
+            {
+                process_ids.push(process_id);
+            }
+        }
+
+        has_entry = unsafe { Process32NextW(snapshot, &mut entry).is_ok() };
+    }
+
+    Ok(process_ids)
+}
+
+fn terminate_process(process_id: u32) -> Result<()> {
+    let access = PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE;
+    let process = unsafe { OpenProcess(access, false, process_id)? };
+    let _process_guard = HandleGuard(process);
+
+    unsafe {
+        TerminateProcess(process, 0)?;
+        match WaitForSingleObject(process, SERVER_EXIT_TIMEOUT_MS) {
+            WAIT_OBJECT_0 => Ok(()),
+            WAIT_TIMEOUT => anyhow::bail!("Timed out waiting for process exit"),
+            event => anyhow::bail!("Unexpected wait result: {:?}", event),
+        }
+    }
+}
+
+fn process_image_path(process_id: u32) -> Option<PathBuf> {
+    let process =
+        unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_id).ok()? };
+    let _process_guard = HandleGuard(process);
+
+    let mut buffer = vec![0u16; 32_768];
+    let mut size = buffer.len() as u32;
+    unsafe {
+        QueryFullProcessImageNameW(
+            process,
+            PROCESS_NAME_WIN32,
+            PWSTR(buffer.as_mut_ptr()),
+            &mut size,
+        )
+        .ok()?;
+    }
+
+    let size = usize::try_from(size).ok()?;
+    Some(PathBuf::from(OsString::from_wide(&buffer[..size])))
+}
+
+fn start_server(server_path: &Path, config: &AppConfig) -> Result<()> {
+    if !server_path.is_file() {
+        anyhow::bail!("Server executable not found: {}", server_path.display());
+    }
+
+    let install_dir = server_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .context("Server executable directory not found")?;
+    let backend_path = install_dir.join(backend_dir(config));
+    let path = prepend_to_path(&backend_path);
+
+    Command::new(server_path)
+        .current_dir(install_dir)
+        .env("AZOOKEY_ZENZAI_CPU_SUPPORTED", zenzai_cpu_supported_env())
+        .env("PATH", path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("Failed to start {}", server_path.display()))?;
+
+    Ok(())
+}
+
+fn backend_dir(config: &AppConfig) -> &'static str {
+    match config.zenzai.backend.as_str() {
+        "cuda" => "llama_cuda",
+        "vulkan" => "llama_vulkan",
+        _ => "llama_cpu",
+    }
+}
+
+fn zenzai_cpu_supported_env() -> &'static str {
+    if shared::zenzai_cpu_backend_supported() {
+        "1"
+    } else {
+        "0"
+    }
+}
+
+fn prepend_to_path(path: &Path) -> String {
+    let existing = std::env::var("PATH").unwrap_or_default();
+    format!("{};{}", path.to_string_lossy(), existing)
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .replace('/', r"\")
+        .to_ascii_lowercase()
+}
+
+fn wide_null_terminated_to_string(value: &[u16]) -> String {
+    let len = value
+        .iter()
+        .position(|unit| *unit == 0)
+        .unwrap_or(value.len());
+    OsString::from_wide(&value[..len])
+        .to_string_lossy()
+        .into_owned()
+}
+
+struct HandleGuard(windows::Win32::Foundation::HANDLE);
+
+impl Drop for HandleGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_path, parse_launcher_response, wide_null_terminated_to_string};
+    use std::{ffi::OsStr, os::windows::ffi::OsStrExt as _, path::Path};
+
+    #[test]
+    fn normalize_path_ignores_case_and_extended_prefix() {
+        assert_eq!(
+            normalize_path(Path::new(r"\\?\C:\Azookey/azookey-server.exe")),
+            r"c:\azookey\azookey-server.exe"
+        );
+    }
+
+    #[test]
+    fn wide_null_terminated_to_string_stops_at_null() {
+        let mut wide: Vec<u16> = OsStr::new("azookey-server.exe").encode_wide().collect();
+        wide.push(0);
+        wide.extend(OsStr::new("ignored").encode_wide());
+
+        assert_eq!(wide_null_terminated_to_string(&wide), "azookey-server.exe");
+    }
+
+    #[test]
+    fn parse_launcher_response_accepts_ok() {
+        parse_launcher_response(b"ok\n").unwrap();
+    }
+
+    #[test]
+    fn parse_launcher_response_rejects_launcher_error() {
+        let error = parse_launcher_response(b"error:denied\n").unwrap_err();
+        assert!(error.to_string().contains("denied"));
+    }
+}

--- a/frontend/src-tauri/src/updater.rs
+++ b/frontend/src-tauri/src/updater.rs
@@ -71,6 +71,7 @@ pub struct UpdateInstallResult {
     pub install_log_path: Option<String>,
 }
 
+#[derive(Debug)]
 struct ReleaseAssets {
     installer_url: String,
     sha256sums_url: String,
@@ -533,14 +534,10 @@ try {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{
-        ffi::OsString,
-        sync::{Mutex, MutexGuard, OnceLock},
-    };
+    use std::{ffi::OsString, sync::MutexGuard};
 
     fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+        crate::test_env_lock()
     }
 
     struct EnvGuard {

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { BookText, Bot, Settings, Megaphone } from "lucide-react"
+import { BookText, Bot, Bug, Settings, Megaphone } from "lucide-react"
 
 import {
     Sidebar,
@@ -33,6 +33,11 @@ const contents = [
         title: "辞書",
         url: "/dictionary",
         icon: BookText,
+    },
+    {
+        title: "デバッグ用設定",
+        url: "/debug",
+        icon: Bug,
     },
 ]
 

--- a/frontend/src/components/debug-settings.tsx
+++ b/frontend/src/components/debug-settings.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { RefreshCcw, Server } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+
+export const DebugSettings = () => {
+    const [isRestartingServer, setIsRestartingServer] = useState(false);
+
+    const restartServer = async () => {
+        if (isRestartingServer) {
+            return;
+        }
+
+        setIsRestartingServer(true);
+        try {
+            await invoke("restart_server");
+            toast("サーバーを再起動しました");
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            toast("サーバーの再起動に失敗しました", {
+                description: message,
+                duration: 10000,
+            });
+        } finally {
+            setIsRestartingServer(false);
+        }
+    };
+
+    return (
+        <section className="space-y-3">
+            <h1 className="text-sm font-bold text-foreground">デバッグ用設定</h1>
+            <div className="flex items-center gap-4 rounded-md border p-4">
+                <Server />
+                <div className="flex-1 space-y-1">
+                    <p className="text-sm font-medium leading-none">サーバー再起動</p>
+                    <p className="text-xs text-muted-foreground">
+                        変換サーバーを停止して起動し直します
+                    </p>
+                </div>
+                <Button
+                    variant="secondary"
+                    onClick={() => void restartServer()}
+                    disabled={isRestartingServer}
+                >
+                    <RefreshCcw />
+                    {isRestartingServer ? "再起動中" : "サーバー再起動"}
+                </Button>
+            </div>
+        </section>
+    );
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,6 +11,7 @@ import { Appearance } from "@/pages/appearance"
 import { Zenzai } from "@/pages/zenzai"
 import { About } from "@/pages/about"
 import { Dictionary } from "@/pages/dictionary"
+import { Debug } from "@/pages/debug"
 import { Toaster } from "@/components/ui/sonner"
 import { showConfigStartupNoticeOnce, showUpdateInstallResultOnce } from "@/lib/config"
 
@@ -26,6 +27,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
               <Route path="/appearance" element={<Appearance />} />
               <Route path="/zenzai" element={<Zenzai />} />
               <Route path="/dictionary" element={<Dictionary />} />
+              <Route path="/debug" element={<Debug />} />
               <Route path="/about" element={<About />} />
             </Routes>
             <Toaster />

--- a/frontend/src/pages/debug.tsx
+++ b/frontend/src/pages/debug.tsx
@@ -1,0 +1,9 @@
+import { DebugSettings } from "@/components/debug-settings";
+
+export const Debug = () => {
+    return (
+        <div className="space-y-8">
+            <DebugSettings />
+        </div>
+    );
+};

--- a/frontend/src/pages/dictionary.tsx
+++ b/frontend/src/pages/dictionary.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { Plus, Save, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { DebugSettings } from "@/components/debug-settings";
 import { Input } from "@/components/ui/input";
 import { saveConfigWithToast } from "@/lib/config";
 
@@ -237,6 +238,8 @@ export const Dictionary = () => {
                     </div>
                 )}
             </section>
+
+            <DebugSettings />
         </div>
     );
 };

--- a/frontend/src/pages/dictionary.tsx
+++ b/frontend/src/pages/dictionary.tsx
@@ -4,7 +4,6 @@ import { toast } from "sonner";
 import { Plus, Save, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { DebugSettings } from "@/components/debug-settings";
 import { Input } from "@/components/ui/input";
 import { saveConfigWithToast } from "@/lib/config";
 
@@ -239,7 +238,6 @@ export const Dictionary = () => {
                 )}
             </section>
 
-            <DebugSettings />
         </div>
     );
 };

--- a/frontend/src/pages/general.tsx
+++ b/frontend/src/pages/general.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Download, Keyboard, RefreshCcw, Table2, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { DebugSettings } from "@/components/debug-settings";
 import { Input } from "@/components/ui/input";
 import {
     Select,
@@ -855,6 +856,8 @@ export const General = () => {
                         <Switch checked={shortcutValue.altBackquoteToggle} onCheckedChange={handleAltBackquoteToggle} />
                     </div>
                 </section>
+
+                <DebugSettings />
             </div>
 
             {isRomajiEditorOpen && (

--- a/frontend/src/pages/general.tsx
+++ b/frontend/src/pages/general.tsx
@@ -5,7 +5,6 @@ import { toast } from "sonner";
 import { Download, Keyboard, RefreshCcw, Table2, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { DebugSettings } from "@/components/debug-settings";
 import { Input } from "@/components/ui/input";
 import {
     Select,
@@ -857,7 +856,6 @@ export const General = () => {
                     </div>
                 </section>
 
-                <DebugSettings />
             </div>
 
             {isRomajiEditorOpen && (

--- a/frontend/src/pages/zenzai.tsx
+++ b/frontend/src/pages/zenzai.tsx
@@ -1,6 +1,5 @@
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
-import { DebugSettings } from "@/components/debug-settings";
 import { Bot, User, Cpu } from "lucide-react";
 import {
     Select,
@@ -176,7 +175,6 @@ export const Zenzai = () => {
                     </Select>
                 </div>
             </section>
-            <DebugSettings />
         </div>
     )
 }

--- a/frontend/src/pages/zenzai.tsx
+++ b/frontend/src/pages/zenzai.tsx
@@ -1,5 +1,6 @@
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
+import { DebugSettings } from "@/components/debug-settings";
 import { Bot, User, Cpu } from "lucide-react";
 import {
     Select,
@@ -175,6 +176,7 @@ export const Zenzai = () => {
                     </Select>
                 </div>
             </section>
+            <DebugSettings />
         </div>
     )
 }

--- a/installer/Installer.iss
+++ b/installer/Installer.iss
@@ -85,6 +85,11 @@ Filename: "taskkill"; \
   Parameters: "/F /IM ""frontend.exe"""; \
   RunOnceId: "StopFrontend"; \
   Flags: runhidden
+; Stop launcher before server so the watchdog cannot respawn it during uninstall.
+Filename: "taskkill"; \
+  Parameters: "/F /T /IM ""launcher.exe"""; \
+  RunOnceId: "StopLauncher"; \
+  Flags: runhidden
 Filename: "taskkill"; \
   Parameters: "/F /T /IM ""azookey-server.exe"""; \
   RunOnceId: "StopAzookeyServer"; \
@@ -92,10 +97,6 @@ Filename: "taskkill"; \
 Filename: "taskkill"; \
   Parameters: "/F /T /IM ""ui.exe"""; \
   RunOnceId: "StopUi"; \
-  Flags: runhidden
-Filename: "taskkill"; \
-  Parameters: "/F /T /IM ""launcher.exe"""; \
-  RunOnceId: "StopLauncher"; \
   Flags: runhidden
 Filename: "schtasks"; \
   Parameters: "/Delete /TN ""Azookey Startup"" /F"; \
@@ -291,9 +292,10 @@ end;
 procedure StopAzookeyProcessesBeforeInstall();
 begin
   StopAzookeyProcess('frontend.exe', False);
+  // Stop launcher before server so the watchdog cannot respawn it during install/update.
+  StopAzookeyProcess('launcher.exe', True);
   StopAzookeyProcess('azookey-server.exe', True);
   StopAzookeyProcess('ui.exe', True);
-  StopAzookeyProcess('launcher.exe', True);
 end;
 
 <event('PrepareToInstall')>


### PR DESCRIPTION
## Summary
- launcher に `azookey-server.exe` の watchdog 再起動を追加しました。
- 設定画面と language bar 右クリックメニューからサーバー再起動を要求できるようにしました。
- restart 時は launcher が設定を再読込し、選択中の Zenzai backend に対応する `llama_*` PATH を server / ui に渡すようにしました。

## Background
- Issue: Closes #82
- `azookey-server.exe` が落ちた場合に launcher から自動復帰できるようにし、設定変更後に明示的な server restart 操作を行えるようにします。
- 既定インストールでは launcher/server が elevated、settings frontend や language bar は通常権限で動くため、restart 要求は launcher pipe 経由で elevated launcher に渡します。

## Changes
- launcher watchdog
  - `azookey-server.exe` を監視し、終了時に再起動
  - 短時間の連続再起動には cooldown を挿入
  - 再起動ごとに `AppConfig` を読み直し、backend PATH を作り直すように変更
  - `ui.exe` 起動にも server と同じ backend PATH を渡すように変更
- restart request path
  - launcher に `\\.\pipe\azookey_launcher` の restart command listener を追加
  - settings frontend は launcher pipe を優先し、launcher がいない場合だけ直接 restart に fallback
  - language bar 右クリックメニューに `サーバー再起動` を追加し、launcher pipe へ restart request を送信
- installer/uninstaller stop order now stops `launcher.exe` before `azookey-server.exe` to avoid watchdog respawn during update/uninstall
- requested server restarts are excluded from the launcher crash cooldown counter
- launcher restart pipe ACL now allows only system/admin/current-user SID and uses medium integrity
- settings UI
  - `DebugSettings` component を追加し、General / Zenzai / Dictionary から server restart を実行可能に変更
  - restart 失敗時は既存 IPC を保持し、新しい IPC 接続が確立できた後だけ差し替えるように変更
- tests
  - launcher command parser / response test を追加
  - frontend server process / IPC restart failure test を追加
  - language bar launcher response parser test を追加
  - frontend test 用 env lock を updater tests と共有し、APPDATA 変更テストの並列実行を安定化

## Verification
- [x] Codex review
  - 初回レビューで language bar 導線漏れを検出
  - 修正後レビューで「重大な問題なし」を確認
- [x] 差分チェック
  - `cargo fmt --all --check`
  - `git diff --check`
  - `git diff --cached --check`
- [x] Windows local check / test
  - `cargo check -p launcher`
  - `cargo check -p frontend`
  - `cargo test -p launcher --bin launcher`
  - `cargo test -p frontend --lib`
  - `cargo check -p azookey-windows`
  - `cargo test -p azookey-windows parse_launcher_response`
  - `npm exec tsc -- --noEmit`
- [x] ローカル Windows VM build / install / smoke
  - `scripts/vm_build.sh fix/82-server-restart`
  - artifact: `.local/artifacts/azookey-setup-fix_82-server-restart-20260604-191611.exe`
  - VM install 成功
  - watchdog restart で server PID 変更を確認
  - settings button restart で server PID 変更を確認
  - Notepad + azooKey で `aiueo` -> `あいうえお` を確認

## Notes
- 最終レビュー対応で追加した language bar の `サーバー再起動` メニューは、`cargo check -p azookey-windows` と targeted unit test では確認済みですが、VM 上での手動クリック検証は未実施です。
- `npm run build` は Windows npm から WSL UNC/mapped drive 上の `node_modules` を読む経路で esbuild/Vite の I/O エラーになったため、TypeScript は `npm exec tsc -- --noEmit` で確認しています。