### PR TITLE
chore(release): prepare v0.1.0-batao.7

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,3 +1,3 @@
 {
-  "version": "0.1.0-batao.6"
+  "version": "0.1.0-batao.7"
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0-batao.6",
+  "version": "0.1.0-batao.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0-batao.6",
+      "version": "0.1.0-batao.7",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-dialog": "^1.1.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0-batao.6",
+  "version": "0.1.0-batao.7",
   "type": "module",
   "scripts": {
     "sync-version": "node ../scripts/sync-version.mjs",

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Azookey",
-  "version": "0.1.0-batao.6",
+  "version": "0.1.0-batao.7",
   "identifier": "com.azookey.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/installer/AppVersion.iss
+++ b/installer/AppVersion.iss
@@ -1,2 +1,2 @@
 ; Generated from app-version.json by scripts/sync-version.mjs.
-#define MyAppVersion "0.1.0-batao.6"
+#define MyAppVersion "0.1.0-batao.7"


### PR DESCRIPTION
## Summary
- Prepare fork release `v0.1.0-batao.7`.
- Bump app / settings / installer version from `0.1.0-batao.6` to `0.1.0-batao.7`.
- Release notes cover the server watchdog restart work from #82 / #83.

## Release notes draft

## Summary
- batao9/azooKey-Windows の fork release `v0.1.0-batao.7`
- こちらは fkunn1326/azooKey-Windows の fork です

## User-facing changes
- `azookey-server.exe` が落ちた場合でも、launcher から自動的に再起動されるようにしました
- 設定画面に「デバッグ用設定」ページを追加し、そこからサーバー再起動を実行できるようにしました
- language bar の右クリックメニューに `サーバー再起動` を追加しました
- 設定変更後などにサーバーを明示的に再起動しやすくしました

## Stability and internal improvements
- launcher に `azookey-server.exe` の watchdog を追加し、終了時に再起動するようにしました
- 短時間の連続クラッシュには cooldown を入れつつ、ユーザー操作による再起動は cooldown カウントから除外するようにしました
- settings / language bar から elevated launcher へ restart request を渡す named pipe 経路を追加しました
- launcher restart pipe の ACL を制限し、system / admin / current user からの要求に絞りました
- サーバー再起動時に `AppConfig` を読み直し、選択中の Zenzai backend に対応する `llama_*` PATH を server / UI に渡すようにしました
- update / uninstall 中に watchdog が server を再起動しないよう、installer 側の停止順を `launcher.exe` -> `azookey-server.exe` に変更しました
- settings 側の pipe 再接続 retry を bounded にし、起動時 retry や restart 失敗時の IPC 扱いを安定化しました
- アプリ内バージョンとインストーラー版数を `0.1.0-batao.7` に更新

## Verification
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `npm exec -- tsc --noEmit`
- [x] `cargo check -p launcher`
- [x] `cargo check -p frontend`
- [x] `cargo test -p launcher --bin launcher`
- [x] `cargo test -p frontend --lib`
- [x] `cargo check -p azookey-windows`
- [x] `cargo test -p azookey-windows parse_launcher_response`
- [x] VM build: `.local/artifacts/azookey-setup-release_v0.1.0-batao.7-20260607-142849.exe`