### PR TITLE
fix(logging): reduce server log I/O

### DIFF
--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -1,9 +1,19 @@
 use anyhow::Result;
 use hyper_util::rt::TokioIo;
-use shared::proto::{
-    azookey_service_client::AzookeyServiceClient, window_service_client::WindowServiceClient,
+use shared::{
+    proto::{
+        azookey_service_client::AzookeyServiceClient, window_service_client::WindowServiceClient,
+        PerformanceLogRequest,
+    },
+    AppConfig,
 };
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex, OnceLock,
+    },
+    time::{Duration, Instant},
+};
 use tokio::{net::windows::named_pipe::ClientOptions, time};
 use tonic::transport::Endpoint;
 use tower::service_fn;
@@ -11,6 +21,16 @@ use windows::Win32::Foundation::ERROR_PIPE_BUSY;
 
 const INPUT_STYLE_ROMAN2KANA: i32 = 0;
 const INPUT_STYLE_DIRECT: i32 = 1;
+const CLIENT_LOG_CONFIG_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+
+static CLIENT_REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+static CLIENT_LOG_CONFIG_CACHE: OnceLock<Mutex<ClientLogConfigCache>> = OnceLock::new();
+
+#[derive(Debug, Default)]
+struct ClientLogConfigCache {
+    last_checked: Option<Instant>,
+    enabled: bool,
+}
 
 // connect to kkc server
 #[derive(Debug, Clone)]
@@ -20,6 +40,7 @@ pub struct IPCService {
     // candidate window server client
     window_client: WindowServiceClient<tonic::transport::channel::Channel>,
     runtime: Arc<tokio::runtime::Runtime>,
+    performance_log_tx: tokio::sync::mpsc::UnboundedSender<PerformanceLogRequest>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -30,9 +51,41 @@ pub struct Candidates {
     pub corresponding_count: Vec<i32>,
 }
 
+fn next_request_id() -> u64 {
+    let counter = CLIENT_REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    (u64::from(std::process::id()) << 32) | (counter & 0xffff_ffff)
+}
+
+fn client_log_config_cache() -> &'static Mutex<ClientLogConfigCache> {
+    CLIENT_LOG_CONFIG_CACHE.get_or_init(|| Mutex::new(ClientLogConfigCache::default()))
+}
+
+fn client_performance_log_enabled() -> bool {
+    let Ok(mut cache) = client_log_config_cache().lock() else {
+        return false;
+    };
+
+    let should_refresh = cache
+        .last_checked
+        .map(|last_checked| last_checked.elapsed() >= CLIENT_LOG_CONFIG_REFRESH_INTERVAL)
+        .unwrap_or(true);
+    if should_refresh {
+        cache.enabled = AppConfig::read()
+            .map(|config| config.debug.server_log_enabled)
+            .unwrap_or(false);
+        cache.last_checked = Some(Instant::now());
+    }
+
+    cache.enabled
+}
+
+fn duration_millis_u64(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
 impl IPCService {
     pub fn new() -> Result<Self> {
-        let runtime = tokio::runtime::Runtime::new()?;
+        let runtime = Arc::new(tokio::runtime::Runtime::new()?);
 
         let server_channel = runtime.block_on(
             Endpoint::try_from("http://[::]:50051")?.connect_with_connector(service_fn(
@@ -72,12 +125,26 @@ impl IPCService {
 
         let azookey_client = AzookeyServiceClient::new(server_channel);
         let window_client = WindowServiceClient::new(ui_channel);
+        let (performance_log_tx, mut performance_log_rx) =
+            tokio::sync::mpsc::unbounded_channel::<PerformanceLogRequest>();
+        let mut performance_log_client = azookey_client.clone();
+        runtime.spawn(async move {
+            while let Some(request) = performance_log_rx.recv().await {
+                if let Err(error) = performance_log_client
+                    .log_performance(tonic::Request::new(request))
+                    .await
+                {
+                    tracing::debug!("failed to write client performance log: {error:?}");
+                }
+            }
+        });
         tracing::debug!("Connected to server: {:?}", azookey_client);
 
         Ok(Self {
             azookey_client,
             window_client,
-            runtime: Arc::new(runtime),
+            runtime,
+            performance_log_tx,
         })
     }
 }
@@ -116,7 +183,34 @@ impl IPCService {
         self.azookey_client = refreshed.azookey_client;
         self.window_client = refreshed.window_client;
         self.runtime = refreshed.runtime;
+        self.performance_log_tx = refreshed.performance_log_tx;
         Ok(())
+    }
+
+    fn log_client_performance(
+        &mut self,
+        request_id: u64,
+        operation: &str,
+        stage: &str,
+        elapsed: Duration,
+        details: String,
+    ) {
+        if !client_performance_log_enabled() {
+            return;
+        }
+
+        let request = PerformanceLogRequest {
+            request_id,
+            component: "ime".to_string(),
+            operation: operation.to_string(),
+            stage: stage.to_string(),
+            elapsed_ms: duration_millis_u64(elapsed),
+            details,
+        };
+
+        if let Err(error) = self.performance_log_tx.send(request) {
+            tracing::debug!("failed to enqueue client performance log: {error:?}");
+        }
     }
 
     #[tracing::instrument]
@@ -175,12 +269,16 @@ impl IPCService {
         input_style: i32,
         previous_candidates: Option<&Candidates>,
     ) -> anyhow::Result<Candidates> {
+        let request_id = next_request_id();
+        let operation_start = Instant::now();
+        let input_len = text.chars().count();
         let send = |this: &mut Self| -> anyhow::Result<
             tonic::Response<shared::proto::AppendTextResponse>,
         > {
             let request = tonic::Request::new(shared::proto::AppendTextRequest {
                 text_to_append: text.clone(),
                 input_style,
+                request_id,
             });
 
             let response = this
@@ -208,6 +306,15 @@ impl IPCService {
                         tracing::error!(
                             "append_text IPC reconnect failed (style={input_style}): {reconnect_error:?}"
                         );
+                        self.log_client_performance(
+                            request_id,
+                            "append_text",
+                            "rpc_total",
+                            operation_start.elapsed(),
+                            format!(
+                                "status=error;phase=reconnect;input_len={input_len};input_style={input_style}"
+                            ),
+                        );
                         return Err(reconnect_error);
                     }
                 }
@@ -220,13 +327,32 @@ impl IPCService {
                                 "append_text recovered unchanged composition after reconnect (style={input_style}), retrying original input"
                             );
                             let retry_response = send(self)?;
-                            return Self::candidates_from_composing_text(
+                            let candidates = Self::candidates_from_composing_text(
                                 retry_response.into_inner().composing_text,
+                            )?;
+                            self.log_client_performance(
+                                request_id,
+                                "append_text",
+                                "rpc_total",
+                                operation_start.elapsed(),
+                                format!(
+                                    "status=success;retry=true;input_len={input_len};input_style={input_style}"
+                                ),
                             );
+                            return Ok(candidates);
                         }
 
                         tracing::info!(
                             "append_text recovered changed composition after reconnect (style={input_style}), reusing server state"
+                        );
+                        self.log_client_performance(
+                            request_id,
+                            "append_text",
+                            "rpc_total",
+                            operation_start.elapsed(),
+                            format!(
+                                "status=recovered_changed;input_len={input_len};input_style={input_style}"
+                            ),
                         );
                         return Ok(candidates);
                     }
@@ -234,61 +360,134 @@ impl IPCService {
                         tracing::error!(
                             "append_text refresh failed after reconnect (style={input_style}): {refresh_error:?}"
                         );
+                        self.log_client_performance(
+                            request_id,
+                            "append_text",
+                            "rpc_total",
+                            operation_start.elapsed(),
+                            format!(
+                                "status=error;phase=refresh;input_len={input_len};input_style={input_style}"
+                            ),
+                        );
                         return Err(refresh_error);
                     }
                 }
             }
         };
-        Self::candidates_from_composing_text(response.into_inner().composing_text)
+        let candidates =
+            Self::candidates_from_composing_text(response.into_inner().composing_text)?;
+        self.log_client_performance(
+            request_id,
+            "append_text",
+            "rpc_total",
+            operation_start.elapsed(),
+            format!("status=success;input_len={input_len};input_style={input_style}"),
+        );
+        Ok(candidates)
     }
 
     #[tracing::instrument]
     pub fn remove_text(&mut self) -> anyhow::Result<Candidates> {
-        let request = tonic::Request::new(shared::proto::RemoveTextRequest {});
+        let request_id = next_request_id();
+        let operation_start = Instant::now();
+        let request = tonic::Request::new(shared::proto::RemoveTextRequest { request_id });
         let response = self
             .runtime
             .clone()
             .block_on(self.azookey_client.remove_text(request))?;
-        Self::candidates_from_composing_text(response.into_inner().composing_text)
+        let candidates =
+            Self::candidates_from_composing_text(response.into_inner().composing_text)?;
+        self.log_client_performance(
+            request_id,
+            "remove_text",
+            "rpc_total",
+            operation_start.elapsed(),
+            "status=success".to_string(),
+        );
+        Ok(candidates)
     }
 
     #[tracing::instrument]
     pub fn clear_text(&mut self) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::ClearTextRequest {});
+        let request_id = next_request_id();
+        let operation_start = Instant::now();
+        let request = tonic::Request::new(shared::proto::ClearTextRequest { request_id });
         let _response = self
             .runtime
             .clone()
             .block_on(self.azookey_client.clear_text(request))?;
+        self.log_client_performance(
+            request_id,
+            "clear_text",
+            "rpc_total",
+            operation_start.elapsed(),
+            "status=success".to_string(),
+        );
 
         Ok(())
     }
 
     #[tracing::instrument]
     pub fn shrink_text(&mut self, offset: i32) -> anyhow::Result<Candidates> {
-        let request = tonic::Request::new(shared::proto::ShrinkTextRequest { offset });
+        let request_id = next_request_id();
+        let operation_start = Instant::now();
+        let request = tonic::Request::new(shared::proto::ShrinkTextRequest { offset, request_id });
         let response = self
             .runtime
             .clone()
             .block_on(self.azookey_client.shrink_text(request))?;
-        Self::candidates_from_composing_text(response.into_inner().composing_text)
+        let candidates =
+            Self::candidates_from_composing_text(response.into_inner().composing_text)?;
+        self.log_client_performance(
+            request_id,
+            "shrink_text",
+            "rpc_total",
+            operation_start.elapsed(),
+            format!("status=success;offset={offset}"),
+        );
+        Ok(candidates)
     }
 
     #[tracing::instrument]
     pub fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
-        let request = tonic::Request::new(shared::proto::MoveCursorRequest { offset });
+        let request_id = next_request_id();
+        let operation_start = Instant::now();
+        let request = tonic::Request::new(shared::proto::MoveCursorRequest { offset, request_id });
         let response = self
             .runtime
             .clone()
             .block_on(self.azookey_client.move_cursor(request))?;
-        Self::candidates_from_composing_text(response.into_inner().composing_text)
+        let candidates =
+            Self::candidates_from_composing_text(response.into_inner().composing_text)?;
+        self.log_client_performance(
+            request_id,
+            "move_cursor",
+            "rpc_total",
+            operation_start.elapsed(),
+            format!("status=success;offset={offset}"),
+        );
+        Ok(candidates)
     }
 
     pub fn set_context(&mut self, context: String) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::SetContextRequest { context });
+        let request_id = next_request_id();
+        let operation_start = Instant::now();
+        let context_len = context.chars().count();
+        let request = tonic::Request::new(shared::proto::SetContextRequest {
+            context,
+            request_id,
+        });
         let _response = self
             .runtime
             .clone()
             .block_on(self.azookey_client.set_context(request))?;
+        self.log_client_performance(
+            request_id,
+            "set_context",
+            "rpc_total",
+            operation_start.elapsed(),
+            format!("status=success;context_len={context_len}"),
+        );
 
         Ok(())
     }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -6,33 +6,41 @@ use windows::Win32::System::Threading::{GetCurrentProcess, SetPriorityClass, HIG
 use shared::proto::azookey_service_server::{AzookeyService, AzookeyServiceServer};
 use shared::proto::{
     AppendTextRequest, AppendTextResponse, ClearTextRequest, ClearTextResponse, ComposingText,
-    MoveCursorRequest, MoveCursorResponse, RemoveTextRequest, RemoveTextResponse,
-    ShrinkTextRequest, ShrinkTextResponse, Suggestion,
+    MoveCursorRequest, MoveCursorResponse, PerformanceLogRequest, PerformanceLogResponse,
+    RemoveTextRequest, RemoveTextResponse, ShrinkTextRequest, ShrinkTextResponse, Suggestion,
 };
+use shared::AppConfig;
 
 use std::{
     backtrace::Backtrace,
     ffi::{c_char, c_int, CStr, CString},
     fs::{self, File, OpenOptions},
-    io::Write,
+    io::{BufWriter, Write},
     path::PathBuf,
     sync::{
-        atomic::{AtomicU64, Ordering},
-        Mutex, OnceLock,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc, OnceLock,
     },
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 const USE_ZENZAI: bool = true;
 const INPUT_STYLE_DIRECT: i32 = 1;
 const SERVER_LOG_FILE_NAME: &str = "server.log";
+const SERVER_PERFORMANCE_LOG_FILE_NAME: &str = "server-performance.tsv";
+const SERVER_PERFORMANCE_LOG_HEADER: &str =
+    "timestamp_ms\trequest_id\tcomponent\toperation\tstage\telapsed_ms\tdetails";
+const LOG_MAX_BYTES: u64 = 4 * 1024 * 1024;
+const LOG_FLUSH_INTERVAL: Duration = Duration::from_millis(500);
+const LOG_FLUSH_ACK_TIMEOUT: Duration = Duration::from_secs(2);
 const WARMUP_INTERVAL_SECS: u64 = 30;
 
-static SERVER_LOG_FILE: OnceLock<Mutex<Option<File>>> = OnceLock::new();
-static SERVER_LOG_LEVEL: OnceLock<ServerLogLevel> = OnceLock::new();
+static SERVER_LOG_WORKER: OnceLock<ServerLogWorker> = OnceLock::new();
+static SERVER_LOG_ENABLED: AtomicBool = AtomicBool::new(false);
+static SERVER_PERFORMANCE_LOG_ENABLED: AtomicBool = AtomicBool::new(false);
 static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
-static HAS_ACTIVE_COMPOSITION: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+const SERVER_GENERATED_REQUEST_ID_PREFIX: u64 = 1 << 63;
+static HAS_ACTIVE_COMPOSITION: AtomicBool = AtomicBool::new(false);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 enum ServerLogLevel {
@@ -44,26 +52,6 @@ enum ServerLogLevel {
 }
 
 impl ServerLogLevel {
-    fn from_label(label: &str) -> Self {
-        if label.eq_ignore_ascii_case("off") {
-            Self::Off
-        } else if label.eq_ignore_ascii_case("error") || label.eq_ignore_ascii_case("panic") {
-            Self::Error
-        } else if label.eq_ignore_ascii_case("warn") || label.eq_ignore_ascii_case("warning") {
-            Self::Warn
-        } else if label.eq_ignore_ascii_case("debug") {
-            Self::Debug
-        } else {
-            Self::Info
-        }
-    }
-
-    fn from_environment() -> Self {
-        std::env::var("AZOOKEY_SERVER_LOG_LEVEL")
-            .map(|value| Self::from_label(&value))
-            .unwrap_or(Self::Warn)
-    }
-
     fn as_str(self) -> &'static str {
         match self {
             Self::Off => "OFF",
@@ -75,12 +63,268 @@ impl ServerLogLevel {
     }
 }
 
-fn current_server_log_level() -> ServerLogLevel {
-    *SERVER_LOG_LEVEL.get_or_init(ServerLogLevel::from_environment)
+#[derive(Clone, Debug)]
+struct LogPaths {
+    server_log: PathBuf,
+    performance_log: PathBuf,
+}
+
+#[derive(Default)]
+struct ServerLogSinks {
+    normal: Option<RotatingLogSink>,
+    performance: Option<RotatingLogSink>,
+}
+
+impl ServerLogSinks {
+    fn flush_all(&mut self) {
+        if let Some(sink) = self.normal.as_mut() {
+            sink.flush();
+        }
+        if let Some(sink) = self.performance.as_mut() {
+            sink.flush();
+        }
+    }
+}
+
+struct ServerLogWorker {
+    sender: mpsc::Sender<ServerLogCommand>,
+}
+
+#[derive(Default)]
+struct ServerLogConfigureResult {
+    normal_enabled: bool,
+    performance_enabled: bool,
+}
+
+enum ServerLogCommand {
+    Configure {
+        paths: Option<LogPaths>,
+        ack: mpsc::Sender<ServerLogConfigureResult>,
+    },
+    WriteLog(String),
+    WritePerformance(String),
+    Flush(mpsc::Sender<()>),
+}
+
+struct RotatingLogSink {
+    path: PathBuf,
+    writer: BufWriter<File>,
+    bytes_written: u64,
+    header: Option<&'static str>,
+    last_flush: Instant,
+}
+
+impl RotatingLogSink {
+    fn open(path: PathBuf, header: Option<&'static str>) -> std::io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        rotate_existing_log_if_needed(&path)?;
+
+        let bytes_written = path.metadata().map(|metadata| metadata.len()).unwrap_or(0);
+        let needs_header = header.is_some() && bytes_written == 0;
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let mut sink = Self {
+            path,
+            writer: BufWriter::new(file),
+            bytes_written,
+            header,
+            last_flush: Instant::now(),
+        };
+
+        if needs_header {
+            if let Some(header) = sink.header {
+                sink.write_raw_line(header)?;
+                sink.flush();
+            }
+        }
+
+        Ok(sink)
+    }
+
+    fn write_line(&mut self, line: &str) -> std::io::Result<()> {
+        let line_bytes = line.len() as u64 + 1;
+        if self.bytes_written.saturating_add(line_bytes) > LOG_MAX_BYTES {
+            self.rotate()?;
+        }
+
+        self.write_raw_line(line)?;
+        if self.last_flush.elapsed() >= LOG_FLUSH_INTERVAL {
+            self.flush();
+        }
+
+        Ok(())
+    }
+
+    fn write_raw_line(&mut self, line: &str) -> std::io::Result<()> {
+        self.writer.write_all(line.as_bytes())?;
+        self.writer.write_all(b"\n")?;
+        self.bytes_written = self.bytes_written.saturating_add(line.len() as u64 + 1);
+        Ok(())
+    }
+
+    fn rotate(&mut self) -> std::io::Result<()> {
+        self.flush();
+        let rotated_path = rotated_log_path(&self.path);
+        match fs::remove_file(&rotated_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        match fs::rename(&self.path, rotated_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        self.writer = BufWriter::new(file);
+        self.bytes_written = 0;
+        self.last_flush = Instant::now();
+
+        if let Some(header) = self.header {
+            self.write_raw_line(header)?;
+        }
+
+        Ok(())
+    }
+
+    fn flush(&mut self) {
+        let _ = self.writer.flush();
+        self.last_flush = Instant::now();
+    }
+}
+
+fn rotated_log_path(path: &std::path::Path) -> PathBuf {
+    let Some(file_name) = path.file_name() else {
+        return path.with_extension("1");
+    };
+    let mut rotated_file_name = file_name.to_os_string();
+    rotated_file_name.push(".1");
+    path.with_file_name(rotated_file_name)
+}
+
+fn rotate_existing_log_if_needed(path: &std::path::Path) -> std::io::Result<()> {
+    let Ok(metadata) = path.metadata() else {
+        return Ok(());
+    };
+
+    if metadata.len() <= LOG_MAX_BYTES {
+        return Ok(());
+    }
+
+    let rotated_path = rotated_log_path(path);
+    match fs::remove_file(&rotated_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    fs::rename(path, rotated_path)
+}
+
+fn server_log_worker() -> &'static ServerLogWorker {
+    SERVER_LOG_WORKER.get_or_init(|| {
+        let (sender, receiver) = mpsc::channel();
+        std::thread::Builder::new()
+            .name("azookey-server-log-writer".to_owned())
+            .spawn(move || server_log_worker_loop(receiver))
+            .expect("failed to spawn azookey server log writer");
+        ServerLogWorker { sender }
+    })
+}
+
+fn server_log_worker_loop(receiver: mpsc::Receiver<ServerLogCommand>) {
+    let mut sinks = ServerLogSinks::default();
+
+    loop {
+        match receiver.recv_timeout(LOG_FLUSH_INTERVAL) {
+            Ok(command) => handle_server_log_command(&mut sinks, command),
+            Err(mpsc::RecvTimeoutError::Timeout) => sinks.flush_all(),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                sinks.flush_all();
+                break;
+            }
+        }
+    }
+}
+
+fn handle_server_log_command(sinks: &mut ServerLogSinks, command: ServerLogCommand) {
+    match command {
+        ServerLogCommand::Configure { paths, ack } => {
+            let result = configure_server_log_sinks(sinks, paths);
+            let _ = ack.send(result);
+        }
+        ServerLogCommand::WriteLog(line) => {
+            if let Some(sink) = sinks.normal.as_mut() {
+                eprintln!("{line}");
+                let _ = sink.write_line(&line);
+            }
+        }
+        ServerLogCommand::WritePerformance(line) => {
+            if let Some(sink) = sinks.performance.as_mut() {
+                let _ = sink.write_line(&line);
+            }
+        }
+        ServerLogCommand::Flush(ack) => {
+            sinks.flush_all();
+            let _ = ack.send(());
+        }
+    }
+}
+
+fn configure_server_log_sinks(
+    sinks: &mut ServerLogSinks,
+    paths: Option<LogPaths>,
+) -> ServerLogConfigureResult {
+    sinks.flush_all();
+    *sinks = ServerLogSinks::default();
+
+    let Some(paths) = paths else {
+        return ServerLogConfigureResult::default();
+    };
+
+    sinks.normal = match RotatingLogSink::open(paths.server_log, None) {
+        Ok(sink) => Some(sink),
+        Err(error) => {
+            eprintln!("Failed to open server log file: {error}");
+            None
+        }
+    };
+    sinks.performance =
+        match RotatingLogSink::open(paths.performance_log, Some(SERVER_PERFORMANCE_LOG_HEADER)) {
+            Ok(sink) => Some(sink),
+            Err(error) => {
+                eprintln!("Failed to open server performance log file: {error}");
+                None
+            }
+        };
+
+    ServerLogConfigureResult {
+        normal_enabled: sinks.normal.is_some(),
+        performance_enabled: sinks.performance.is_some(),
+    }
+}
+
+fn send_server_log_command(command: ServerLogCommand) {
+    if let Err(error) = server_log_worker().sender.send(command) {
+        eprintln!("Failed to send server log command: {error}");
+    }
 }
 
 fn should_log(level: ServerLogLevel) -> bool {
-    level <= current_server_log_level()
+    if level == ServerLogLevel::Off {
+        return false;
+    }
+
+    SERVER_LOG_ENABLED.load(Ordering::Relaxed)
+}
+
+fn should_log_performance() -> bool {
+    SERVER_PERFORMANCE_LOG_ENABLED.load(Ordering::Relaxed)
 }
 
 macro_rules! log_event_lazy {
@@ -88,6 +332,21 @@ macro_rules! log_event_lazy {
         let level = $level;
         if should_log(level) {
             log_event(level, &format!($($arg)*));
+        }
+    }};
+}
+
+macro_rules! performance_event_lazy {
+    ($request_id:expr, $operation:expr, $stage:expr, $elapsed_ms:expr, $($arg:tt)*) => {{
+        if should_log_performance() {
+            log_performance_event(
+                $request_id,
+                "rust",
+                $operation,
+                $stage,
+                $elapsed_ms,
+                &format!($($arg)*),
+            );
         }
     }};
 }
@@ -127,6 +386,13 @@ unsafe extern "C" {
     fn FreeCString(ptr: *mut c_char);
     fn FreeCandidateList(ptr: *mut *mut FFICandidate, length: c_int);
     fn LoadConfig();
+    fn SetRequestId(request_id: u64);
+    fn SetServerLogCallbacks(
+        log_enabled: extern "C" fn() -> bool,
+        performance_log_enabled: extern "C" fn() -> bool,
+        write_log: extern "C" fn(*const c_char, *const c_char),
+        write_performance_log: extern "C" fn(u64, *const c_char, *const c_char, u64, *const c_char),
+    );
 }
 
 struct OwnedFfiString {
@@ -202,7 +468,36 @@ impl Drop for OwnedFfiCandidates {
 }
 
 fn next_request_id() -> u64 {
-    REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    SERVER_GENERATED_REQUEST_ID_PREFIX | REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+}
+
+fn request_id_or_next(request_id: u64) -> u64 {
+    if request_id == 0 {
+        next_request_id()
+    } else {
+        request_id
+    }
+}
+
+fn set_request_id(request_id: u64) {
+    unsafe {
+        SetRequestId(request_id);
+    }
+}
+
+fn register_server_log_callbacks() {
+    unsafe {
+        SetServerLogCallbacks(
+            AzookeyServerLogEnabled,
+            AzookeyServerPerformanceLogEnabled,
+            AzookeyServerLogFromSwift,
+            AzookeyServerPerformanceLogFromSwift,
+        );
+    }
+}
+
+fn elapsed_ms(start: Instant) -> u128 {
+    start.elapsed().as_millis()
 }
 
 fn now_timestamp_millis() -> u128 {
@@ -212,66 +507,179 @@ fn now_timestamp_millis() -> u128 {
         .unwrap_or_default()
 }
 
-fn resolve_server_log_path() -> PathBuf {
+fn resolve_log_path(file_name: &str) -> PathBuf {
     if let Ok(appdata) = std::env::var("APPDATA") {
         PathBuf::from(appdata)
             .join("Azookey")
             .join("logs")
-            .join(SERVER_LOG_FILE_NAME)
+            .join(file_name)
     } else {
         std::env::current_exe()
             .ok()
             .and_then(|path| path.parent().map(|parent| parent.to_path_buf()))
             .unwrap_or_else(|| PathBuf::from("."))
             .join("logs")
-            .join(SERVER_LOG_FILE_NAME)
+            .join(file_name)
     }
 }
 
-fn init_server_log_file() -> PathBuf {
-    let log_path = resolve_server_log_path();
-    let mut file = None;
+fn configure_server_logging(enabled: bool) -> Option<LogPaths> {
+    let paths = enabled.then(|| LogPaths {
+        server_log: resolve_log_path(SERVER_LOG_FILE_NAME),
+        performance_log: resolve_log_path(SERVER_PERFORMANCE_LOG_FILE_NAME),
+    });
+    let (ack_tx, ack_rx) = mpsc::channel();
+    send_server_log_command(ServerLogCommand::Configure {
+        paths: paths.clone(),
+        ack: ack_tx,
+    });
 
-    if let Some(parent) = log_path.parent() {
-        if let Err(error) = fs::create_dir_all(parent) {
-            eprintln!("Failed to create log directory: {error}");
-        } else {
-            match OpenOptions::new().create(true).append(true).open(&log_path) {
-                Ok(opened) => file = Some(opened),
-                Err(error) => eprintln!("Failed to open server log file: {error}"),
-            }
+    match ack_rx.recv_timeout(LOG_FLUSH_ACK_TIMEOUT) {
+        Ok(result) => {
+            SERVER_LOG_ENABLED.store(result.normal_enabled, Ordering::Relaxed);
+            SERVER_PERFORMANCE_LOG_ENABLED.store(result.performance_enabled, Ordering::Relaxed);
+        }
+        Err(error) => {
+            SERVER_LOG_ENABLED.store(false, Ordering::Relaxed);
+            SERVER_PERFORMANCE_LOG_ENABLED.store(false, Ordering::Relaxed);
+            eprintln!("Timed out configuring server logging: {error}");
         }
     }
 
-    let slot = SERVER_LOG_FILE.get_or_init(|| Mutex::new(None));
-    if let Ok(mut guard) = slot.lock() {
-        *guard = file;
-    }
+    paths
+}
 
-    log_path
+fn reload_server_logging_from_settings() -> Option<LogPaths> {
+    let enabled = AppConfig::read()
+        .map(|config| config.debug.server_log_enabled)
+        .unwrap_or(false);
+    configure_server_logging(enabled)
+}
+
+fn flush_server_logs() {
+    let (ack_tx, ack_rx) = mpsc::channel();
+    send_server_log_command(ServerLogCommand::Flush(ack_tx));
+    if let Err(error) = ack_rx.recv_timeout(LOG_FLUSH_ACK_TIMEOUT) {
+        eprintln!("Timed out flushing server logs: {error}");
+    }
 }
 
 fn log_event(level: ServerLogLevel, message: &str) {
+    log_event_with_component(None, level, message);
+}
+
+fn log_event_with_component(component: Option<&str>, level: ServerLogLevel, message: &str) {
     if !should_log(level) {
         return;
     }
 
-    let line = format!(
-        "[{}] [{}] {}",
-        now_timestamp_millis(),
-        level.as_str(),
-        message
-    );
-    eprintln!("{line}");
+    let level_label = if let Some(component) = component {
+        format!("{component}/{}", level.as_str())
+    } else {
+        level.as_str().to_owned()
+    };
+    let line = format!("[{}] [{}] {}", now_timestamp_millis(), level_label, message);
 
-    if let Some(slot) = SERVER_LOG_FILE.get() {
-        if let Ok(mut guard) = slot.lock() {
-            if let Some(file) = guard.as_mut() {
-                let _ = writeln!(file, "{line}");
-                let _ = file.flush();
-            }
-        }
+    send_server_log_command(ServerLogCommand::WriteLog(line));
+}
+
+fn sanitize_performance_field(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| match ch {
+            '\t' | '\r' | '\n' => ' ',
+            _ => ch,
+        })
+        .collect()
+}
+
+fn log_performance_event(
+    request_id: u64,
+    component: &str,
+    operation: &str,
+    stage: &str,
+    elapsed_ms: u128,
+    details: &str,
+) {
+    if !should_log_performance() {
+        return;
     }
+
+    let line = format!(
+        "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+        now_timestamp_millis(),
+        request_id,
+        sanitize_performance_field(component),
+        sanitize_performance_field(operation),
+        sanitize_performance_field(stage),
+        elapsed_ms,
+        sanitize_performance_field(details),
+    );
+
+    send_server_log_command(ServerLogCommand::WritePerformance(line));
+}
+
+fn optional_cstr_lossy(ptr: *const c_char) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+
+    unsafe { CStr::from_ptr(ptr) }
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn server_log_level_from_str(level: &str) -> ServerLogLevel {
+    match level.to_ascii_uppercase().as_str() {
+        "ERROR" => ServerLogLevel::Error,
+        "WARN" | "WARNING" => ServerLogLevel::Warn,
+        "INFO" => ServerLogLevel::Info,
+        "DEBUG" => ServerLogLevel::Debug,
+        _ => ServerLogLevel::Info,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn AzookeyServerLogEnabled() -> bool {
+    SERVER_LOG_ENABLED.load(Ordering::Relaxed)
+}
+
+#[no_mangle]
+pub extern "C" fn AzookeyServerPerformanceLogEnabled() -> bool {
+    should_log_performance()
+}
+
+#[no_mangle]
+pub extern "C" fn AzookeyServerLogFromSwift(level: *const c_char, message: *const c_char) {
+    if !AzookeyServerLogEnabled() {
+        return;
+    }
+
+    let level = server_log_level_from_str(&optional_cstr_lossy(level));
+    let message = optional_cstr_lossy(message);
+    log_event_with_component(Some("SWIFT"), level, &message);
+}
+
+#[no_mangle]
+pub extern "C" fn AzookeyServerPerformanceLogFromSwift(
+    request_id: u64,
+    operation: *const c_char,
+    stage: *const c_char,
+    elapsed_ms: u64,
+    details: *const c_char,
+) {
+    if !should_log_performance() {
+        return;
+    }
+
+    log_performance_event(
+        request_id,
+        "swift",
+        &optional_cstr_lossy(operation),
+        &optional_cstr_lossy(stage),
+        elapsed_ms as u128,
+        &optional_cstr_lossy(details),
+    );
 }
 
 fn install_panic_hook() {
@@ -302,6 +710,7 @@ fn install_panic_hook() {
             ServerLogLevel::Error,
             &format!("payload={payload}; location={location}; backtrace={backtrace}"),
         );
+        flush_server_logs();
 
         default_hook(panic_info);
     }));
@@ -535,45 +944,53 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<AppendTextRequest>,
     ) -> Result<Response<AppendTextResponse>, Status> {
-        let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
         let request = request.into_inner();
+        let request_id = request_id_or_next(request.request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+        let input_style = request.input_style;
         let input = request.text_to_append;
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[append_text:{request_id}] start input_len={} input_style={}",
-            input.chars().count(),
-            request.input_style
-        );
-        let t0 = now_timestamp_millis();
-        let composing_text = if request.input_style == INPUT_STYLE_DIRECT {
+        let input_len = input.chars().count();
+        let append_start = Instant::now();
+        let composing_text = if input_style == INPUT_STYLE_DIRECT {
             add_text_direct(&input).map_err(|error| status_from_error("append_text", error))?
         } else {
             add_text(&input).map_err(|error| status_from_error("append_text", error))?
         };
-        let t1 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[append_text:{request_id}] add_text elapsed_ms={}",
-            t1.saturating_sub(t0)
+        performance_event_lazy!(
+            request_id,
+            "append_text",
+            "swift_append_text",
+            elapsed_ms(append_start),
+            "input_len={input_len};input_style={input_style}"
         );
+        let get_composed_start = Instant::now();
         let composed_text =
             get_composed_text(false).map_err(|error| status_from_error("append_text", error))?;
-        let t2 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[append_text:{request_id}] get_composed_text elapsed_ms={}",
-            t2.saturating_sub(t1)
+        performance_event_lazy!(
+            request_id,
+            "append_text",
+            "swift_get_composed_text",
+            elapsed_ms(get_composed_start),
+            "suggestions={};hiragana_len={}",
+            composed_text.suggestions.len(),
+            composed_text
+                .hiragana
+                .as_ref()
+                .unwrap_or(&composing_text.text)
+                .chars()
+                .count()
         );
         update_active_composition_state(&composing_text.text);
-
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[append_text:{request_id}] success cursor={} hiragana_len={} suggestions={} total_elapsed_ms={}",
+        performance_event_lazy!(
+            request_id,
+            "append_text",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success;cursor={};hiragana_len={};suggestions={}",
             composing_text.cursor,
             composing_text.text.chars().count(),
-            composed_text.suggestions.len(),
-            t2.saturating_sub(handler_start)
+            composed_text.suggestions.len()
         );
 
         Ok(Response::new(AppendTextResponse {
@@ -586,38 +1003,44 @@ impl AzookeyService for MyAzookeyService {
 
     async fn remove_text(
         &self,
-        _: Request<RemoveTextRequest>,
+        request: Request<RemoveTextRequest>,
     ) -> Result<Response<RemoveTextResponse>, Status> {
-        let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
-        log_event_lazy!(ServerLogLevel::Info, "[remove_text:{request_id}] start");
+        let request_id = request_id_or_next(request.into_inner().request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
 
-        let t0 = now_timestamp_millis();
+        let remove_start = Instant::now();
         let composing_text =
             remove_text().map_err(|error| status_from_error("remove_text", error))?;
-        let t1 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[remove_text:{request_id}] remove_text elapsed_ms={}",
-            t1.saturating_sub(t0)
+        performance_event_lazy!(
+            request_id,
+            "remove_text",
+            "swift_remove_text",
+            elapsed_ms(remove_start),
+            "hiragana_len={}",
+            composing_text.text.chars().count()
         );
+        let get_composed_start = Instant::now();
         let composed_text =
             get_composed_text(false).map_err(|error| status_from_error("remove_text", error))?;
-        let t2 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[remove_text:{request_id}] get_composed_text elapsed_ms={}",
-            t2.saturating_sub(t1)
+        performance_event_lazy!(
+            request_id,
+            "remove_text",
+            "swift_get_composed_text",
+            elapsed_ms(get_composed_start),
+            "suggestions={}",
+            composed_text.suggestions.len()
         );
         update_active_composition_state(&composing_text.text);
-
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[remove_text:{request_id}] success cursor={} hiragana_len={} suggestions={} total_elapsed_ms={}",
+        performance_event_lazy!(
+            request_id,
+            "remove_text",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success;cursor={};hiragana_len={};suggestions={}",
             composing_text.cursor,
             composing_text.text.chars().count(),
-            composed_text.suggestions.len(),
-            t2.saturating_sub(handler_start)
+            composed_text.suggestions.len()
         );
 
         Ok(Response::new(RemoveTextResponse {
@@ -632,42 +1055,46 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<MoveCursorRequest>,
     ) -> Result<Response<MoveCursorResponse>, Status> {
-        let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
-        let raw_offset = request.into_inner().offset;
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[move_cursor:{request_id}] start offset={raw_offset}"
-        );
+        let request = request.into_inner();
+        let request_id = request_id_or_next(request.request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+        let raw_offset = request.offset;
 
         let offset = i8_offset_from_i32("move_cursor", raw_offset)?;
         let use_cursor_prefix = offset == 0;
-        let t0 = now_timestamp_millis();
+        let move_start = Instant::now();
         let composing_text =
             move_cursor(offset).map_err(|error| status_from_error("move_cursor", error))?;
-        let t1 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[move_cursor:{request_id}] move_cursor elapsed_ms={}",
-            t1.saturating_sub(t0)
+        performance_event_lazy!(
+            request_id,
+            "move_cursor",
+            "swift_move_cursor",
+            elapsed_ms(move_start),
+            "offset={raw_offset};hiragana_len={}",
+            composing_text.text.chars().count()
         );
+        let get_composed_start = Instant::now();
         let composed_text = get_composed_text(use_cursor_prefix)
             .map_err(|error| status_from_error("move_cursor", error))?;
-        let t2 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[move_cursor:{request_id}] get_composed_text elapsed_ms={}",
-            t2.saturating_sub(t1)
+        performance_event_lazy!(
+            request_id,
+            "move_cursor",
+            "swift_get_composed_text",
+            elapsed_ms(get_composed_start),
+            "use_cursor_prefix={use_cursor_prefix};suggestions={}",
+            composed_text.suggestions.len()
         );
         update_active_composition_state(&composing_text.text);
-
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[move_cursor:{request_id}] success cursor={} hiragana_len={} suggestions={} use_cursor_prefix={use_cursor_prefix} total_elapsed_ms={}",
+        performance_event_lazy!(
+            request_id,
+            "move_cursor",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success;cursor={};hiragana_len={};suggestions={};use_cursor_prefix={use_cursor_prefix}",
             composing_text.cursor,
             composing_text.text.chars().count(),
-            composed_text.suggestions.len(),
-            t2.saturating_sub(handler_start)
+            composed_text.suggestions.len()
         );
 
         Ok(Response::new(MoveCursorResponse {
@@ -680,19 +1107,26 @@ impl AzookeyService for MyAzookeyService {
 
     async fn clear_text(
         &self,
-        _: Request<ClearTextRequest>,
+        request: Request<ClearTextRequest>,
     ) -> Result<Response<ClearTextResponse>, Status> {
-        let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
-        log_event_lazy!(ServerLogLevel::Info, "[clear_text:{request_id}] start");
-        let t0 = now_timestamp_millis();
+        let request_id = request_id_or_next(request.into_inner().request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+        let clear_start = Instant::now();
         clear_text();
-        let t1 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[clear_text:{request_id}] success clear_text_elapsed_ms={} total_elapsed_ms={}",
-            t1.saturating_sub(t0),
-            t1.saturating_sub(handler_start)
+        performance_event_lazy!(
+            request_id,
+            "clear_text",
+            "swift_clear_text",
+            elapsed_ms(clear_start),
+            "status=success"
+        );
+        performance_event_lazy!(
+            request_id,
+            "clear_text",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success"
         );
         HAS_ACTIVE_COMPOSITION.store(false, Ordering::Relaxed);
         Ok(Response::new(ClearTextResponse {}))
@@ -702,40 +1136,44 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<ShrinkTextRequest>,
     ) -> Result<Response<ShrinkTextResponse>, Status> {
-        let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
-        let raw_offset = request.into_inner().offset;
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[shrink_text:{request_id}] start offset={raw_offset}"
-        );
+        let request = request.into_inner();
+        let request_id = request_id_or_next(request.request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+        let raw_offset = request.offset;
 
         let offset = i8_offset_from_i32("shrink_text", raw_offset)?;
-        let t0 = now_timestamp_millis();
+        let shrink_start = Instant::now();
         let composing_text =
             shrink_text(offset).map_err(|error| status_from_error("shrink_text", error))?;
-        let t1 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[shrink_text:{request_id}] shrink_text elapsed_ms={}",
-            t1.saturating_sub(t0)
+        performance_event_lazy!(
+            request_id,
+            "shrink_text",
+            "swift_shrink_text",
+            elapsed_ms(shrink_start),
+            "offset={raw_offset};hiragana_len={}",
+            composing_text.text.chars().count()
         );
+        let get_composed_start = Instant::now();
         let composed_text =
             get_composed_text(false).map_err(|error| status_from_error("shrink_text", error))?;
-        let t2 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[shrink_text:{request_id}] get_composed_text elapsed_ms={}",
-            t2.saturating_sub(t1)
+        performance_event_lazy!(
+            request_id,
+            "shrink_text",
+            "swift_get_composed_text",
+            elapsed_ms(get_composed_start),
+            "suggestions={}",
+            composed_text.suggestions.len()
         );
         update_active_composition_state(&composing_text.text);
-
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[shrink_text:{request_id}] success hiragana_len={} suggestions={} total_elapsed_ms={}",
+        performance_event_lazy!(
+            request_id,
+            "shrink_text",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success;hiragana_len={};suggestions={}",
             composing_text.text.chars().count(),
-            composed_text.suggestions.len(),
-            t2.saturating_sub(handler_start)
+            composed_text.suggestions.len()
         );
 
         Ok(Response::new(ShrinkTextResponse {
@@ -750,72 +1188,101 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<shared::proto::SetContextRequest>,
     ) -> Result<Response<shared::proto::SetContextResponse>, Status> {
-        let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
-        let context = request.into_inner().context;
+        let request = request.into_inner();
+        let request_id = request_id_or_next(request.request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+        let context = request.context;
         let trimmed_context = context
             .split('\r')
             .filter(|s| !s.is_empty())
             .last()
             .unwrap_or_default();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[set_context:{request_id}] start original_len={} trimmed_len={}",
-            context.chars().count(),
-            trimmed_context.chars().count()
-        );
+        let original_len = context.chars().count();
+        let trimmed_len = trimmed_context.chars().count();
 
         let context = cstring_from_input("SetContext.context", trimmed_context)
             .map_err(|error| status_from_error("set_context", error))?;
 
-        let t0 = now_timestamp_millis();
+        let set_context_start = Instant::now();
         unsafe { SetContext(context.as_ptr()) };
-        let t1 = now_timestamp_millis();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[set_context:{request_id}] success set_context_elapsed_ms={} total_elapsed_ms={}",
-            t1.saturating_sub(t0),
-            t1.saturating_sub(handler_start)
+        performance_event_lazy!(
+            request_id,
+            "set_context",
+            "swift_set_context",
+            elapsed_ms(set_context_start),
+            "original_len={original_len};trimmed_len={trimmed_len}"
+        );
+        performance_event_lazy!(
+            request_id,
+            "set_context",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success"
         );
         Ok(Response::new(shared::proto::SetContextResponse {}))
     }
 
     async fn update_config(
         &self,
-        _: Request<shared::proto::UpdateConfigRequest>,
+        request: Request<shared::proto::UpdateConfigRequest>,
     ) -> Result<Response<shared::proto::UpdateConfigResponse>, Status> {
-        let request_id = next_request_id();
-        let handler_start = now_timestamp_millis();
-        log_event_lazy!(ServerLogLevel::Info, "[update_config:{request_id}] start");
-        let t0 = now_timestamp_millis();
+        let request_id = request_id_or_next(request.into_inner().request_id);
+        let _log_paths = reload_server_logging_from_settings();
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+        let load_config_start = Instant::now();
         unsafe { LoadConfig() };
-        let t1 = now_timestamp_millis();
         let has_active_composition = query_active_composition_state();
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[update_config:{request_id}] load_config_elapsed_ms={}",
-            t1.saturating_sub(t0)
+        performance_event_lazy!(
+            request_id,
+            "update_config",
+            "swift_load_config",
+            elapsed_ms(load_config_start),
+            "active_composition={has_active_composition}"
         );
         HAS_ACTIVE_COMPOSITION.store(has_active_composition, Ordering::Relaxed);
-        log_event_lazy!(
-            ServerLogLevel::Info,
-            "[update_config:{request_id}] success active_composition={} total_elapsed_ms={}",
-            has_active_composition,
-            t1.saturating_sub(handler_start)
+        performance_event_lazy!(
+            request_id,
+            "update_config",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success;active_composition={has_active_composition}"
         );
         Ok(Response::new(shared::proto::UpdateConfigResponse {}))
+    }
+
+    async fn log_performance(
+        &self,
+        request: Request<PerformanceLogRequest>,
+    ) -> Result<Response<PerformanceLogResponse>, Status> {
+        let request = request.into_inner();
+        log_performance_event(
+            request.request_id,
+            &request.component,
+            &request.operation,
+            &request.stage,
+            u128::from(request.elapsed_ms),
+            &request.details,
+        );
+        Ok(Response::new(PerformanceLogResponse {}))
     }
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let log_path = init_server_log_file();
     install_panic_hook();
-    log_event_lazy!(
-        ServerLogLevel::Info,
-        "AzookeyServer started (log_path={})",
-        log_path.display()
-    );
+    if let Some(log_paths) = reload_server_logging_from_settings() {
+        log_event(
+            ServerLogLevel::Info,
+            &format!(
+                "AzookeyServer started (log_path={} performance_log_path={})",
+                log_paths.server_log.display(),
+                log_paths.performance_log.display()
+            ),
+        );
+    }
+    register_server_log_callbacks();
 
     // プロセス優先度を HIGH_PRIORITY_CLASS に引き上げ（放置後のOSスケジューリング遅延を抑制）
     unsafe {
@@ -852,6 +1319,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             log_event_lazy!(ServerLogLevel::Debug, "[warmup] start");
+            set_request_id(0);
             warmup();
             log_event_lazy!(ServerLogLevel::Debug, "[warmup] done");
         }

--- a/crates/shared/service.proto
+++ b/crates/shared/service.proto
@@ -23,6 +23,7 @@ enum InputStyle {
 message AppendTextRequest {
   string text_to_append = 1; // The text to append to the current content.
   InputStyle input_style = 2;
+  uint64 request_id = 3;
 }
 
 // Response message for AppendText.
@@ -31,7 +32,9 @@ message AppendTextResponse {
 }
 
 // Request message for RemoveText.
-message RemoveTextRequest {}
+message RemoveTextRequest {
+  uint64 request_id = 1;
+}
 
 // Response message for RemoveText.
 message RemoveTextResponse {
@@ -41,11 +44,13 @@ message RemoveTextResponse {
 // Request message for MoveCursor.
 message MoveCursorRequest {
   int32 offset = 1; // The new cursor position.
+  uint64 request_id = 2;
 }
 
 // Request message for ShrinkText.
 message ShrinkTextRequest {
   int32 offset = 1;
+  uint64 request_id = 2;
 }
 
 message ShrinkTextResponse {
@@ -58,19 +63,35 @@ message MoveCursorResponse {
 }
 
 // Request message for ClearText.
-message ClearTextRequest {}
+message ClearTextRequest {
+  uint64 request_id = 1;
+}
 
 // Response message for ClearText.
 message ClearTextResponse {}
 
 message SetContextRequest {
   string context = 1;
+  uint64 request_id = 2;
 }
 
 message SetContextResponse {}
 
-message UpdateConfigRequest {}
+message UpdateConfigRequest {
+  uint64 request_id = 1;
+}
 message UpdateConfigResponse {}
+
+message PerformanceLogRequest {
+  uint64 request_id = 1;
+  string component = 2;
+  string operation = 3;
+  string stage = 4;
+  uint64 elapsed_ms = 5;
+  string details = 6;
+}
+
+message PerformanceLogResponse {}
 
 
 // Service definition for text editing operations.
@@ -82,4 +103,5 @@ service AzookeyService {
   rpc ClearText (ClearTextRequest) returns (ClearTextResponse);
   rpc SetContext (SetContextRequest) returns (SetContextResponse);
   rpc UpdateConfig (UpdateConfigRequest) returns (UpdateConfigResponse);
+  rpc LogPerformance (PerformanceLogRequest) returns (PerformanceLogResponse);
 }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -436,7 +436,8 @@ pub fn zenzai_cpu_backend_supported() -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppConfig, ConfigError, GeneralConfig, NumpadInputMode, CONFIG_VERSION, SETTINGS_FILENAME,
+        AppConfig, ConfigError, DebugConfig, GeneralConfig, NumpadInputMode, CONFIG_VERSION,
+        SETTINGS_FILENAME,
     };
     use std::{
         env,
@@ -518,6 +519,14 @@ mod tests {
     }
 
     #[test]
+    fn debug_server_log_defaults_to_off() {
+        assert!(!DebugConfig::default().server_log_enabled);
+
+        let deserialized: DebugConfig = serde_json::from_str("{}").unwrap();
+        assert!(!deserialized.server_log_enabled);
+    }
+
+    #[test]
     fn new_creates_default_settings_when_file_is_missing() {
         let temp = tempfile::tempdir().unwrap();
         let _appdata = AppDataGuard::set(temp.path());
@@ -582,6 +591,74 @@ mod tests {
 
         assert_eq!(migrated.version, CONFIG_VERSION);
         assert_eq!(migrated.general.numpad_input, NumpadInputMode::DirectInput);
+    }
+
+    #[test]
+    fn new_with_recovery_repairs_mojibake_default_romaji_table() {
+        let temp = tempfile::tempdir().unwrap();
+        let _appdata = AppDataGuard::set(temp.path());
+        let config_root = temp.path().join("Azookey");
+        fs::create_dir_all(&config_root).unwrap();
+        let config_path = config_root.join(SETTINGS_FILENAME);
+        let mut config = AppConfig::default();
+        for row in &mut config.romaji_table.rows {
+            row.output = "繝ｼ".to_string();
+        }
+        fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+        let result = AppConfig::new_with_recovery().unwrap();
+
+        assert_eq!(
+            result
+                .config
+                .romaji_table
+                .rows
+                .iter()
+                .find(|row| row.input == "-")
+                .unwrap()
+                .output,
+            "ー"
+        );
+        assert_eq!(
+            result
+                .config
+                .romaji_table
+                .rows
+                .iter()
+                .find(|row| row.input == "a")
+                .unwrap()
+                .output,
+            "あ"
+        );
+
+        let saved: AppConfig = serde_json::from_str(&fs::read_to_string(config_path).unwrap())
+            .expect("rewritten settings should be valid JSON");
+        assert_eq!(
+            saved
+                .romaji_table
+                .rows
+                .iter()
+                .find(|row| row.input == "a")
+                .unwrap()
+                .output,
+            "あ"
+        );
+    }
+
+    #[test]
+    fn read_keeps_custom_romaji_table_output() {
+        let temp = tempfile::tempdir().unwrap();
+        let _appdata = AppDataGuard::set(temp.path());
+        let config_root = temp.path().join("Azookey");
+        fs::create_dir_all(&config_root).unwrap();
+        let config_path = config_root.join(SETTINGS_FILENAME);
+        let mut config = AppConfig::default();
+        config.romaji_table.rows[0].output = "custom".to_string();
+        fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+        let loaded = AppConfig::read().unwrap();
+
+        assert_eq!(loaded.romaji_table.rows[0].output, "custom");
     }
 
     #[test]
@@ -676,6 +753,12 @@ pub struct ShortcutConfig {
     pub alt_backquote_toggle: bool,
 }
 
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+pub struct DebugConfig {
+    #[serde(default)]
+    pub server_log_enabled: bool,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct CharacterWidthConfig {
     #[serde(default = "default_symbol_fullwidth_map")]
@@ -749,6 +832,8 @@ impl Default for ShortcutConfig {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AppConfig {
     pub version: String,
+    #[serde(default)]
+    pub debug: DebugConfig,
     pub zenzai: ZenzaiConfig,
     #[serde(default)]
     pub shortcuts: ShortcutConfig,
@@ -766,6 +851,7 @@ impl Default for AppConfig {
     fn default() -> Self {
         AppConfig {
             version: CONFIG_VERSION.to_string(),
+            debug: DebugConfig::default(),
             zenzai: ZenzaiConfig {
                 enable: false,
                 profile: "".to_string(),
@@ -904,7 +990,52 @@ fn parse_config(config_path: &Path, config_str: &str) -> Result<AppConfig, Confi
         config.version = CONFIG_VERSION.to_string();
     }
 
+    repair_mojibake_default_romaji_table(&mut config);
+
     Ok(config)
+}
+
+fn repair_mojibake_default_romaji_table(config: &mut AppConfig) {
+    if romaji_table_looks_like_mojibake_default(&config.romaji_table.rows) {
+        config.romaji_table.rows = default_romaji_rows();
+    }
+}
+
+fn romaji_table_looks_like_mojibake_default(rows: &[RomajiRule]) -> bool {
+    let default_rows = default_romaji_rows();
+    if rows.len() != default_rows.len() {
+        return false;
+    }
+
+    let matching_keys = rows
+        .iter()
+        .zip(default_rows.iter())
+        .filter(|(row, default_row)| {
+            row.input == default_row.input && row.next_input == default_row.next_input
+        })
+        .count();
+    if matching_keys < default_rows.len().saturating_mul(9) / 10 {
+        return false;
+    }
+
+    let differing_outputs = rows
+        .iter()
+        .zip(default_rows.iter())
+        .filter(|(row, default_row)| row.output != default_row.output)
+        .count();
+    let mojibake_outputs = rows
+        .iter()
+        .filter(|row| contains_common_utf8_mojibake_marker(&row.output))
+        .count();
+
+    differing_outputs > default_rows.len() / 2 && mojibake_outputs > 10
+}
+
+fn contains_common_utf8_mojibake_marker(value: &str) -> bool {
+    const MARKERS: [&str; 12] = [
+        "繝", "縺", "繧", "窶", "竊", "縲", "荳", "譁", "ã", "Ã", "Â", "â",
+    ];
+    MARKERS.iter().any(|marker| value.contains(marker))
 }
 
 fn ensure_config_dir(config_root: &Path) -> Result<(), ConfigError> {

--- a/frontend/src-tauri/src/ipc.rs
+++ b/frontend/src-tauri/src/ipc.rs
@@ -100,7 +100,7 @@ fn should_retry_pipe_connect_error(
 // implement methods to interact with kkc server
 impl IPCService {
     pub fn update_config(&mut self) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::UpdateConfigRequest {});
+        let request = tonic::Request::new(shared::proto::UpdateConfigRequest { request_id: 0 });
         self.runtime
             .clone()
             .block_on(self.azookey_client.update_config(request))?;

--- a/frontend/src/components/debug-settings.tsx
+++ b/frontend/src/components/debug-settings.tsx
@@ -1,12 +1,41 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { RefreshCcw, Server } from "lucide-react";
+import { FileText, RefreshCcw, Server } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { saveConfigWithToast } from "@/lib/config";
+
+type DebugConfigState = {
+    server_log_enabled: boolean;
+};
+
+const DEFAULT_DEBUG_CONFIG: DebugConfigState = {
+    server_log_enabled: false,
+};
+
+const normalizeDebugConfig = (value?: Record<string, unknown>): DebugConfigState => ({
+    server_log_enabled:
+        typeof value?.server_log_enabled === "boolean"
+            ? value.server_log_enabled
+            : DEFAULT_DEBUG_CONFIG.server_log_enabled,
+});
 
 export const DebugSettings = () => {
     const [isRestartingServer, setIsRestartingServer] = useState(false);
+    const [debugConfig, setDebugConfig] =
+        useState<DebugConfigState>(DEFAULT_DEBUG_CONFIG);
+
+    useEffect(() => {
+        invoke<any>("get_config")
+            .then((data) => {
+                setDebugConfig(normalizeDebugConfig(data.debug));
+            })
+            .catch(() => {
+                // Keep default values if config fetch fails.
+            });
+    }, []);
 
     const restartServer = async () => {
         if (isRestartingServer) {
@@ -28,9 +57,36 @@ export const DebugSettings = () => {
         }
     };
 
+    const updateServerLogEnabled = async (enabled: boolean) => {
+        const data = await saveConfigWithToast((config) => {
+            config.debug = {
+                ...DEFAULT_DEBUG_CONFIG,
+                ...(config.debug ?? {}),
+                server_log_enabled: enabled,
+            };
+        });
+
+        if (data) {
+            setDebugConfig(normalizeDebugConfig(data.debug));
+        }
+    };
+
     return (
         <section className="space-y-3">
             <h1 className="text-sm font-bold text-foreground">デバッグ用設定</h1>
+            <div className="flex items-center gap-4 rounded-md border p-4">
+                <FileText />
+                <div className="flex-1 space-y-1">
+                    <p className="text-sm font-medium leading-none">サーバーログ</p>
+                    <p className="text-xs text-muted-foreground">
+                        server.log と性能計測ログを記録します
+                    </p>
+                </div>
+                <Switch
+                    checked={debugConfig.server_log_enabled}
+                    onCheckedChange={(checked) => void updateServerLogEnabled(checked)}
+                />
+            </div>
             <div className="flex items-center gap-4 rounded-md border p-4">
                 <Server />
                 <div className="flex-1 space-y-1">

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -35,99 +35,152 @@ let minInputCountForZenzaiCandidates = 4
 let minHiraganaCountForZenzaiCandidates = 2
 // Request exact-clause supplements only when boundary-matched candidates are sparse.
 let cursorPrefixExactClauseSupplementCandidateThreshold = 5
-let serverLogFileName = "server.log"
 
-private enum ServerLogLevel: Int {
-    case off = 0
-    case error = 1
-    case warn = 2
-    case info = 3
-    case debug = 4
+@MainActor var currentRequestId: UInt64 = 0
 
-    init(label: String) {
-        switch label.lowercased() {
-        case "off":
-            self = .off
-        case "error", "panic":
-            self = .error
-        case "warn", "warning":
-            self = .warn
-        case "debug":
-            self = .debug
-        default:
-            self = .info
+public typealias ServerLogEnabledCallback = @convention(c) () -> Bool
+public typealias ServerLogWriteCallback = @convention(c) (
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?
+) -> Void
+public typealias ServerPerformanceLogWriteCallback = @convention(c) (
+    UInt64,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?,
+    UInt64,
+    UnsafePointer<CChar>?
+) -> Void
+
+private final class ServerLogCallbacks: @unchecked Sendable {
+    private let lock = NSLock()
+    private var logEnabled: ServerLogEnabledCallback?
+    private var performanceLogEnabled: ServerLogEnabledCallback?
+    private var writeLog: ServerLogWriteCallback?
+    private var writePerformanceLog: ServerPerformanceLogWriteCallback?
+
+    func configure(
+        logEnabled: ServerLogEnabledCallback?,
+        performanceLogEnabled: ServerLogEnabledCallback?,
+        writeLog: ServerLogWriteCallback?,
+        writePerformanceLog: ServerPerformanceLogWriteCallback?
+    ) {
+        lock.lock()
+        self.logEnabled = logEnabled
+        self.performanceLogEnabled = performanceLogEnabled
+        self.writeLog = writeLog
+        self.writePerformanceLog = writePerformanceLog
+        lock.unlock()
+    }
+
+    func isLogEnabled() -> Bool {
+        lock.lock()
+        let callback = logEnabled
+        lock.unlock()
+        return callback?() ?? false
+    }
+
+    func isPerformanceLogEnabled() -> Bool {
+        lock.lock()
+        let callback = performanceLogEnabled
+        lock.unlock()
+        return callback?() ?? false
+    }
+
+    func log(level: String, message: String) {
+        lock.lock()
+        let callback = writeLog
+        lock.unlock()
+
+        guard let callback else {
+            return
+        }
+
+        level.withCString { levelPointer in
+            message.withCString { messagePointer in
+                callback(levelPointer, messagePointer)
+            }
         }
     }
 
-    static func fromEnvironment() -> Self {
-        guard let rawValue = ProcessInfo.processInfo.environment["AZOOKEY_SERVER_LOG_LEVEL"] else {
-            return .warn
+    func performanceLog(
+        requestId: UInt64,
+        operation: String,
+        stage: String,
+        elapsedMs: UInt64,
+        details: String
+    ) {
+        lock.lock()
+        let callback = writePerformanceLog
+        lock.unlock()
+
+        guard let callback else {
+            return
         }
-        return .init(label: rawValue)
+
+        operation.withCString { operationPointer in
+            stage.withCString { stagePointer in
+                details.withCString { detailsPointer in
+                    callback(requestId, operationPointer, stagePointer, elapsedMs, detailsPointer)
+                }
+            }
+        }
     }
 }
 
-private let serverLogThreshold = ServerLogLevel.fromEnvironment()
+private let serverLogCallbacks = ServerLogCallbacks()
 
-private func serverLogPath() -> URL {
-    if let appDataPath = ProcessInfo.processInfo.environment["APPDATA"] {
-        return URL(filePath: appDataPath)
-            .appendingPathComponent("Azookey")
-            .appendingPathComponent("logs")
-            .appendingPathComponent(serverLogFileName)
-    }
-
-    return (executableDirectoryURL() ?? URL(filePath: FileManager.default.currentDirectoryPath))
-        .appendingPathComponent("logs")
-        .appendingPathComponent(serverLogFileName)
-}
-
-private func serverLogTimestampMillis() -> UInt64 {
-    UInt64(Date().timeIntervalSince1970 * 1000)
+@_silgen_name("SetServerLogCallbacks")
+public func set_server_log_callbacks(
+    _ logEnabled: ServerLogEnabledCallback?,
+    _ performanceLogEnabled: ServerLogEnabledCallback?,
+    _ writeLog: ServerLogWriteCallback?,
+    _ writePerformanceLog: ServerPerformanceLogWriteCallback?
+) {
+    serverLogCallbacks.configure(
+        logEnabled: logEnabled,
+        performanceLogEnabled: performanceLogEnabled,
+        writeLog: writeLog,
+        writePerformanceLog: writePerformanceLog
+    )
 }
 
 private func serverLog(_ level: String = "INFO", _ message: @autoclosure () -> String) {
-    let resolvedLevel = ServerLogLevel(label: level)
-    guard resolvedLevel.rawValue <= serverLogThreshold.rawValue else {
+    guard serverLogCallbacks.isLogEnabled() else {
         return
     }
 
-    let resolvedMessage = message()
-    let line = "[\(serverLogTimestampMillis())] [SWIFT/\(level)] \(resolvedMessage)"
-    fputs("\(line)\n", stderr)
+    serverLogCallbacks.log(level: level, message: message())
+}
 
-    let logPath = serverLogPath()
-    let logDirectory = logPath.deletingLastPathComponent()
-
-    do {
-        try FileManager.default.createDirectory(
-            at: logDirectory,
-            withIntermediateDirectories: true
-        )
-    } catch {
-        fputs("Failed to create log directory: \(error)\n", stderr)
+@MainActor private func performanceLog(
+    operation: String,
+    stage: String,
+    elapsedMs: Int,
+    details: @autoclosure () -> String = ""
+) {
+    guard serverLogCallbacks.isPerformanceLogEnabled() else {
         return
     }
 
-    if !FileManager.default.fileExists(atPath: logPath.path) {
-        FileManager.default.createFile(atPath: logPath.path, contents: nil)
-    }
+    serverLogCallbacks.performanceLog(
+        requestId: currentRequestId,
+        operation: operation,
+        stage: stage,
+        elapsedMs: UInt64(max(0, elapsedMs)),
+        details: details()
+    )
+}
 
-    guard let handle = FileHandle(forWritingAtPath: logPath.path) else {
-        fputs("Failed to open log file at \(logPath.path)\n", stderr)
-        return
+private func settingsPath() -> URL? {
+    guard let appDataPath = ProcessInfo.processInfo.environment["APPDATA"] else {
+        return nil
     }
+    return URL(filePath: appDataPath).appendingPathComponent("Azookey/settings.json")
+}
 
-    defer {
-        handle.closeFile()
-    }
-
-    guard let data = "\(line)\n".data(using: .utf8) else {
-        return
-    }
-
-    handle.seekToEndOfFile()
-    handle.write(data)
+private func readAppSettings(at path: URL) throws -> AppSettings {
+    let data = try Data(contentsOf: path)
+    return try JSONDecoder().decode(AppSettings.self, from: data)
 }
 
 @MainActor private func rebuildConverter() {
@@ -925,6 +978,18 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 
 @_silgen_name("LoadConfig")
 @MainActor public func load_config() {
+    let loadedSettingsPath = settingsPath()
+    var loadedSettings: AppSettings?
+    var settingsLoadError: Error?
+    if let loadedSettingsPath {
+        do {
+            let settings = try readAppSettings(at: loadedSettingsPath)
+            loadedSettings = settings
+        } catch {
+            settingsLoadError = error
+        }
+    }
+
     serverLog("INFO", "LoadConfig: start")
     let previousZenzaiEnabled = (config["enable"] as? Bool) ?? false
     let previousProfile = (config["profile"] as? String) ?? ""
@@ -945,70 +1010,66 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     config["backend"] = "cpu"
     setRoman2KanaInputStyle()
 
-    if let appDataPath = ProcessInfo.processInfo.environment["APPDATA"] {
-        let settingsPath = URL(filePath: appDataPath).appendingPathComponent("Azookey/settings.json")
-        serverLog("INFO", "LoadConfig: reading settingsPath=\(settingsPath.path)")
-        
-        do {
-            let data = try Data(contentsOf: settingsPath)
-            let settings = try JSONDecoder().decode(AppSettings.self, from: data)
-
-            if let zenzai = settings.zenzai {
-                if let enableValue = zenzai.enable {
-                    config["enable"] = enableValue
-                }
-
-                if let profileValue = zenzai.profile {
-                    config["profile"] = profileValue
-                }
-
-                if let backendValue = zenzai.backend {
-                    config["backend"] = backendValue
-                }
-            }
-
-            applyRomajiInputStyle(rows: settings.romaji_table?.rows)
-
-            let sourceEntries = settings.user_dictionary?.entries ?? []
-            var seen: Set<String> = []
-            var priorityRank = 0
-            for entry in sourceEntries {
-                if dynamicUserDictionary.count >= maxUserDictionaryEntryCount {
-                    break
-                }
-
-                let reading = entry.reading.trimmingCharacters(in: .whitespacesAndNewlines)
-                let word = entry.word.trimmingCharacters(in: .whitespacesAndNewlines)
-                if reading.isEmpty || word.isEmpty {
-                    continue
-                }
-
-                let normalizedReading = normalizeReading(reading)
-                let key = normalizedReading + "\u{0}" + word
-                if seen.contains(key) {
-                    continue
-                }
-                seen.insert(key)
-
-                let priorityAdjustedValue = PValue(-5 - Float(priorityRank) * 0.01)
-                dynamicUserDictionary.append(
-                    DicdataElement(
-                        word: word,
-                        ruby: normalizedReading,
-                        cid: CIDData.固有名詞.cid,
-                        mid: MIDData.一般.mid,
-                        value: priorityAdjustedValue
-                    )
-                )
-                priorityRank += 1
-            }
-
-            if sourceEntries.count > maxUserDictionaryEntryCount {
-                serverLog("WARN", "User dictionary entries are truncated to \(maxUserDictionaryEntryCount).")
-            }
-        } catch {
-            serverLog("ERROR", "Failed to read settings: \(error)")
+    if let settings = loadedSettings {
+        if let loadedSettingsPath {
+            serverLog("INFO", "LoadConfig: reading settingsPath=\(loadedSettingsPath.path)")
         }
+
+        if let zenzai = settings.zenzai {
+            if let enableValue = zenzai.enable {
+                config["enable"] = enableValue
+            }
+
+            if let profileValue = zenzai.profile {
+                config["profile"] = profileValue
+            }
+
+            if let backendValue = zenzai.backend {
+                config["backend"] = backendValue
+            }
+        }
+
+        applyRomajiInputStyle(rows: settings.romaji_table?.rows)
+
+        let sourceEntries = settings.user_dictionary?.entries ?? []
+        var seen: Set<String> = []
+        var priorityRank = 0
+        for entry in sourceEntries {
+            if dynamicUserDictionary.count >= maxUserDictionaryEntryCount {
+                break
+            }
+
+            let reading = entry.reading.trimmingCharacters(in: .whitespacesAndNewlines)
+            let word = entry.word.trimmingCharacters(in: .whitespacesAndNewlines)
+            if reading.isEmpty || word.isEmpty {
+                continue
+            }
+
+            let normalizedReading = normalizeReading(reading)
+            let key = normalizedReading + "\u{0}" + word
+            if seen.contains(key) {
+                continue
+            }
+            seen.insert(key)
+
+            let priorityAdjustedValue = PValue(-5 - Float(priorityRank) * 0.01)
+            dynamicUserDictionary.append(
+                DicdataElement(
+                    word: word,
+                    ruby: normalizedReading,
+                    cid: CIDData.固有名詞.cid,
+                    mid: MIDData.一般.mid,
+                    value: priorityAdjustedValue
+                )
+            )
+            priorityRank += 1
+        }
+
+        if sourceEntries.count > maxUserDictionaryEntryCount {
+            serverLog("WARN", "User dictionary entries are truncated to \(maxUserDictionaryEntryCount).")
+        }
+    } else if let settingsLoadError {
+        serverLog("ERROR", "Failed to read settings: \(settingsLoadError)")
     } else {
         serverLog("WARN", "LoadConfig: APPDATA is not set. Using defaults.")
     }
@@ -1075,6 +1136,11 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     )
 }
 
+@_silgen_name("SetRequestId")
+@MainActor public func set_request_id(_ requestID: UInt64) {
+    currentRequestId = requestID
+}
+
 @_silgen_name("Warmup")
 @MainActor public func warmup() {
     let contextString = (config["context"] as? String) ?? ""
@@ -1088,9 +1154,17 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
         "DEBUG",
         "Warmup: start hiraganaLength=\(warmupComposingText.convertTarget.count) inputCount=\(warmupComposingText.input.count) contextLength=\(contextString.count) useZenzai=\(useZenzai)"
     )
+    let requestStart = ProcessInfo.processInfo.systemUptime
     _ = converter.requestCandidates(
         warmupComposingText,
         options: getOptions(context: contextString, zenzaiEnabled: useZenzai)
+    )
+    let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
+    performanceLog(
+        operation: "warmup",
+        stage: "request_candidates",
+        elapsedMs: requestMs,
+        details: "use_zenzai=\(useZenzai);hiragana_len=\(warmupComposingText.convertTarget.count);input_count=\(warmupComposingText.input.count)"
     )
     serverLog("DEBUG", "Warmup: completed")
 }
@@ -1266,7 +1340,13 @@ public func free_candidate_list(
     let requestStart = ProcessInfo.processInfo.systemUptime
     let converted = converter.requestCandidates(previewComposingText, options: options)
     let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
-    serverLog("INFO", "GetComposedText: requestCandidates returned candidateCount=\(converted.mainResults.count) elapsed_ms=\(requestMs)")
+    performanceLog(
+        operation: "get_composed_text",
+        stage: "request_candidates",
+        elapsedMs: requestMs,
+        details: "candidate_count=\(converted.mainResults.count);use_zenzai=\(useZenzai);synthetic_end_of_text=\(previewState.syntheticEndOfText);hiragana_len=\(originalHiragana.count);preview_hiragana_len=\(previewHiragana.count)"
+    )
+    serverLog("INFO", "GetComposedText: requestCandidates returned candidateCount=\(converted.mainResults.count)")
     var result: [FFICandidate] = []
 
     for i in 0..<converted.mainResults.count {
@@ -1374,7 +1454,13 @@ public func free_candidate_list(
             resolutionCache: &cursorPrefixResolutionCache
         )
     let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
-    serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(cursorPrefixResults.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) exactClauseCandidateCount=\(exactClauseResults.count) elapsed_ms=\(requestMs)")
+    performanceLog(
+        operation: "get_composed_text_for_cursor_prefix",
+        stage: "request_candidates",
+        elapsedMs: requestMs,
+        details: "candidate_count=\(cursorPrefixResults.count);first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);exact_clause_candidate_count=\(exactClauseResults.count);use_zenzai=\(useZenzai);synthetic_end_of_text=\(previewState.syntheticEndOfText);prefix_len=\(prefixHiragana.count);preview_prefix_len=\(previewPrefixHiragana.count);suffix_len=\(suffixAfterCursor.count)"
+    )
+    serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(cursorPrefixResults.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) exactClauseCandidateCount=\(exactClauseResults.count)")
     var result: [FFICandidate] = []
 
     for i in 0..<cursorPrefixResults.count {


### PR DESCRIPTION
## Summary
- server logging をデバッグ設定から明示的に ON/OFF できるようにしました。
- 通常ログと request id 付き performance log を分離し、IME -> Rust server -> Swift converter の所要時間を追えるようにしました。
- Rust / Swift 側のログ書き込みを async / buffered 寄りに変更し、ログ有効時の入力 hot path の同期 I/O を減らしました。
- 検証中に発覚した既定ローマ字テーブルの UTF-8 文字化け状態を、狭い条件で自動修復するようにしました。

## Background
- Issue: Closes #54
- Related: #81
- `server.log` 有効時は Rust 側の flush や Swift 側の file open/close が入力処理の遅延要因になり得るため、#81 の入力引っかかり調査に先立って計測環境を整備します。
- ログ有効化は環境変数ではなく、設定画面のデバッグ設定から切り替えられるようにします。

## Changes
- debug settings
  - `debug.server_log_enabled` を追加し、設定画面のデバッグ設定から server log / performance log を切り替え可能に変更
  - logging OFF を既定値にし、OFF 時は log file を作成しないように変更
- Rust server logging
  - logging worker thread を追加し、通常ログと `server-performance.tsv` を分離
  - request id / operation / stage / elapsed_ms / details を TSV へ出力
  - Swift converter からの log / performance event を Rust server 側で受け取り、ログ出力を一元化
  - panic hook でログ flush を試みるように変更
- client performance logging
  - client request id を生成し、IME 側の IPC stage と Rust / Swift 側の stage を同じ id で追跡可能に変更
  - logging 設定は短周期 cache で読み、OFF 時の設定 read 頻度を抑制
- Swift converter logging
  - request id を受け取り、候補生成 / 変換などの stage を performance log に記録
  - Swift 側で都度 file open/close する経路をやめ、Rust server callback 経由で logging
- settings recovery
  - default と同じ行数・キー順に見える romaji table が大量に UTF-8 mojibake している場合だけ、既定ローマ字テーブルへ復旧
  - 通常の custom romaji table は保持する回帰テストを追加

## Verification
- [x] Codex review
  - 初回レビューで重大な問題なしを確認
  - mojibake recovery 追加後の再レビューでも重大な問題なしを確認
- [x] 差分チェック / format
  - `cargo fmt`
  - `cargo fmt --all --check`
  - `git diff --check`
  - `git diff --cached --check`
- [x] ローカル test / check
  - `PROTOC=.local/tmp/protoc/bin/protoc cargo test -p shared`
  - `cargo check -p azookey-server --target x86_64-pc-windows-msvc`
  - `cargo check -p azookey-windows --target x86_64-pc-windows-msvc`
- [x] ローカル Windows VM build / install
  - `.local/vm_build_master.sh fix/54-server-log-io`
  - artifact: `.local/artifacts/azookey-setup-fix_54-server-log-io-20260608-065958.exe`
  - `.local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-fix_54-server-log-io-20260608-065958.exe`
  - install log: `.local/logs/win11-install-20260608-074701.log`
- [x] ローカル Windows VM logging smoke
  - 設定 OFF で `server.log` / `server-performance.tsv` が書き込まれないことを確認
  - 設定 ON で `server-performance.tsv` に header と ime / rust / swift の request id 付き stage が出力されることを確認
  - malformed row がないことを確認
- [x] ローカル Windows VM mojibake recovery smoke
  - VM の `settings.json` の romaji table output を意図的に UTF-8 mojibake 状態へ変更
  - 起動後に `a` が `あ`、`-` が `ー` へ復旧し、mojibake marker rows が 0 になることを確認
  - Notepad + azooKey で以前の `ã...` 系の候補文字化けが消えることを確認
- [ ] GitHub Actions build 成功
  - run: pending

## Notes
- performance logging ON は計測用のため、出力先が長時間詰まるケースでは queue のメモリ増加余地があります。通常利用では OFF が既定です。
- mojibake recovery は default romaji table と強く一致する壊れ方だけを対象にしており、通常の custom romaji table は修復対象にしない方針です。