### PR TITLE
feat(client): add input hot path latency tracing

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    time::{Duration, Instant},
+};
 
 use crate::{
     engine::user_action::UserAction,
@@ -11,7 +14,10 @@ use super::{
     client_action::{ClientAction, SetSelectionType, SetTextType},
     full_width::{convert_kana_symbol, to_fullwidth, to_halfwidth},
     input_mode::InputMode,
-    ipc_service::{Candidates, IPCService},
+    ipc_service::{
+        client_performance_log_enabled, current_input_trace_request_id, Candidates,
+        ClientInputTraceGuard, IPCService,
+    },
     state::{keyboard_disabled_from_context, IMEState},
     text_util::{to_half_katakana, to_katakana},
     user_action::{Function, Navigation},
@@ -37,8 +43,10 @@ pub(super) use clause_state::{
     ClauseCommand, ClauseState, ClauseTransitionInput, MoveClauseProgressMarker,
 };
 
+#[cfg(test)]
 pub(crate) struct CompositionReducer;
 
+#[cfg(test)]
 impl CompositionReducer {
     pub(crate) fn plan_actions_for_user_action(
         composition: &Composition,
@@ -284,6 +292,28 @@ impl TextServiceFactory {
         })
     }
 
+    fn log_client_performance(
+        request_id: u64,
+        operation: &str,
+        stage: &str,
+        elapsed: Duration,
+        details: impl Into<String>,
+    ) {
+        if !client_performance_log_enabled() {
+            return;
+        }
+
+        if let Ok(Some(ipc_service)) = IMEState::ipc_service() {
+            ipc_service.log_client_performance(
+                request_id,
+                operation,
+                stage,
+                elapsed,
+                details.into(),
+            );
+        }
+    }
+
     #[inline]
     fn is_ctrl_pressed() -> bool {
         VK_CONTROL.is_pressed() || VK_LCONTROL.is_pressed() || VK_RCONTROL.is_pressed()
@@ -499,15 +529,6 @@ impl TextServiceFactory {
         }
     }
 
-    fn has_romaji_table_context(
-        raw_input_before: &str,
-        symbol: char,
-        romaji_rows: &[RomajiRule],
-    ) -> bool {
-        let romaji_lookup = RomajiLookup::from_rows(romaji_rows);
-        Self::has_romaji_table_context_with_lookup(raw_input_before, symbol, &romaji_lookup)
-    }
-
     #[inline]
     fn has_romaji_table_context_with_lookup(
         raw_input_before: &str,
@@ -518,6 +539,7 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    #[cfg(test)]
     fn should_apply_symbol_fallback(
         raw_input_before: &str,
         input: &str,
@@ -540,20 +562,6 @@ impl TextServiceFactory {
         !symbols.iter().any(|symbol| {
             Self::has_romaji_table_context_with_lookup(raw_input_before, *symbol, romaji_lookup)
         })
-    }
-
-    #[inline]
-    fn has_multi_character_romaji_context(
-        raw_input_before: &str,
-        symbol: char,
-        romaji_rows: &[RomajiRule],
-    ) -> bool {
-        let romaji_lookup = RomajiLookup::from_rows(romaji_rows);
-        Self::has_multi_character_romaji_context_with_lookup(
-            raw_input_before,
-            symbol,
-            &romaji_lookup,
-        )
     }
 
     #[inline]
@@ -580,6 +588,7 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    #[cfg(test)]
     fn single_symbol_romaji_output(input: &str, romaji_rows: &[RomajiRule]) -> Option<String> {
         let romaji_lookup = RomajiLookup::from_rows(romaji_rows);
         Self::single_symbol_romaji_output_with_lookup(input, &romaji_lookup)
@@ -595,6 +604,7 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    #[cfg(test)]
     fn resolve_symbol_input_text(
         raw_input_before: &str,
         input: &str,
@@ -1450,19 +1460,61 @@ impl TextServiceFactory {
         visible: Option<bool>,
         update_pos: bool,
     ) -> Result<()> {
-        let position = if update_pos {
-            self.candidate_window_position()?
-        } else {
-            None
-        };
-        ipc_service.update_candidate_window(
-            visible,
-            position,
-            Some(candidates.texts.clone()),
-            Some(selection_index),
-            None,
-        )?;
-        Ok(())
+        let trace_request_id = current_input_trace_request_id();
+        let total_start = trace_request_id.map(|_| Instant::now());
+        let result: Result<()> = (|| {
+            let position = if update_pos {
+                let position_start = trace_request_id.map(|_| Instant::now());
+                let position = self.candidate_window_position()?;
+                if let (Some(request_id), Some(position_start)) = (trace_request_id, position_start)
+                {
+                    Self::log_client_performance(
+                        request_id,
+                        "sync_candidate_window_update",
+                        "candidate_window_position",
+                        position_start.elapsed(),
+                        format!(
+                            "status=success;position_present={};candidate_count={}",
+                            position.is_some(),
+                            candidates.texts.len()
+                        ),
+                    );
+                }
+                position
+            } else {
+                None
+            };
+            ipc_service.update_candidate_window(
+                visible,
+                position,
+                Some(candidates.texts.clone()),
+                Some(selection_index),
+                None,
+            )?;
+            Ok(())
+        })();
+
+        if let (Some(request_id), Some(total_start)) = (trace_request_id, total_start) {
+            let details = match &result {
+                Ok(()) => format!(
+                    "status=success;update_pos={update_pos};visible={visible:?};candidate_count={};selection_index={selection_index}",
+                    candidates.texts.len()
+                ),
+                Err(error) => format!(
+                    "status=error;update_pos={update_pos};visible={visible:?};candidate_count={};selection_index={selection_index};error={error:?}",
+                    candidates.texts.len()
+                ),
+            };
+            Self::log_client_performance(
+                request_id,
+                "sync_candidate_window_update",
+                "total",
+                total_start.elapsed(),
+                details,
+            );
+        }
+
+        result
     }
 
     #[inline]
@@ -2593,6 +2645,7 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    #[cfg(test)]
     fn plan_actions_for_user_action(
         composition: &Composition,
         action: &UserAction,
@@ -3005,139 +3058,213 @@ impl TextServiceFactory {
         wparam: WPARAM,
         lparam: LPARAM,
     ) -> Result<Option<(Vec<ClientAction>, CompositionState)>> {
-        let Some(context) = context else {
-            self.set_keyboard_disabled_state(true)?;
-            return Ok(None);
-        };
-        let keyboard_disabled = keyboard_disabled_from_context(context);
-        self.set_keyboard_disabled_state(keyboard_disabled)?;
-        if keyboard_disabled {
-            self.cancel_composition_for_disabled_context();
-            return Ok(None);
-        }
+        let standalone_trace = (current_input_trace_request_id().is_none()
+            && client_performance_log_enabled())
+        .then(ClientInputTraceGuard::begin);
+        let trace_request_id = current_input_trace_request_id().or_else(|| {
+            standalone_trace
+                .as_ref()
+                .map(ClientInputTraceGuard::request_id)
+        });
+        let total_start = trace_request_id.map(|_| Instant::now());
+        let result: Result<Option<(Vec<ClientAction>, CompositionState)>> = (|| {
+            let Some(context) = context else {
+                self.set_keyboard_disabled_state(true)?;
+                return Ok(None);
+            };
+            let keyboard_disabled = keyboard_disabled_from_context(context);
+            self.set_keyboard_disabled_state(keyboard_disabled)?;
+            if keyboard_disabled {
+                self.cancel_composition_for_disabled_context();
+                return Ok(None);
+            }
 
-        let is_ctrl_pressed = Self::is_ctrl_pressed();
-        let is_alt_pressed = Self::is_alt_pressed();
-        let is_shift_pressed = Self::is_shift_pressed();
-        let is_ctrl_space = is_ctrl_pressed && wparam.0 == 0x20;
-        let is_ctrl_enter = is_ctrl_pressed && wparam.0 == 0x0D;
-        let is_ctrl_down = is_ctrl_pressed && wparam.0 == 0x28;
-        let ctrl_conversion_function =
-            Self::ctrl_conversion_shortcut_function(wparam.0, is_ctrl_pressed, is_alt_pressed);
-        let is_shift_left = is_shift_pressed && wparam.0 == 0x25;
-        let is_shift_right = is_shift_pressed && wparam.0 == 0x27;
-        let is_shift_key = Self::is_shift_key(wparam);
-        let is_alt_backquote = Self::is_alt_backquote(wparam, lparam);
-        let app_config = Self::load_app_config_or_default();
+            let is_ctrl_pressed = Self::is_ctrl_pressed();
+            let is_alt_pressed = Self::is_alt_pressed();
+            let is_shift_pressed = Self::is_shift_pressed();
+            let is_ctrl_space = is_ctrl_pressed && wparam.0 == 0x20;
+            let is_ctrl_enter = is_ctrl_pressed && wparam.0 == 0x0D;
+            let is_ctrl_down = is_ctrl_pressed && wparam.0 == 0x28;
+            let ctrl_conversion_function =
+                Self::ctrl_conversion_shortcut_function(wparam.0, is_ctrl_pressed, is_alt_pressed);
+            let is_shift_left = is_shift_pressed && wparam.0 == 0x25;
+            let is_shift_right = is_shift_pressed && wparam.0 == 0x27;
+            let is_shift_key = Self::is_shift_key(wparam);
+            let is_alt_backquote = Self::is_alt_backquote(wparam, lparam);
+            let app_config_start = trace_request_id.map(|_| Instant::now());
+            let app_config = Self::load_app_config_or_default();
+            if let (Some(request_id), Some(app_config_start)) = (trace_request_id, app_config_start)
+            {
+                Self::log_client_performance(
+                    request_id,
+                    "process_key",
+                    "app_config_read",
+                    app_config_start.elapsed(),
+                    format!(
+                        "romaji_rows={};wparam={}",
+                        app_config.romaji_table.rows.len(),
+                        wparam.0
+                    ),
+                );
+            }
 
-        // check shortcut keys
-        if is_ctrl_pressed
-            && !is_ctrl_space
-            && !is_alt_backquote
-            && !is_ctrl_enter
-            && !is_ctrl_down
-            && ctrl_conversion_function.is_none()
-        {
-            self.clear_temporary_latin_shift_pending_if_needed(!Self::is_shift_key(wparam))?;
-            return Ok(None);
-        }
-
-        if is_ctrl_space || is_alt_backquote {
-            let shortcuts = &app_config.shortcuts;
-
-            if is_ctrl_space && !shortcuts.ctrl_space_toggle {
+            // check shortcut keys
+            if is_ctrl_pressed
+                && !is_ctrl_space
+                && !is_alt_backquote
+                && !is_ctrl_enter
+                && !is_ctrl_down
+                && ctrl_conversion_function.is_none()
+            {
                 self.clear_temporary_latin_shift_pending_if_needed(!Self::is_shift_key(wparam))?;
                 return Ok(None);
             }
 
-            if is_alt_backquote && !shortcuts.alt_backquote_toggle {
-                self.clear_temporary_latin_shift_pending_if_needed(!Self::is_shift_key(wparam))?;
-                return Ok(None);
+            if is_ctrl_space || is_alt_backquote {
+                let shortcuts = &app_config.shortcuts;
+
+                if is_ctrl_space && !shortcuts.ctrl_space_toggle {
+                    self.clear_temporary_latin_shift_pending_if_needed(!Self::is_shift_key(
+                        wparam,
+                    ))?;
+                    return Ok(None);
+                }
+
+                if is_alt_backquote && !shortcuts.alt_backquote_toggle {
+                    self.clear_temporary_latin_shift_pending_if_needed(!Self::is_shift_key(
+                        wparam,
+                    ))?;
+                    return Ok(None);
+                }
             }
-        }
 
-        #[allow(clippy::let_and_return)]
-        let (composition, mode) = {
-            let text_service = self.borrow()?;
-            let composition = text_service.borrow_composition()?.clone();
-            let mode = IMEState::input_mode()?;
-            (composition, mode)
-        };
-        let start_temporary_latin = !composition.temporary_latin
-            && mode == InputMode::Kana
-            && Self::is_shift_alphabet_shortcut(wparam, is_shift_pressed);
+            #[allow(clippy::let_and_return)]
+            let (composition, mode) = {
+                let text_service = self.borrow()?;
+                let composition = text_service.borrow_composition()?.clone();
+                let mode = IMEState::input_mode()?;
+                (composition, mode)
+            };
+            let start_temporary_latin = !composition.temporary_latin
+                && mode == InputMode::Kana
+                && Self::is_shift_alphabet_shortcut(wparam, is_shift_pressed);
 
-        if composition.temporary_latin && is_shift_key && !is_shift_left && !is_shift_right {
-            return Ok(Some((
-                vec![ClientAction::SetTemporaryLatinShiftPending(true)],
-                composition.state.clone(),
-            )));
-        }
+            if composition.temporary_latin && is_shift_key && !is_shift_left && !is_shift_right {
+                return Ok(Some((
+                    vec![ClientAction::SetTemporaryLatinShiftPending(true)],
+                    composition.state.clone(),
+                )));
+            }
 
-        let should_clear_shift_pending = composition.temporary_latin_shift_pending && !is_shift_key;
+            let should_clear_shift_pending =
+                composition.temporary_latin_shift_pending && !is_shift_key;
 
-        let action = if is_alt_backquote {
-            UserAction::ToggleInputMode
-        } else if is_ctrl_enter {
-            UserAction::CommitFirstClause
-        } else if is_ctrl_down {
-            UserAction::CommitAndNextClause
-        } else if let Some(function) = ctrl_conversion_function {
-            UserAction::Function(function)
-        } else if is_shift_left {
-            UserAction::AdjustClauseBoundary(-1)
-        } else if is_shift_right {
-            UserAction::AdjustClauseBoundary(1)
-        } else {
-            UserAction::try_from(wparam.0)?
-        };
+            let action = if is_alt_backquote {
+                UserAction::ToggleInputMode
+            } else if is_ctrl_enter {
+                UserAction::CommitFirstClause
+            } else if is_ctrl_down {
+                UserAction::CommitAndNextClause
+            } else if let Some(function) = ctrl_conversion_function {
+                UserAction::Function(function)
+            } else if is_shift_left {
+                UserAction::AdjustClauseBoundary(-1)
+            } else if is_shift_right {
+                UserAction::AdjustClauseBoundary(1)
+            } else {
+                UserAction::try_from(wparam.0)?
+            };
 
-        let Some((transition, mut actions)) = CompositionReducer::plan_actions_for_user_action(
-            &composition,
-            &action,
-            &mode,
-            is_shift_pressed,
-            &app_config,
-            start_temporary_latin,
-        ) else {
-            self.clear_temporary_latin_shift_pending_if_needed(should_clear_shift_pending)?;
-            return Ok(None);
-        };
+            let romaji_lookup_start = trace_request_id.map(|_| Instant::now());
+            let romaji_lookup = RomajiLookup::from_rows(&app_config.romaji_table.rows);
+            if let (Some(request_id), Some(romaji_lookup_start)) =
+                (trace_request_id, romaji_lookup_start)
+            {
+                Self::log_client_performance(
+                    request_id,
+                    "process_key",
+                    "romaji_lookup_build",
+                    romaji_lookup_start.elapsed(),
+                    format!(
+                        "rows={};max_input_len={};max_multi_char_input_len={}",
+                        app_config.romaji_table.rows.len(),
+                        romaji_lookup.max_input_len,
+                        romaji_lookup.max_multi_char_input_len
+                    ),
+                );
+            }
 
-        if composition.temporary_latin {
-            let should_reset_on_confirm = matches!(
-                action,
-                UserAction::Enter | UserAction::CommitAndNextClause | UserAction::CommitFirstClause
-            );
-            let should_reset_on_end = transition == CompositionState::None
-                || actions.iter().any(|current_action| {
+            let Some((transition, mut actions)) = Self::plan_actions_for_user_action_with_lookup(
+                &composition,
+                &action,
+                &mode,
+                is_shift_pressed,
+                &app_config,
+                &romaji_lookup,
+                start_temporary_latin,
+            ) else {
+                self.clear_temporary_latin_shift_pending_if_needed(should_clear_shift_pending)?;
+                return Ok(None);
+            };
+
+            if composition.temporary_latin {
+                let should_reset_on_confirm = matches!(
+                    action,
+                    UserAction::Enter
+                        | UserAction::CommitAndNextClause
+                        | UserAction::CommitFirstClause
+                );
+                let should_reset_on_end = transition == CompositionState::None
+                    || actions.iter().any(|current_action| {
+                        matches!(
+                            current_action,
+                            ClientAction::EndComposition | ClientAction::SetIMEMode(_)
+                        )
+                    });
+
+                if (should_reset_on_confirm || should_reset_on_end)
+                    && !actions.iter().any(|current_action| {
+                        matches!(current_action, ClientAction::SetTemporaryLatin(false))
+                    })
+                {
+                    actions.insert(0, ClientAction::SetTemporaryLatin(false));
+                }
+            }
+
+            if should_clear_shift_pending
+                && !actions.iter().any(|current_action| {
                     matches!(
                         current_action,
-                        ClientAction::EndComposition | ClientAction::SetIMEMode(_)
+                        ClientAction::SetTemporaryLatinShiftPending(_)
                     )
-                });
-
-            if (should_reset_on_confirm || should_reset_on_end)
-                && !actions.iter().any(|current_action| {
-                    matches!(current_action, ClientAction::SetTemporaryLatin(false))
                 })
             {
-                actions.insert(0, ClientAction::SetTemporaryLatin(false));
+                actions.insert(0, ClientAction::SetTemporaryLatinShiftPending(false));
             }
+
+            Ok(Some((actions, transition)))
+        })();
+
+        if let (Some(request_id), Some(total_start)) = (trace_request_id, total_start) {
+            let details = match &result {
+                Ok(Some((actions, transition))) => format!(
+                    "status=success;handled=true;actions={};transition={transition:?};wparam={}",
+                    actions.len(),
+                    wparam.0
+                ),
+                Ok(None) => format!("status=success;handled=false;wparam={}", wparam.0),
+                Err(error) => format!("status=error;wparam={};error={error:?}", wparam.0),
+            };
+            Self::log_client_performance(
+                request_id,
+                "process_key",
+                "total",
+                total_start.elapsed(),
+                details,
+            );
         }
 
-        if should_clear_shift_pending
-            && !actions.iter().any(|current_action| {
-                matches!(
-                    current_action,
-                    ClientAction::SetTemporaryLatinShiftPending(_)
-                )
-            })
-        {
-            actions.insert(0, ClientAction::SetTemporaryLatinShiftPending(false));
-        }
-
-        Ok(Some((actions, transition)))
+        result
     }
 
     #[tracing::instrument]
@@ -3186,6 +3313,8 @@ impl TextServiceFactory {
         wparam: WPARAM,
         lparam: LPARAM,
     ) -> Result<bool> {
+        let input_trace = client_performance_log_enabled().then(ClientInputTraceGuard::begin);
+        let total_start = input_trace.as_ref().map(|_| Instant::now());
         let result: Result<bool> = (|| {
             if let Some(context) = context {
                 self.borrow_mut()?.context = Some(context.clone());
@@ -3201,6 +3330,27 @@ impl TextServiceFactory {
                 Ok(false)
             }
         })();
+
+        if let (Some(input_trace), Some(total_start)) = (input_trace.as_ref(), total_start) {
+            let request_id = input_trace.request_id();
+            let details = match &result {
+                Ok(handled) => format!(
+                    "status=success;handled={handled};wparam={};lparam={}",
+                    wparam.0, lparam.0
+                ),
+                Err(error) => format!(
+                    "status=error;wparam={};lparam={};error={error:?}",
+                    wparam.0, lparam.0
+                ),
+            };
+            Self::log_client_performance(
+                request_id,
+                "handle_key",
+                "total",
+                total_start.elapsed(),
+                details,
+            );
+        }
 
         match result {
             Ok(handled) => Ok(handled),
@@ -3219,6 +3369,8 @@ impl TextServiceFactory {
         wparam: WPARAM,
         lparam: LPARAM,
     ) -> Result<bool> {
+        let input_trace = client_performance_log_enabled().then(ClientInputTraceGuard::begin);
+        let total_start = input_trace.as_ref().map(|_| Instant::now());
         let result: Result<bool> = (|| {
             if let Some(context) = context {
                 self.borrow_mut()?.context = Some(context.clone());
@@ -3234,6 +3386,27 @@ impl TextServiceFactory {
 
             Ok(false)
         })();
+
+        if let (Some(input_trace), Some(total_start)) = (input_trace.as_ref(), total_start) {
+            let request_id = input_trace.request_id();
+            let details = match &result {
+                Ok(handled) => format!(
+                    "status=success;handled={handled};wparam={};lparam={}",
+                    wparam.0, lparam.0
+                ),
+                Err(error) => format!(
+                    "status=error;wparam={};lparam={};error={error:?}",
+                    wparam.0, lparam.0
+                ),
+            };
+            Self::log_client_performance(
+                request_id,
+                "handle_key_up",
+                "total",
+                total_start.elapsed(),
+                details,
+            );
+        }
 
         match result {
             Ok(handled) => Ok(handled),
@@ -3275,241 +3448,119 @@ impl TextServiceFactory {
         actions: &[ClientAction],
         transition: CompositionState,
     ) -> Result<()> {
-        #[allow(clippy::let_and_return)]
-        let (composition, mode) = {
-            let text_service = self.borrow()?;
-            let composition = text_service.borrow_composition()?.clone();
-            let mode = IMEState::input_mode()?;
-            (composition, mode)
-        };
-        let app_config = Self::load_app_config_or_default();
-        let romaji_lookup = RomajiLookup::from_rows(&app_config.romaji_table.rows);
+        let trace_request_id = current_input_trace_request_id();
+        let total_start = trace_request_id.map(|_| Instant::now());
+        let requested_transition = transition.clone();
+        let result: Result<()> = (|| {
+            #[allow(clippy::let_and_return)]
+            let (composition, mode) = {
+                let text_service = self.borrow()?;
+                let composition = text_service.borrow_composition()?.clone();
+                let mode = IMEState::input_mode()?;
+                (composition, mode)
+            };
+            let app_config_start = trace_request_id.map(|_| Instant::now());
+            let app_config = Self::load_app_config_or_default();
+            if let (Some(request_id), Some(app_config_start)) = (trace_request_id, app_config_start)
+            {
+                Self::log_client_performance(
+                    request_id,
+                    "handle_action",
+                    "app_config_read",
+                    app_config_start.elapsed(),
+                    format!(
+                        "actions={};romaji_rows={}",
+                        actions.len(),
+                        app_config.romaji_table.rows.len()
+                    ),
+                );
+            }
+            let romaji_lookup_start = trace_request_id.map(|_| Instant::now());
+            let romaji_lookup = RomajiLookup::from_rows(&app_config.romaji_table.rows);
+            if let (Some(request_id), Some(romaji_lookup_start)) =
+                (trace_request_id, romaji_lookup_start)
+            {
+                Self::log_client_performance(
+                    request_id,
+                    "handle_action",
+                    "romaji_lookup_build",
+                    romaji_lookup_start.elapsed(),
+                    format!(
+                        "rows={};max_input_len={};max_multi_char_input_len={}",
+                        app_config.romaji_table.rows.len(),
+                        romaji_lookup.max_input_len,
+                        romaji_lookup.max_multi_char_input_len
+                    ),
+                );
+            }
 
-        let mut preview = composition.preview.clone();
-        let mut suffix = composition.suffix.clone();
-        let mut raw_input = composition.raw_input.clone();
-        let mut raw_hiragana = composition.raw_hiragana.clone();
-        let mut fixed_prefix = composition.fixed_prefix.clone();
-        let mut corresponding_count = composition.corresponding_count.clone();
-        let mut candidates = composition.candidates.clone();
-        let mut clause_snapshots = composition.clause_snapshots.clone();
-        let mut future_clause_snapshots = composition.future_clause_snapshots.clone();
-        let mut current_clause_is_split_derived = composition.current_clause_is_split_derived;
-        let mut current_clause_is_direct_split_remainder =
-            composition.current_clause_is_direct_split_remainder;
-        let mut current_clause_has_split_left_neighbor =
-            composition.current_clause_has_split_left_neighbor;
-        let mut current_clause_split_group_id = composition.current_clause_split_group_id;
-        let mut next_split_group_id = composition.next_split_group_id;
-        let mut selection_index = composition.selection_index;
-        let mut temporary_latin = composition.temporary_latin;
-        let mut temporary_latin_shift_pending = composition.temporary_latin_shift_pending;
-        let mut ipc_service = IMEState::ipc_service()?.context("ipc_service is None")?;
-        let mut transition = transition;
-        let mut deferred_clause_navigation_ready_ui_sync = None;
+            let mut preview = composition.preview.clone();
+            let mut suffix = composition.suffix.clone();
+            let mut raw_input = composition.raw_input.clone();
+            let mut raw_hiragana = composition.raw_hiragana.clone();
+            let mut fixed_prefix = composition.fixed_prefix.clone();
+            let mut corresponding_count = composition.corresponding_count.clone();
+            let mut candidates = composition.candidates.clone();
+            let mut clause_snapshots = composition.clause_snapshots.clone();
+            let mut future_clause_snapshots = composition.future_clause_snapshots.clone();
+            let mut current_clause_is_split_derived = composition.current_clause_is_split_derived;
+            let mut current_clause_is_direct_split_remainder =
+                composition.current_clause_is_direct_split_remainder;
+            let mut current_clause_has_split_left_neighbor =
+                composition.current_clause_has_split_left_neighbor;
+            let mut current_clause_split_group_id = composition.current_clause_split_group_id;
+            let mut next_split_group_id = composition.next_split_group_id;
+            let mut selection_index = composition.selection_index;
+            let mut temporary_latin = composition.temporary_latin;
+            let mut temporary_latin_shift_pending = composition.temporary_latin_shift_pending;
+            let mut ipc_service = IMEState::ipc_service()?.context("ipc_service is None")?;
+            let mut transition = transition;
+            let mut deferred_clause_navigation_ready_ui_sync = None;
 
-        self.update_context(&preview)?;
+            self.update_context(&preview)?;
 
-        for (action_index, action) in actions.iter().enumerate() {
-            match action {
-                ClientAction::StartComposition => {
-                    self.start_composition()?;
-                    if app_config.general.show_candidate_window_after_space {
-                        ipc_service.update_candidate_window(Some(false), None, None, None, None)?;
+            for (action_index, action) in actions.iter().enumerate() {
+                match action {
+                    ClientAction::StartComposition => {
+                        self.start_composition()?;
+                        if app_config.general.show_candidate_window_after_space {
+                            ipc_service.update_candidate_window(
+                                Some(false),
+                                None,
+                                None,
+                                None,
+                                None,
+                            )?;
+                        }
                     }
-                }
-                ClientAction::ShowCandidateWindow => {
-                    let position = self.candidate_window_position()?;
-                    ipc_service.update_candidate_window(Some(true), position, None, None, None)?;
-                }
-                ClientAction::EndComposition => {
-                    self.end_composition()?;
-                    selection_index = 0;
-                    corresponding_count = 0;
-                    temporary_latin = false;
-                    temporary_latin_shift_pending = false;
-                    preview.clear();
-                    suffix.clear();
-                    raw_input.clear();
-                    raw_hiragana.clear();
-                    fixed_prefix.clear();
-                    clause_snapshots.clear();
-                    future_clause_snapshots.clear();
-                    current_clause_is_split_derived = false;
-                    current_clause_is_direct_split_remainder = false;
-                    current_clause_has_split_left_neighbor = false;
-                    current_clause_split_group_id = None;
-                    next_split_group_id = 0;
-                    ipc_service.update_candidate_window(
-                        Some(false),
-                        None,
-                        Some(vec![]),
-                        Some(0),
-                        None,
-                    )?;
-                    ipc_service.clear_text()?;
-                }
-                ClientAction::AppendText(text) => {
-                    Self::clear_clause_caches(
-                        &mut clause_snapshots,
-                        &mut future_clause_snapshots,
-                        &mut ipc_service,
-                    )?;
-                    let resolved_symbol_text = match mode {
-                        InputMode::Kana => Self::resolve_symbol_input_text_with_lookup(
-                            &raw_input,
-                            text,
-                            &app_config,
-                            &romaji_lookup,
-                        ),
-                        InputMode::Latin => None,
-                    };
-                    let text = match mode {
-                        InputMode::Kana => resolved_symbol_text.unwrap_or_else(|| text.to_string()),
-                        InputMode::Latin => text.to_string(),
-                    };
-
-                    current_clause_is_split_derived = false;
-                    current_clause_is_direct_split_remainder = false;
-                    current_clause_has_split_left_neighbor = false;
-                    current_clause_split_group_id = None;
-                    candidates = ipc_service.append_text_with_context(text.clone(), &candidates)?;
-                    raw_input.push_str(&text);
-                    if let Some(selected) = Self::select_candidate(&candidates, selection_index) {
-                        selection_index = selected.index;
-                        corresponding_count = selected.corresponding_count;
-                        preview = Self::merge_preview_with_prefix(&fixed_prefix, &selected.text);
-                        suffix = selected.sub_text.clone();
-                        raw_hiragana = selected.hiragana;
-
-                        self.set_text(&preview, &suffix)?;
-                        self.sync_candidate_window_after_text_update(
-                            &mut ipc_service,
-                            &candidates,
-                            selection_index,
-                            &app_config,
-                            &transition,
-                        )?;
-                    }
-                }
-                ClientAction::AppendTextRaw(text) => {
-                    Self::clear_clause_caches(
-                        &mut clause_snapshots,
-                        &mut future_clause_snapshots,
-                        &mut ipc_service,
-                    )?;
-                    current_clause_is_split_derived = false;
-                    current_clause_is_direct_split_remainder = false;
-                    current_clause_has_split_left_neighbor = false;
-                    current_clause_split_group_id = None;
-                    candidates = ipc_service.append_text_with_context(text.clone(), &candidates)?;
-                    raw_input.push_str(text);
-                    if let Some(selected) = Self::select_candidate(&candidates, selection_index) {
-                        selection_index = selected.index;
-                        corresponding_count = selected.corresponding_count;
-                        preview = Self::merge_preview_with_prefix(&fixed_prefix, &selected.text);
-                        suffix = selected.sub_text.clone();
-                        raw_hiragana = selected.hiragana;
-
-                        self.set_text(&preview, &suffix)?;
-                        self.sync_candidate_window_after_text_update(
-                            &mut ipc_service,
-                            &candidates,
-                            selection_index,
-                            &app_config,
-                            &transition,
-                        )?;
-                    }
-                }
-                ClientAction::AppendTextDirect(text) => {
-                    Self::clear_clause_caches(
-                        &mut clause_snapshots,
-                        &mut future_clause_snapshots,
-                        &mut ipc_service,
-                    )?;
-                    current_clause_is_split_derived = false;
-                    current_clause_is_direct_split_remainder = false;
-                    current_clause_has_split_left_neighbor = false;
-                    current_clause_split_group_id = None;
-                    candidates =
-                        ipc_service.append_text_direct_with_context(text.clone(), &candidates)?;
-                    raw_input.push_str(text);
-                    if let Some(selected) = Self::select_candidate(&candidates, selection_index) {
-                        selection_index = selected.index;
-                        corresponding_count = selected.corresponding_count;
-                        preview = Self::merge_preview_with_prefix(&fixed_prefix, &selected.text);
-                        suffix = selected.sub_text.clone();
-                        raw_hiragana = selected.hiragana;
-
-                        self.set_text(&preview, &suffix)?;
-                        self.sync_candidate_window_after_text_update(
-                            &mut ipc_service,
-                            &candidates,
-                            selection_index,
-                            &app_config,
-                            &transition,
-                        )?;
-                    }
-                }
-                ClientAction::CommitTextDirect(text) => {
-                    self.start_composition()?;
-                    self.set_text(text, "")?;
-                    self.end_composition()?;
-                }
-                ClientAction::RemoveText => {
-                    Self::clear_clause_caches(
-                        &mut clause_snapshots,
-                        &mut future_clause_snapshots,
-                        &mut ipc_service,
-                    )?;
-                    current_clause_is_split_derived = false;
-                    current_clause_is_direct_split_remainder = false;
-                    current_clause_has_split_left_neighbor = false;
-                    current_clause_split_group_id = None;
-                    raw_input.pop();
-                    candidates = ipc_service.remove_text()?;
-                    if let Some(selected) = Self::select_candidate(&candidates, selection_index) {
-                        selection_index = selected.index;
-                        corresponding_count = selected.corresponding_count;
-
-                        preview = Self::merge_preview_with_prefix(&fixed_prefix, &selected.text);
-                        suffix = selected.sub_text.clone();
-                        raw_hiragana = selected.hiragana;
-
-                        self.set_text(&preview, &suffix)?;
-                        self.sync_candidate_window_update(
-                            &mut ipc_service,
-                            &candidates,
-                            selection_index,
+                    ClientAction::ShowCandidateWindow => {
+                        let position = self.candidate_window_position()?;
+                        ipc_service.update_candidate_window(
+                            Some(true),
+                            position,
                             None,
-                            false,
+                            None,
+                            None,
                         )?;
-                    } else {
-                        // Server side text is fully removed. Close TSF composition too
-                        // so preedit text does not linger in an inconsistent state.
-                        let committed_prefix = fixed_prefix.clone();
-
-                        transition = CompositionState::None;
+                    }
+                    ClientAction::EndComposition => {
+                        self.end_composition()?;
                         selection_index = 0;
                         corresponding_count = 0;
                         temporary_latin = false;
                         temporary_latin_shift_pending = false;
+                        preview.clear();
                         suffix.clear();
                         raw_input.clear();
                         raw_hiragana.clear();
+                        fixed_prefix.clear();
                         clause_snapshots.clear();
                         future_clause_snapshots.clear();
                         current_clause_is_split_derived = false;
                         current_clause_is_direct_split_remainder = false;
                         current_clause_has_split_left_neighbor = false;
                         current_clause_split_group_id = None;
-
-                        if committed_prefix.is_empty() {
-                            self.set_text("", "")?;
-                        } else {
-                            self.set_text(&committed_prefix, "")?;
-                        }
-                        self.end_composition()?;
+                        next_split_group_id = 0;
                         ipc_service.update_candidate_window(
                             Some(false),
                             None,
@@ -3518,82 +3569,294 @@ impl TextServiceFactory {
                             None,
                         )?;
                         ipc_service.clear_text()?;
-
-                        preview.clear();
-                        fixed_prefix.clear();
                     }
-                }
-                ClientAction::MoveCursor(offset) => {
-                    candidates = ipc_service.move_cursor(*offset)?;
-                    if let Some(selected) = Self::select_candidate(&candidates, selection_index) {
-                        selection_index = selected.index;
-                        corresponding_count = selected.corresponding_count;
-                        preview = Self::merge_preview_with_prefix(&fixed_prefix, &selected.text);
-                        suffix = selected.sub_text.clone();
-                        raw_hiragana = selected.hiragana;
-
-                        self.set_text(&preview, &suffix)?;
-                        self.sync_candidate_window_update(
-                            &mut ipc_service,
-                            &candidates,
-                            selection_index,
-                            None,
-                            true,
-                        )?;
-                    }
-                }
-                ClientAction::EnsureClauseNavigationReady => {
-                    Self::log_clause_action_state(
-                        "before",
-                        action,
-                        &preview,
-                        &suffix,
-                        &raw_input,
-                        &raw_hiragana,
-                        &fixed_prefix,
-                        corresponding_count,
-                        selection_index,
-                        &candidates,
-                        &clause_snapshots,
-                        &future_clause_snapshots,
-                    );
-                    let effect = {
-                        let mut state = ClauseState::from_composition_parts(
-                            &mut preview,
-                            &mut suffix,
-                            &mut raw_input,
-                            &mut raw_hiragana,
-                            &mut fixed_prefix,
-                            &mut corresponding_count,
-                            &mut selection_index,
-                            &mut candidates,
+                    ClientAction::AppendText(text) => {
+                        Self::clear_clause_caches(
                             &mut clause_snapshots,
                             &mut future_clause_snapshots,
-                            &mut current_clause_is_split_derived,
-                            &mut current_clause_is_direct_split_remainder,
-                            &mut current_clause_has_split_left_neighbor,
-                            &mut current_clause_split_group_id,
-                            &mut next_split_group_id,
-                        );
-                        let transition = ClauseState::transition_with_backend(
-                            &mut state,
-                            ClauseCommand::StartClauseNavigation,
-                            ClauseTransitionInput::default(),
                             &mut ipc_service,
                         )?;
-                        let effect = transition.effect;
-                        ClauseState::write_back(state);
-                        effect
-                    };
+                        let resolved_symbol_text = match mode {
+                            InputMode::Kana => Self::resolve_symbol_input_text_with_lookup(
+                                &raw_input,
+                                text,
+                                &app_config,
+                                &romaji_lookup,
+                            ),
+                            InputMode::Latin => None,
+                        };
+                        let text = match mode {
+                            InputMode::Kana => {
+                                resolved_symbol_text.unwrap_or_else(|| text.to_string())
+                            }
+                            InputMode::Latin => text.to_string(),
+                        };
 
-                    if effect.applied {
-                        let defer_ui_sync =
-                            Self::should_defer_clause_navigation_ready_sync(actions, action_index);
-                        let ready_ui_sync = Self::clause_navigation_ready_ui_sync(effect);
-                        if defer_ui_sync {
-                            deferred_clause_navigation_ready_ui_sync = ready_ui_sync;
+                        current_clause_is_split_derived = false;
+                        current_clause_is_direct_split_remainder = false;
+                        current_clause_has_split_left_neighbor = false;
+                        current_clause_split_group_id = None;
+                        candidates =
+                            ipc_service.append_text_with_context(text.clone(), &candidates)?;
+                        raw_input.push_str(&text);
+                        if let Some(selected) = Self::select_candidate(&candidates, selection_index)
+                        {
+                            selection_index = selected.index;
+                            corresponding_count = selected.corresponding_count;
+                            preview =
+                                Self::merge_preview_with_prefix(&fixed_prefix, &selected.text);
+                            suffix = selected.sub_text.clone();
+                            raw_hiragana = selected.hiragana;
+
+                            self.set_text(&preview, &suffix)?;
+                            self.sync_candidate_window_after_text_update(
+                                &mut ipc_service,
+                                &candidates,
+                                selection_index,
+                                &app_config,
+                                &transition,
+                            )?;
+                        }
+                    }
+                    ClientAction::AppendTextRaw(text) => {
+                        Self::clear_clause_caches(
+                            &mut clause_snapshots,
+                            &mut future_clause_snapshots,
+                            &mut ipc_service,
+                        )?;
+                        current_clause_is_split_derived = false;
+                        current_clause_is_direct_split_remainder = false;
+                        current_clause_has_split_left_neighbor = false;
+                        current_clause_split_group_id = None;
+                        candidates =
+                            ipc_service.append_text_with_context(text.clone(), &candidates)?;
+                        raw_input.push_str(text);
+                        if let Some(selected) = Self::select_candidate(&candidates, selection_index)
+                        {
+                            selection_index = selected.index;
+                            corresponding_count = selected.corresponding_count;
+                            preview =
+                                Self::merge_preview_with_prefix(&fixed_prefix, &selected.text);
+                            suffix = selected.sub_text.clone();
+                            raw_hiragana = selected.hiragana;
+
+                            self.set_text(&preview, &suffix)?;
+                            self.sync_candidate_window_after_text_update(
+                                &mut ipc_service,
+                                &candidates,
+                                selection_index,
+                                &app_config,
+                                &transition,
+                            )?;
+                        }
+                    }
+                    ClientAction::AppendTextDirect(text) => {
+                        Self::clear_clause_caches(
+                            &mut clause_snapshots,
+                            &mut future_clause_snapshots,
+                            &mut ipc_service,
+                        )?;
+                        current_clause_is_split_derived = false;
+                        current_clause_is_direct_split_remainder = false;
+                        current_clause_has_split_left_neighbor = false;
+                        current_clause_split_group_id = None;
+                        candidates = ipc_service
+                            .append_text_direct_with_context(text.clone(), &candidates)?;
+                        raw_input.push_str(text);
+                        if let Some(selected) = Self::select_candidate(&candidates, selection_index)
+                        {
+                            selection_index = selected.index;
+                            corresponding_count = selected.corresponding_count;
+                            preview =
+                                Self::merge_preview_with_prefix(&fixed_prefix, &selected.text);
+                            suffix = selected.sub_text.clone();
+                            raw_hiragana = selected.hiragana;
+
+                            self.set_text(&preview, &suffix)?;
+                            self.sync_candidate_window_after_text_update(
+                                &mut ipc_service,
+                                &candidates,
+                                selection_index,
+                                &app_config,
+                                &transition,
+                            )?;
+                        }
+                    }
+                    ClientAction::CommitTextDirect(text) => {
+                        self.start_composition()?;
+                        self.set_text(text, "")?;
+                        self.end_composition()?;
+                    }
+                    ClientAction::RemoveText => {
+                        Self::clear_clause_caches(
+                            &mut clause_snapshots,
+                            &mut future_clause_snapshots,
+                            &mut ipc_service,
+                        )?;
+                        current_clause_is_split_derived = false;
+                        current_clause_is_direct_split_remainder = false;
+                        current_clause_has_split_left_neighbor = false;
+                        current_clause_split_group_id = None;
+                        raw_input.pop();
+                        candidates = ipc_service.remove_text()?;
+                        if let Some(selected) = Self::select_candidate(&candidates, selection_index)
+                        {
+                            selection_index = selected.index;
+                            corresponding_count = selected.corresponding_count;
+
+                            preview =
+                                Self::merge_preview_with_prefix(&fixed_prefix, &selected.text);
+                            suffix = selected.sub_text.clone();
+                            raw_hiragana = selected.hiragana;
+
+                            self.set_text(&preview, &suffix)?;
+                            self.sync_candidate_window_update(
+                                &mut ipc_service,
+                                &candidates,
+                                selection_index,
+                                None,
+                                false,
+                            )?;
+                        } else {
+                            // Server side text is fully removed. Close TSF composition too
+                            // so preedit text does not linger in an inconsistent state.
+                            let committed_prefix = fixed_prefix.clone();
+
+                            transition = CompositionState::None;
+                            selection_index = 0;
+                            corresponding_count = 0;
+                            temporary_latin = false;
+                            temporary_latin_shift_pending = false;
+                            suffix.clear();
+                            raw_input.clear();
+                            raw_hiragana.clear();
+                            clause_snapshots.clear();
+                            future_clause_snapshots.clear();
+                            current_clause_is_split_derived = false;
+                            current_clause_is_direct_split_remainder = false;
+                            current_clause_has_split_left_neighbor = false;
+                            current_clause_split_group_id = None;
+
+                            if committed_prefix.is_empty() {
+                                self.set_text("", "")?;
+                            } else {
+                                self.set_text(&committed_prefix, "")?;
+                            }
+                            self.end_composition()?;
+                            ipc_service.update_candidate_window(
+                                Some(false),
+                                None,
+                                Some(vec![]),
+                                Some(0),
+                                None,
+                            )?;
+                            ipc_service.clear_text()?;
+
+                            preview.clear();
+                            fixed_prefix.clear();
+                        }
+                    }
+                    ClientAction::MoveCursor(offset) => {
+                        candidates = ipc_service.move_cursor(*offset)?;
+                        if let Some(selected) = Self::select_candidate(&candidates, selection_index)
+                        {
+                            selection_index = selected.index;
+                            corresponding_count = selected.corresponding_count;
+                            preview =
+                                Self::merge_preview_with_prefix(&fixed_prefix, &selected.text);
+                            suffix = selected.sub_text.clone();
+                            raw_hiragana = selected.hiragana;
+
+                            self.set_text(&preview, &suffix)?;
+                            self.sync_candidate_window_update(
+                                &mut ipc_service,
+                                &candidates,
+                                selection_index,
+                                None,
+                                true,
+                            )?;
+                        }
+                    }
+                    ClientAction::EnsureClauseNavigationReady => {
+                        Self::log_clause_action_state(
+                            "before",
+                            action,
+                            &preview,
+                            &suffix,
+                            &raw_input,
+                            &raw_hiragana,
+                            &fixed_prefix,
+                            corresponding_count,
+                            selection_index,
+                            &candidates,
+                            &clause_snapshots,
+                            &future_clause_snapshots,
+                        );
+                        let effect = {
+                            let mut state = ClauseState::from_composition_parts(
+                                &mut preview,
+                                &mut suffix,
+                                &mut raw_input,
+                                &mut raw_hiragana,
+                                &mut fixed_prefix,
+                                &mut corresponding_count,
+                                &mut selection_index,
+                                &mut candidates,
+                                &mut clause_snapshots,
+                                &mut future_clause_snapshots,
+                                &mut current_clause_is_split_derived,
+                                &mut current_clause_is_direct_split_remainder,
+                                &mut current_clause_has_split_left_neighbor,
+                                &mut current_clause_split_group_id,
+                                &mut next_split_group_id,
+                            );
+                            let transition = ClauseState::transition_with_backend(
+                                &mut state,
+                                ClauseCommand::StartClauseNavigation,
+                                ClauseTransitionInput::default(),
+                                &mut ipc_service,
+                            )?;
+                            let effect = transition.effect;
+                            ClauseState::write_back(state);
+                            effect
+                        };
+
+                        if effect.applied {
+                            let defer_ui_sync = Self::should_defer_clause_navigation_ready_sync(
+                                actions,
+                                action_index,
+                            );
+                            let ready_ui_sync = Self::clause_navigation_ready_ui_sync(effect);
+                            if defer_ui_sync {
+                                deferred_clause_navigation_ready_ui_sync = ready_ui_sync;
+                                Self::log_clause_action_state(
+                                    "defer",
+                                    action,
+                                    &preview,
+                                    &suffix,
+                                    &raw_input,
+                                    &raw_hiragana,
+                                    &fixed_prefix,
+                                    corresponding_count,
+                                    selection_index,
+                                    &candidates,
+                                    &clause_snapshots,
+                                    &future_clause_snapshots,
+                                );
+                                continue;
+                            }
+
+                            self.sync_clause_action_ui(
+                                &preview,
+                                &suffix,
+                                &candidates,
+                                selection_index,
+                                &mut ipc_service,
+                                ready_ui_sync.and_then(|sync| sync.visible),
+                                effect.update_pos,
+                            )?;
                             Self::log_clause_action_state(
-                                "defer",
+                                "after",
                                 action,
                                 &preview,
                                 &suffix,
@@ -3606,569 +3869,583 @@ impl TextServiceFactory {
                                 &clause_snapshots,
                                 &future_clause_snapshots,
                             );
-                            continue;
+                        } else {
+                            Self::log_clause_action_state(
+                                "skip",
+                                action,
+                                &preview,
+                                &suffix,
+                                &raw_input,
+                                &raw_hiragana,
+                                &fixed_prefix,
+                                corresponding_count,
+                                selection_index,
+                                &candidates,
+                                &clause_snapshots,
+                                &future_clause_snapshots,
+                            );
+                        }
+                    }
+                    ClientAction::MoveClause(direction) => {
+                        Self::log_clause_action_state(
+                            "before",
+                            action,
+                            &preview,
+                            &suffix,
+                            &raw_input,
+                            &raw_hiragana,
+                            &fixed_prefix,
+                            corresponding_count,
+                            selection_index,
+                            &candidates,
+                            &clause_snapshots,
+                            &future_clause_snapshots,
+                        );
+                        let effect = {
+                            let mut state = ClauseState::from_composition_parts(
+                                &mut preview,
+                                &mut suffix,
+                                &mut raw_input,
+                                &mut raw_hiragana,
+                                &mut fixed_prefix,
+                                &mut corresponding_count,
+                                &mut selection_index,
+                                &mut candidates,
+                                &mut clause_snapshots,
+                                &mut future_clause_snapshots,
+                                &mut current_clause_is_split_derived,
+                                &mut current_clause_is_direct_split_remainder,
+                                &mut current_clause_has_split_left_neighbor,
+                                &mut current_clause_split_group_id,
+                                &mut next_split_group_id,
+                            );
+                            let transition = ClauseState::transition_with_backend(
+                                &mut state,
+                                ClauseCommand::MoveBy(*direction),
+                                ClauseTransitionInput::default(),
+                                &mut ipc_service,
+                            )?;
+                            let effect = transition.effect;
+                            ClauseState::write_back(state);
+                            effect
+                        };
+
+                        let deferred_ready_ui_sync =
+                            Self::deferred_clause_navigation_ready_ui_sync_after_move(
+                                deferred_clause_navigation_ready_ui_sync.take(),
+                                effect,
+                            );
+                        if effect.applied {
+                            self.sync_clause_action_ui(
+                                &preview,
+                                &suffix,
+                                &candidates,
+                                selection_index,
+                                &mut ipc_service,
+                                deferred_ready_ui_sync.and_then(|sync| sync.visible),
+                                effect.update_pos,
+                            )?;
+                            Self::log_clause_action_state(
+                                "after",
+                                action,
+                                &preview,
+                                &suffix,
+                                &raw_input,
+                                &raw_hiragana,
+                                &fixed_prefix,
+                                corresponding_count,
+                                selection_index,
+                                &candidates,
+                                &clause_snapshots,
+                                &future_clause_snapshots,
+                            );
+                        } else if let Some(sync) = deferred_ready_ui_sync {
+                            self.sync_clause_action_ui(
+                                &preview,
+                                &suffix,
+                                &candidates,
+                                selection_index,
+                                &mut ipc_service,
+                                sync.visible,
+                                sync.update_pos,
+                            )?;
+                            Self::log_clause_action_state(
+                                "after-deferred",
+                                action,
+                                &preview,
+                                &suffix,
+                                &raw_input,
+                                &raw_hiragana,
+                                &fixed_prefix,
+                                corresponding_count,
+                                selection_index,
+                                &candidates,
+                                &clause_snapshots,
+                                &future_clause_snapshots,
+                            );
+                        } else {
+                            Self::log_clause_action_state(
+                                "skip",
+                                action,
+                                &preview,
+                                &suffix,
+                                &raw_input,
+                                &raw_hiragana,
+                                &fixed_prefix,
+                                corresponding_count,
+                                selection_index,
+                                &candidates,
+                                &clause_snapshots,
+                                &future_clause_snapshots,
+                            );
+                        }
+                    }
+                    ClientAction::AdjustBoundary(direction) => {
+                        Self::log_clause_action_state(
+                            "before",
+                            action,
+                            &preview,
+                            &suffix,
+                            &raw_input,
+                            &raw_hiragana,
+                            &fixed_prefix,
+                            corresponding_count,
+                            selection_index,
+                            &candidates,
+                            &clause_snapshots,
+                            &future_clause_snapshots,
+                        );
+                        let effect = {
+                            let mut state = ClauseState::from_composition_parts(
+                                &mut preview,
+                                &mut suffix,
+                                &mut raw_input,
+                                &mut raw_hiragana,
+                                &mut fixed_prefix,
+                                &mut corresponding_count,
+                                &mut selection_index,
+                                &mut candidates,
+                                &mut clause_snapshots,
+                                &mut future_clause_snapshots,
+                                &mut current_clause_is_split_derived,
+                                &mut current_clause_is_direct_split_remainder,
+                                &mut current_clause_has_split_left_neighbor,
+                                &mut current_clause_split_group_id,
+                                &mut next_split_group_id,
+                            );
+                            let transition = ClauseState::transition_with_backend(
+                                &mut state,
+                                ClauseCommand::AdjustBoundary(*direction),
+                                ClauseTransitionInput::default(),
+                                &mut ipc_service,
+                            )?;
+                            let effect = transition.effect;
+                            ClauseState::write_back(state);
+                            effect
+                        };
+
+                        if effect.applied {
+                            self.sync_clause_action_ui(
+                                &preview,
+                                &suffix,
+                                &candidates,
+                                selection_index,
+                                &mut ipc_service,
+                                None,
+                                effect.update_pos,
+                            )?;
+                            Self::log_clause_action_state(
+                                "after",
+                                action,
+                                &preview,
+                                &suffix,
+                                &raw_input,
+                                &raw_hiragana,
+                                &fixed_prefix,
+                                corresponding_count,
+                                selection_index,
+                                &candidates,
+                                &clause_snapshots,
+                                &future_clause_snapshots,
+                            );
+                        } else {
+                            Self::log_clause_action_state(
+                                "skip",
+                                action,
+                                &preview,
+                                &suffix,
+                                &raw_input,
+                                &raw_hiragana,
+                                &fixed_prefix,
+                                corresponding_count,
+                                selection_index,
+                                &candidates,
+                                &clause_snapshots,
+                                &future_clause_snapshots,
+                            );
+                        }
+                    }
+                    ClientAction::SetIMEMode(mode) => {
+                        self.start_composition()?;
+                        let position = self.candidate_window_position()?;
+                        self.end_composition()?;
+
+                        IMEState::set_input_mode(mode.clone())?;
+
+                        // update the language bar
+                        self.update_lang_bar()?;
+
+                        let mode = match mode {
+                            InputMode::Latin => "A",
+                            InputMode::Kana => "あ",
+                        };
+
+                        ipc_service.update_candidate_window(
+                            None,
+                            position,
+                            None,
+                            None,
+                            Some(mode),
+                        )?;
+
+                        selection_index = 0;
+                        corresponding_count = 0;
+                        temporary_latin = false;
+                        temporary_latin_shift_pending = false;
+                        preview.clear();
+                        suffix.clear();
+                        raw_input.clear();
+                        raw_hiragana.clear();
+                        fixed_prefix.clear();
+                        clause_snapshots.clear();
+                        future_clause_snapshots.clear();
+                        current_clause_is_split_derived = false;
+                        current_clause_is_direct_split_remainder = false;
+                        current_clause_has_split_left_neighbor = false;
+                        current_clause_split_group_id = None;
+                        next_split_group_id = 0;
+                        ipc_service.clear_text()?;
+                    }
+                    ClientAction::SetSelection(selection) => {
+                        Self::log_clause_action_state(
+                            "before",
+                            action,
+                            &preview,
+                            &suffix,
+                            &raw_input,
+                            &raw_hiragana,
+                            &fixed_prefix,
+                            corresponding_count,
+                            selection_index,
+                            &candidates,
+                            &clause_snapshots,
+                            &future_clause_snapshots,
+                        );
+                        let effect = {
+                            let mut state = ClauseState::from_composition_parts(
+                                &mut preview,
+                                &mut suffix,
+                                &mut raw_input,
+                                &mut raw_hiragana,
+                                &mut fixed_prefix,
+                                &mut corresponding_count,
+                                &mut selection_index,
+                                &mut candidates,
+                                &mut clause_snapshots,
+                                &mut future_clause_snapshots,
+                                &mut current_clause_is_split_derived,
+                                &mut current_clause_is_direct_split_remainder,
+                                &mut current_clause_has_split_left_neighbor,
+                                &mut current_clause_split_group_id,
+                                &mut next_split_group_id,
+                            );
+                            let transition = ClauseState::transition_without_backend(
+                                &mut state,
+                                ClauseCommand::SetSelection(selection),
+                            );
+                            let effect = transition.effect;
+                            ClauseState::write_back(state);
+                            effect
+                        };
+
+                        if effect.applied {
+                            self.sync_clause_action_ui(
+                                &preview,
+                                &suffix,
+                                &candidates,
+                                selection_index,
+                                &mut ipc_service,
+                                None,
+                                effect.update_pos,
+                            )?;
+                            Self::log_clause_action_state(
+                                "after",
+                                action,
+                                &preview,
+                                &suffix,
+                                &raw_input,
+                                &raw_hiragana,
+                                &fixed_prefix,
+                                corresponding_count,
+                                selection_index,
+                                &candidates,
+                                &clause_snapshots,
+                                &future_clause_snapshots,
+                            );
+                        } else {
+                            Self::log_clause_action_state(
+                                "skip",
+                                action,
+                                &preview,
+                                &suffix,
+                                &raw_input,
+                                &raw_hiragana,
+                                &fixed_prefix,
+                                corresponding_count,
+                                selection_index,
+                                &candidates,
+                                &clause_snapshots,
+                                &future_clause_snapshots,
+                            );
+                        }
+                    }
+                    ClientAction::ShrinkText(text) => {
+                        fixed_prefix.clear();
+                        Self::clear_clause_caches(
+                            &mut clause_snapshots,
+                            &mut future_clause_snapshots,
+                            &mut ipc_service,
+                        )?;
+                        current_clause_is_split_derived = false;
+                        current_clause_is_direct_split_remainder = false;
+                        current_clause_has_split_left_neighbor = false;
+                        current_clause_split_group_id = None;
+                        let shrunk_raw_input =
+                            Self::current_raw_input_suffix(&raw_input, corresponding_count);
+                        let resolved_symbol_text = match mode {
+                            InputMode::Kana => Self::resolve_symbol_input_text_with_lookup(
+                                &shrunk_raw_input,
+                                text,
+                                &app_config,
+                                &romaji_lookup,
+                            ),
+                            InputMode::Latin => None,
+                        };
+                        let mut updated_raw_input = shrunk_raw_input.clone();
+                        updated_raw_input.push_str(text);
+
+                        let shrunk_candidates = ipc_service.shrink_text(corresponding_count)?;
+                        let text = match mode {
+                            InputMode::Kana => {
+                                resolved_symbol_text.unwrap_or_else(|| text.to_string())
+                            }
+                            InputMode::Latin => text.to_string(),
+                        };
+                        candidates =
+                            ipc_service.append_text_with_context(text, &shrunk_candidates)?;
+                        raw_input = updated_raw_input;
+                        selection_index = 0;
+
+                        if let Some(selected) = Self::select_candidate(&candidates, selection_index)
+                        {
+                            self.shift_start(&preview, &selected.text)?;
+
+                            selection_index = selected.index;
+                            corresponding_count = selected.corresponding_count;
+                            preview = selected.text.clone();
+                            suffix = selected.sub_text.clone();
+                            raw_hiragana = selected.hiragana;
+
+                            self.sync_candidate_window_update(
+                                &mut ipc_service,
+                                &candidates,
+                                selection_index,
+                                None,
+                                true,
+                            )?;
                         }
 
-                        self.sync_clause_action_ui(
-                            &preview,
-                            &suffix,
-                            &candidates,
-                            selection_index,
-                            &mut ipc_service,
-                            ready_ui_sync.and_then(|sync| sync.visible),
-                            effect.update_pos,
-                        )?;
-                        Self::log_clause_action_state(
-                            "after",
-                            action,
-                            &preview,
-                            &suffix,
-                            &raw_input,
-                            &raw_hiragana,
-                            &fixed_prefix,
-                            corresponding_count,
-                            selection_index,
-                            &candidates,
-                            &clause_snapshots,
-                            &future_clause_snapshots,
-                        );
-                    } else {
-                        Self::log_clause_action_state(
-                            "skip",
-                            action,
-                            &preview,
-                            &suffix,
-                            &raw_input,
-                            &raw_hiragana,
-                            &fixed_prefix,
-                            corresponding_count,
-                            selection_index,
-                            &candidates,
-                            &clause_snapshots,
-                            &future_clause_snapshots,
-                        );
+                        transition = CompositionState::Composing;
                     }
-                }
-                ClientAction::MoveClause(direction) => {
-                    Self::log_clause_action_state(
-                        "before",
-                        action,
-                        &preview,
-                        &suffix,
-                        &raw_input,
-                        &raw_hiragana,
-                        &fixed_prefix,
-                        corresponding_count,
-                        selection_index,
-                        &candidates,
-                        &clause_snapshots,
-                        &future_clause_snapshots,
-                    );
-                    let effect = {
-                        let mut state = ClauseState::from_composition_parts(
-                            &mut preview,
-                            &mut suffix,
-                            &mut raw_input,
-                            &mut raw_hiragana,
-                            &mut fixed_prefix,
-                            &mut corresponding_count,
-                            &mut selection_index,
-                            &mut candidates,
+                    ClientAction::ShrinkTextRaw(text) => {
+                        fixed_prefix.clear();
+                        Self::clear_clause_caches(
                             &mut clause_snapshots,
                             &mut future_clause_snapshots,
-                            &mut current_clause_is_split_derived,
-                            &mut current_clause_is_direct_split_remainder,
-                            &mut current_clause_has_split_left_neighbor,
-                            &mut current_clause_split_group_id,
-                            &mut next_split_group_id,
-                        );
-                        let transition = ClauseState::transition_with_backend(
-                            &mut state,
-                            ClauseCommand::MoveBy(*direction),
-                            ClauseTransitionInput::default(),
                             &mut ipc_service,
                         )?;
-                        let effect = transition.effect;
-                        ClauseState::write_back(state);
-                        effect
-                    };
+                        current_clause_is_split_derived = false;
+                        current_clause_is_direct_split_remainder = false;
+                        current_clause_has_split_left_neighbor = false;
+                        current_clause_split_group_id = None;
+                        let mut updated_raw_input =
+                            Self::current_raw_input_suffix(&raw_input, corresponding_count);
+                        updated_raw_input.push_str(text);
 
-                    let deferred_ready_ui_sync =
-                        Self::deferred_clause_navigation_ready_ui_sync_after_move(
-                            deferred_clause_navigation_ready_ui_sync.take(),
-                            effect,
-                        );
-                    if effect.applied {
-                        self.sync_clause_action_ui(
-                            &preview,
-                            &suffix,
-                            &candidates,
-                            selection_index,
-                            &mut ipc_service,
-                            deferred_ready_ui_sync.and_then(|sync| sync.visible),
-                            effect.update_pos,
-                        )?;
-                        Self::log_clause_action_state(
-                            "after",
-                            action,
-                            &preview,
-                            &suffix,
-                            &raw_input,
-                            &raw_hiragana,
-                            &fixed_prefix,
-                            corresponding_count,
-                            selection_index,
-                            &candidates,
-                            &clause_snapshots,
-                            &future_clause_snapshots,
-                        );
-                    } else if let Some(sync) = deferred_ready_ui_sync {
-                        self.sync_clause_action_ui(
-                            &preview,
-                            &suffix,
-                            &candidates,
-                            selection_index,
-                            &mut ipc_service,
-                            sync.visible,
-                            sync.update_pos,
-                        )?;
-                        Self::log_clause_action_state(
-                            "after-deferred",
-                            action,
-                            &preview,
-                            &suffix,
-                            &raw_input,
-                            &raw_hiragana,
-                            &fixed_prefix,
-                            corresponding_count,
-                            selection_index,
-                            &candidates,
-                            &clause_snapshots,
-                            &future_clause_snapshots,
-                        );
-                    } else {
-                        Self::log_clause_action_state(
-                            "skip",
-                            action,
-                            &preview,
-                            &suffix,
-                            &raw_input,
-                            &raw_hiragana,
-                            &fixed_prefix,
-                            corresponding_count,
-                            selection_index,
-                            &candidates,
-                            &clause_snapshots,
-                            &future_clause_snapshots,
-                        );
+                        let shrunk_candidates = ipc_service.shrink_text(corresponding_count)?;
+                        candidates = ipc_service
+                            .append_text_with_context(text.clone(), &shrunk_candidates)?;
+                        raw_input = updated_raw_input;
+                        selection_index = 0;
+
+                        if let Some(selected) = Self::select_candidate(&candidates, selection_index)
+                        {
+                            self.shift_start(&preview, &selected.text)?;
+
+                            selection_index = selected.index;
+                            corresponding_count = selected.corresponding_count;
+                            preview = selected.text.clone();
+                            suffix = selected.sub_text.clone();
+                            raw_hiragana = selected.hiragana;
+
+                            self.sync_candidate_window_update(
+                                &mut ipc_service,
+                                &candidates,
+                                selection_index,
+                                None,
+                                true,
+                            )?;
+                        }
+
+                        transition = CompositionState::Composing;
                     }
-                }
-                ClientAction::AdjustBoundary(direction) => {
-                    Self::log_clause_action_state(
-                        "before",
-                        action,
-                        &preview,
-                        &suffix,
-                        &raw_input,
-                        &raw_hiragana,
-                        &fixed_prefix,
-                        corresponding_count,
-                        selection_index,
-                        &candidates,
-                        &clause_snapshots,
-                        &future_clause_snapshots,
-                    );
-                    let effect = {
-                        let mut state = ClauseState::from_composition_parts(
-                            &mut preview,
-                            &mut suffix,
-                            &mut raw_input,
-                            &mut raw_hiragana,
-                            &mut fixed_prefix,
-                            &mut corresponding_count,
-                            &mut selection_index,
-                            &mut candidates,
+                    ClientAction::ShrinkTextDirect(text) => {
+                        fixed_prefix.clear();
+                        Self::clear_clause_caches(
                             &mut clause_snapshots,
                             &mut future_clause_snapshots,
-                            &mut current_clause_is_split_derived,
-                            &mut current_clause_is_direct_split_remainder,
-                            &mut current_clause_has_split_left_neighbor,
-                            &mut current_clause_split_group_id,
-                            &mut next_split_group_id,
-                        );
-                        let transition = ClauseState::transition_with_backend(
-                            &mut state,
-                            ClauseCommand::AdjustBoundary(*direction),
-                            ClauseTransitionInput::default(),
                             &mut ipc_service,
                         )?;
-                        let effect = transition.effect;
-                        ClauseState::write_back(state);
-                        effect
-                    };
+                        current_clause_is_split_derived = false;
+                        current_clause_is_direct_split_remainder = false;
+                        current_clause_has_split_left_neighbor = false;
+                        current_clause_split_group_id = None;
+                        let mut updated_raw_input =
+                            Self::current_raw_input_suffix(&raw_input, corresponding_count);
+                        updated_raw_input.push_str(text);
 
-                    if effect.applied {
-                        self.sync_clause_action_ui(
-                            &preview,
-                            &suffix,
-                            &candidates,
-                            selection_index,
-                            &mut ipc_service,
-                            None,
-                            effect.update_pos,
-                        )?;
-                        Self::log_clause_action_state(
-                            "after",
-                            action,
-                            &preview,
-                            &suffix,
-                            &raw_input,
-                            &raw_hiragana,
-                            &fixed_prefix,
-                            corresponding_count,
-                            selection_index,
-                            &candidates,
-                            &clause_snapshots,
-                            &future_clause_snapshots,
-                        );
-                    } else {
-                        Self::log_clause_action_state(
-                            "skip",
-                            action,
-                            &preview,
-                            &suffix,
-                            &raw_input,
-                            &raw_hiragana,
-                            &fixed_prefix,
-                            corresponding_count,
-                            selection_index,
-                            &candidates,
-                            &clause_snapshots,
-                            &future_clause_snapshots,
-                        );
+                        let shrunk_candidates = ipc_service.shrink_text(corresponding_count)?;
+                        candidates = ipc_service
+                            .append_text_direct_with_context(text.clone(), &shrunk_candidates)?;
+                        raw_input = updated_raw_input;
+                        selection_index = 0;
+
+                        if let Some(selected) = Self::select_candidate(&candidates, selection_index)
+                        {
+                            self.shift_start(&preview, &selected.text)?;
+
+                            selection_index = selected.index;
+                            corresponding_count = selected.corresponding_count;
+                            preview = selected.text.clone();
+                            suffix = selected.sub_text.clone();
+                            raw_hiragana = selected.hiragana;
+
+                            self.sync_candidate_window_update(
+                                &mut ipc_service,
+                                &candidates,
+                                selection_index,
+                                None,
+                                true,
+                            )?;
+                        }
+
+                        transition = CompositionState::Composing;
                     }
-                }
-                ClientAction::SetIMEMode(mode) => {
-                    self.start_composition()?;
-                    let position = self.candidate_window_position()?;
-                    self.end_composition()?;
+                    ClientAction::SetTemporaryLatin(is_temporary_latin) => {
+                        temporary_latin = *is_temporary_latin;
+                        if !temporary_latin {
+                            temporary_latin_shift_pending = false;
+                        }
+                    }
+                    ClientAction::SetTemporaryLatinShiftPending(is_shift_pending) => {
+                        temporary_latin_shift_pending = *is_shift_pending;
+                    }
+                    ClientAction::SetTextWithType(set_type) => {
+                        let clause_raw_input = Self::current_clause_raw_input_preview(
+                            &raw_input,
+                            corresponding_count,
+                            &future_clause_snapshots,
+                        );
+                        let clause_raw_hiragana = Self::current_clause_raw_hiragana_preview(
+                            &raw_hiragana,
+                            corresponding_count,
+                            &future_clause_snapshots,
+                        );
+                        let converted_clause = Self::converted_clause_preview_text(
+                            set_type,
+                            &clause_raw_input,
+                            &clause_raw_hiragana,
+                        );
 
-                    IMEState::set_input_mode(mode.clone())?;
-
-                    // update the language bar
-                    self.update_lang_bar()?;
-
-                    let mode = match mode {
-                        InputMode::Latin => "A",
-                        InputMode::Kana => "あ",
-                    };
-
-                    ipc_service.update_candidate_window(None, position, None, None, Some(mode))?;
-
-                    selection_index = 0;
-                    corresponding_count = 0;
-                    temporary_latin = false;
-                    temporary_latin_shift_pending = false;
-                    preview.clear();
-                    suffix.clear();
-                    raw_input.clear();
-                    raw_hiragana.clear();
-                    fixed_prefix.clear();
-                    clause_snapshots.clear();
-                    future_clause_snapshots.clear();
-                    current_clause_is_split_derived = false;
-                    current_clause_is_direct_split_remainder = false;
-                    current_clause_has_split_left_neighbor = false;
-                    current_clause_split_group_id = None;
-                    next_split_group_id = 0;
-                    ipc_service.clear_text()?;
-                }
-                ClientAction::SetSelection(selection) => {
-                    Self::log_clause_action_state(
-                        "before",
-                        action,
-                        &preview,
-                        &suffix,
-                        &raw_input,
-                        &raw_hiragana,
-                        &fixed_prefix,
-                        corresponding_count,
-                        selection_index,
-                        &candidates,
-                        &clause_snapshots,
-                        &future_clause_snapshots,
-                    );
-                    let effect = {
-                        let mut state = ClauseState::from_composition_parts(
-                            &mut preview,
-                            &mut suffix,
-                            &mut raw_input,
-                            &mut raw_hiragana,
-                            &mut fixed_prefix,
-                            &mut corresponding_count,
-                            &mut selection_index,
-                            &mut candidates,
+                        preview = Self::merge_preview_with_prefix(&fixed_prefix, &converted_clause);
+                        Self::sync_clause_snapshot_suffixes(
                             &mut clause_snapshots,
-                            &mut future_clause_snapshots,
-                            &mut current_clause_is_split_derived,
-                            &mut current_clause_is_direct_split_remainder,
-                            &mut current_clause_has_split_left_neighbor,
-                            &mut current_clause_split_group_id,
-                            &mut next_split_group_id,
-                        );
-                        let transition = ClauseState::transition_without_backend(
-                            &mut state,
-                            ClauseCommand::SetSelection(selection),
-                        );
-                        let effect = transition.effect;
-                        ClauseState::write_back(state);
-                        effect
-                    };
-
-                    if effect.applied {
-                        self.sync_clause_action_ui(
                             &preview,
                             &suffix,
-                            &candidates,
-                            selection_index,
-                            &mut ipc_service,
-                            None,
-                            effect.update_pos,
-                        )?;
-                        Self::log_clause_action_state(
-                            "after",
-                            action,
-                            &preview,
-                            &suffix,
-                            &raw_input,
-                            &raw_hiragana,
-                            &fixed_prefix,
-                            corresponding_count,
-                            selection_index,
-                            &candidates,
-                            &clause_snapshots,
-                            &future_clause_snapshots,
                         );
-                    } else {
-                        Self::log_clause_action_state(
-                            "skip",
-                            action,
-                            &preview,
-                            &suffix,
-                            &raw_input,
-                            &raw_hiragana,
-                            &fixed_prefix,
-                            corresponding_count,
-                            selection_index,
-                            &candidates,
-                            &clause_snapshots,
-                            &future_clause_snapshots,
-                        );
+                        self.set_text(&preview, &suffix)?;
                     }
-                }
-                ClientAction::ShrinkText(text) => {
-                    fixed_prefix.clear();
-                    Self::clear_clause_caches(
-                        &mut clause_snapshots,
-                        &mut future_clause_snapshots,
-                        &mut ipc_service,
-                    )?;
-                    current_clause_is_split_derived = false;
-                    current_clause_is_direct_split_remainder = false;
-                    current_clause_has_split_left_neighbor = false;
-                    current_clause_split_group_id = None;
-                    let shrunk_raw_input =
-                        Self::current_raw_input_suffix(&raw_input, corresponding_count);
-                    let resolved_symbol_text = match mode {
-                        InputMode::Kana => Self::resolve_symbol_input_text_with_lookup(
-                            &shrunk_raw_input,
-                            text,
-                            &app_config,
-                            &romaji_lookup,
-                        ),
-                        InputMode::Latin => None,
-                    };
-                    let mut updated_raw_input = shrunk_raw_input.clone();
-                    updated_raw_input.push_str(text);
-
-                    let shrunk_candidates = ipc_service.shrink_text(corresponding_count)?;
-                    let text = match mode {
-                        InputMode::Kana => resolved_symbol_text.unwrap_or_else(|| text.to_string()),
-                        InputMode::Latin => text.to_string(),
-                    };
-                    candidates = ipc_service.append_text_with_context(text, &shrunk_candidates)?;
-                    raw_input = updated_raw_input;
-                    selection_index = 0;
-
-                    if let Some(selected) = Self::select_candidate(&candidates, selection_index) {
-                        self.shift_start(&preview, &selected.text)?;
-
-                        selection_index = selected.index;
-                        corresponding_count = selected.corresponding_count;
-                        preview = selected.text.clone();
-                        suffix = selected.sub_text.clone();
-                        raw_hiragana = selected.hiragana;
-
-                        self.sync_candidate_window_update(
-                            &mut ipc_service,
-                            &candidates,
-                            selection_index,
-                            None,
-                            true,
-                        )?;
-                    }
-
-                    transition = CompositionState::Composing;
-                }
-                ClientAction::ShrinkTextRaw(text) => {
-                    fixed_prefix.clear();
-                    Self::clear_clause_caches(
-                        &mut clause_snapshots,
-                        &mut future_clause_snapshots,
-                        &mut ipc_service,
-                    )?;
-                    current_clause_is_split_derived = false;
-                    current_clause_is_direct_split_remainder = false;
-                    current_clause_has_split_left_neighbor = false;
-                    current_clause_split_group_id = None;
-                    let mut updated_raw_input =
-                        Self::current_raw_input_suffix(&raw_input, corresponding_count);
-                    updated_raw_input.push_str(text);
-
-                    let shrunk_candidates = ipc_service.shrink_text(corresponding_count)?;
-                    candidates =
-                        ipc_service.append_text_with_context(text.clone(), &shrunk_candidates)?;
-                    raw_input = updated_raw_input;
-                    selection_index = 0;
-
-                    if let Some(selected) = Self::select_candidate(&candidates, selection_index) {
-                        self.shift_start(&preview, &selected.text)?;
-
-                        selection_index = selected.index;
-                        corresponding_count = selected.corresponding_count;
-                        preview = selected.text.clone();
-                        suffix = selected.sub_text.clone();
-                        raw_hiragana = selected.hiragana;
-
-                        self.sync_candidate_window_update(
-                            &mut ipc_service,
-                            &candidates,
-                            selection_index,
-                            None,
-                            true,
-                        )?;
-                    }
-
-                    transition = CompositionState::Composing;
-                }
-                ClientAction::ShrinkTextDirect(text) => {
-                    fixed_prefix.clear();
-                    Self::clear_clause_caches(
-                        &mut clause_snapshots,
-                        &mut future_clause_snapshots,
-                        &mut ipc_service,
-                    )?;
-                    current_clause_is_split_derived = false;
-                    current_clause_is_direct_split_remainder = false;
-                    current_clause_has_split_left_neighbor = false;
-                    current_clause_split_group_id = None;
-                    let mut updated_raw_input =
-                        Self::current_raw_input_suffix(&raw_input, corresponding_count);
-                    updated_raw_input.push_str(text);
-
-                    let shrunk_candidates = ipc_service.shrink_text(corresponding_count)?;
-                    candidates = ipc_service
-                        .append_text_direct_with_context(text.clone(), &shrunk_candidates)?;
-                    raw_input = updated_raw_input;
-                    selection_index = 0;
-
-                    if let Some(selected) = Self::select_candidate(&candidates, selection_index) {
-                        self.shift_start(&preview, &selected.text)?;
-
-                        selection_index = selected.index;
-                        corresponding_count = selected.corresponding_count;
-                        preview = selected.text.clone();
-                        suffix = selected.sub_text.clone();
-                        raw_hiragana = selected.hiragana;
-
-                        self.sync_candidate_window_update(
-                            &mut ipc_service,
-                            &candidates,
-                            selection_index,
-                            None,
-                            true,
-                        )?;
-                    }
-
-                    transition = CompositionState::Composing;
-                }
-                ClientAction::SetTemporaryLatin(is_temporary_latin) => {
-                    temporary_latin = *is_temporary_latin;
-                    if !temporary_latin {
-                        temporary_latin_shift_pending = false;
-                    }
-                }
-                ClientAction::SetTemporaryLatinShiftPending(is_shift_pending) => {
-                    temporary_latin_shift_pending = *is_shift_pending;
-                }
-                ClientAction::SetTextWithType(set_type) => {
-                    let clause_raw_input = Self::current_clause_raw_input_preview(
-                        &raw_input,
-                        corresponding_count,
-                        &future_clause_snapshots,
-                    );
-                    let clause_raw_hiragana = Self::current_clause_raw_hiragana_preview(
-                        &raw_hiragana,
-                        corresponding_count,
-                        &future_clause_snapshots,
-                    );
-                    let converted_clause = Self::converted_clause_preview_text(
-                        set_type,
-                        &clause_raw_input,
-                        &clause_raw_hiragana,
-                    );
-
-                    preview = Self::merge_preview_with_prefix(&fixed_prefix, &converted_clause);
-                    Self::sync_clause_snapshot_suffixes(&mut clause_snapshots, &preview, &suffix);
-                    self.set_text(&preview, &suffix)?;
                 }
             }
-        }
 
-        let text_service = self.borrow()?;
-        let mut composition = text_service.borrow_mut_composition()?;
+            let text_service = self.borrow()?;
+            let mut composition = text_service.borrow_mut_composition()?;
 
-        composition.preview = preview.clone();
-        composition.state = transition;
-        composition.selection_index = selection_index;
-        composition.raw_input = raw_input.clone();
-        composition.raw_hiragana = raw_hiragana.clone();
-        composition.fixed_prefix = fixed_prefix.clone();
-        composition.candidates = candidates;
-        composition.clause_snapshots = clause_snapshots;
-        composition.future_clause_snapshots = future_clause_snapshots;
-        composition.current_clause_is_split_derived = current_clause_is_split_derived;
-        composition.current_clause_is_direct_split_remainder =
-            current_clause_is_direct_split_remainder;
-        composition.current_clause_has_split_left_neighbor = current_clause_has_split_left_neighbor;
-        composition.current_clause_split_group_id = current_clause_split_group_id;
-        composition.next_split_group_id = next_split_group_id;
-        composition.suffix = suffix.clone();
-        composition.corresponding_count = corresponding_count;
-        composition.temporary_latin = temporary_latin;
-        composition.temporary_latin_shift_pending = temporary_latin_shift_pending;
+            composition.preview = preview.clone();
+            composition.state = transition;
+            composition.selection_index = selection_index;
+            composition.raw_input = raw_input.clone();
+            composition.raw_hiragana = raw_hiragana.clone();
+            composition.fixed_prefix = fixed_prefix.clone();
+            composition.candidates = candidates;
+            composition.clause_snapshots = clause_snapshots;
+            composition.future_clause_snapshots = future_clause_snapshots;
+            composition.current_clause_is_split_derived = current_clause_is_split_derived;
+            composition.current_clause_is_direct_split_remainder =
+                current_clause_is_direct_split_remainder;
+            composition.current_clause_has_split_left_neighbor =
+                current_clause_has_split_left_neighbor;
+            composition.current_clause_split_group_id = current_clause_split_group_id;
+            composition.next_split_group_id = next_split_group_id;
+            composition.suffix = suffix.clone();
+            composition.corresponding_count = corresponding_count;
+            composition.temporary_latin = temporary_latin;
+            composition.temporary_latin_shift_pending = temporary_latin_shift_pending;
 
-        drop(composition);
-        drop(text_service);
+            drop(composition);
+            drop(text_service);
 
-        if let Err(error) = IMEState::set_ipc_service(ipc_service) {
-            tracing::warn!(
-                ?error,
-                "Failed to persist updated IPC service into IMEState"
+            if let Err(error) = IMEState::set_ipc_service(ipc_service) {
+                tracing::warn!(
+                    ?error,
+                    "Failed to persist updated IPC service into IMEState"
+                );
+            }
+
+            Ok(())
+        })();
+
+        if let (Some(request_id), Some(total_start)) = (trace_request_id, total_start) {
+            let details = match &result {
+                Ok(()) => format!(
+                    "status=success;actions={};requested_transition={requested_transition:?}",
+                    actions.len()
+                ),
+                Err(error) => format!(
+                    "status=error;actions={};requested_transition={requested_transition:?};error={error:?}",
+                    actions.len()
+                ),
+            };
+            Self::log_client_performance(
+                request_id,
+                "handle_action",
+                "total",
+                total_start.elapsed(),
+                details,
             );
         }
 
-        Ok(())
+        result
     }
 }
 

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -8,6 +8,7 @@ use shared::{
     AppConfig,
 };
 use std::{
+    cell::Cell,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex, OnceLock,
@@ -25,6 +26,10 @@ const CLIENT_LOG_CONFIG_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 static CLIENT_REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 static CLIENT_LOG_CONFIG_CACHE: OnceLock<Mutex<ClientLogConfigCache>> = OnceLock::new();
+
+thread_local! {
+    static CLIENT_INPUT_TRACE_REQUEST_ID: Cell<Option<u64>> = const { Cell::new(None) };
+}
 
 #[derive(Debug, Default)]
 struct ClientLogConfigCache {
@@ -56,11 +61,21 @@ fn next_request_id() -> u64 {
     (u64::from(std::process::id()) << 32) | (counter & 0xffff_ffff)
 }
 
+fn current_or_next_request_id() -> u64 {
+    CLIENT_INPUT_TRACE_REQUEST_ID
+        .with(|current| current.get())
+        .unwrap_or_else(next_request_id)
+}
+
+pub(crate) fn current_input_trace_request_id() -> Option<u64> {
+    CLIENT_INPUT_TRACE_REQUEST_ID.with(|current| current.get())
+}
+
 fn client_log_config_cache() -> &'static Mutex<ClientLogConfigCache> {
     CLIENT_LOG_CONFIG_CACHE.get_or_init(|| Mutex::new(ClientLogConfigCache::default()))
 }
 
-fn client_performance_log_enabled() -> bool {
+pub(crate) fn client_performance_log_enabled() -> bool {
     let Ok(mut cache) = client_log_config_cache().lock() else {
         return false;
     };
@@ -81,6 +96,38 @@ fn client_performance_log_enabled() -> bool {
 
 fn duration_millis_u64(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn client_performance_start() -> Option<Instant> {
+    client_performance_log_enabled().then(Instant::now)
+}
+
+#[derive(Debug)]
+pub(crate) struct ClientInputTraceGuard {
+    request_id: u64,
+    previous_request_id: Option<u64>,
+}
+
+impl ClientInputTraceGuard {
+    pub(crate) fn begin() -> Self {
+        let request_id = next_request_id();
+        let previous_request_id =
+            CLIENT_INPUT_TRACE_REQUEST_ID.with(|current| current.replace(Some(request_id)));
+        Self {
+            request_id,
+            previous_request_id,
+        }
+    }
+
+    pub(crate) fn request_id(&self) -> u64 {
+        self.request_id
+    }
+}
+
+impl Drop for ClientInputTraceGuard {
+    fn drop(&mut self) {
+        CLIENT_INPUT_TRACE_REQUEST_ID.with(|current| current.set(self.previous_request_id));
+    }
 }
 
 impl IPCService {
@@ -187,18 +234,14 @@ impl IPCService {
         Ok(())
     }
 
-    fn log_client_performance(
-        &mut self,
+    fn enqueue_client_performance(
+        &self,
         request_id: u64,
         operation: &str,
         stage: &str,
         elapsed: Duration,
         details: String,
     ) {
-        if !client_performance_log_enabled() {
-            return;
-        }
-
         let request = PerformanceLogRequest {
             request_id,
             component: "ime".to_string(),
@@ -210,6 +253,40 @@ impl IPCService {
 
         if let Err(error) = self.performance_log_tx.send(request) {
             tracing::debug!("failed to enqueue client performance log: {error:?}");
+        }
+    }
+
+    pub(crate) fn log_client_performance(
+        &self,
+        request_id: u64,
+        operation: &str,
+        stage: &str,
+        elapsed: Duration,
+        details: String,
+    ) {
+        if !client_performance_log_enabled() {
+            return;
+        }
+
+        self.enqueue_client_performance(request_id, operation, stage, elapsed, details);
+    }
+
+    fn log_client_performance_from_start(
+        &self,
+        start: Option<Instant>,
+        request_id: u64,
+        operation: &str,
+        stage: &str,
+        details: impl FnOnce() -> String,
+    ) {
+        if let Some(start) = start {
+            self.enqueue_client_performance(
+                request_id,
+                operation,
+                stage,
+                start.elapsed(),
+                details(),
+            );
         }
     }
 
@@ -269,9 +346,9 @@ impl IPCService {
         input_style: i32,
         previous_candidates: Option<&Candidates>,
     ) -> anyhow::Result<Candidates> {
-        let request_id = next_request_id();
-        let operation_start = Instant::now();
-        let input_len = text.chars().count();
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let input_len = performance_start.map(|_| text.chars().count());
         let send = |this: &mut Self| -> anyhow::Result<
             tonic::Response<shared::proto::AppendTextResponse>,
         > {
@@ -306,14 +383,17 @@ impl IPCService {
                         tracing::error!(
                             "append_text IPC reconnect failed (style={input_style}): {reconnect_error:?}"
                         );
-                        self.log_client_performance(
+                        self.log_client_performance_from_start(
+                            performance_start,
                             request_id,
                             "append_text",
                             "rpc_total",
-                            operation_start.elapsed(),
-                            format!(
-                                "status=error;phase=reconnect;input_len={input_len};input_style={input_style}"
-                            ),
+                            || {
+                                let input_len = input_len.unwrap_or_default();
+                                format!(
+                                    "status=error;phase=reconnect;input_len={input_len};input_style={input_style}"
+                                )
+                            },
                         );
                         return Err(reconnect_error);
                     }
@@ -330,14 +410,17 @@ impl IPCService {
                             let candidates = Self::candidates_from_composing_text(
                                 retry_response.into_inner().composing_text,
                             )?;
-                            self.log_client_performance(
+                            self.log_client_performance_from_start(
+                                performance_start,
                                 request_id,
                                 "append_text",
                                 "rpc_total",
-                                operation_start.elapsed(),
-                                format!(
-                                    "status=success;retry=true;input_len={input_len};input_style={input_style}"
-                                ),
+                                || {
+                                    let input_len = input_len.unwrap_or_default();
+                                    format!(
+                                        "status=success;retry=true;input_len={input_len};input_style={input_style}"
+                                    )
+                                },
                             );
                             return Ok(candidates);
                         }
@@ -345,14 +428,17 @@ impl IPCService {
                         tracing::info!(
                             "append_text recovered changed composition after reconnect (style={input_style}), reusing server state"
                         );
-                        self.log_client_performance(
+                        self.log_client_performance_from_start(
+                            performance_start,
                             request_id,
                             "append_text",
                             "rpc_total",
-                            operation_start.elapsed(),
-                            format!(
-                                "status=recovered_changed;input_len={input_len};input_style={input_style}"
-                            ),
+                            || {
+                                let input_len = input_len.unwrap_or_default();
+                                format!(
+                                    "status=recovered_changed;input_len={input_len};input_style={input_style}"
+                                )
+                            },
                         );
                         return Ok(candidates);
                     }
@@ -360,14 +446,17 @@ impl IPCService {
                         tracing::error!(
                             "append_text refresh failed after reconnect (style={input_style}): {refresh_error:?}"
                         );
-                        self.log_client_performance(
+                        self.log_client_performance_from_start(
+                            performance_start,
                             request_id,
                             "append_text",
                             "rpc_total",
-                            operation_start.elapsed(),
-                            format!(
-                                "status=error;phase=refresh;input_len={input_len};input_style={input_style}"
-                            ),
+                            || {
+                                let input_len = input_len.unwrap_or_default();
+                                format!(
+                                    "status=error;phase=refresh;input_len={input_len};input_style={input_style}"
+                                )
+                            },
                         );
                         return Err(refresh_error);
                     }
@@ -376,20 +465,23 @@ impl IPCService {
         };
         let candidates =
             Self::candidates_from_composing_text(response.into_inner().composing_text)?;
-        self.log_client_performance(
+        self.log_client_performance_from_start(
+            performance_start,
             request_id,
             "append_text",
             "rpc_total",
-            operation_start.elapsed(),
-            format!("status=success;input_len={input_len};input_style={input_style}"),
+            || {
+                let input_len = input_len.unwrap_or_default();
+                format!("status=success;input_len={input_len};input_style={input_style}")
+            },
         );
         Ok(candidates)
     }
 
     #[tracing::instrument]
     pub fn remove_text(&mut self) -> anyhow::Result<Candidates> {
-        let request_id = next_request_id();
-        let operation_start = Instant::now();
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
         let request = tonic::Request::new(shared::proto::RemoveTextRequest { request_id });
         let response = self
             .runtime
@@ -397,31 +489,31 @@ impl IPCService {
             .block_on(self.azookey_client.remove_text(request))?;
         let candidates =
             Self::candidates_from_composing_text(response.into_inner().composing_text)?;
-        self.log_client_performance(
+        self.log_client_performance_from_start(
+            performance_start,
             request_id,
             "remove_text",
             "rpc_total",
-            operation_start.elapsed(),
-            "status=success".to_string(),
+            || "status=success".to_string(),
         );
         Ok(candidates)
     }
 
     #[tracing::instrument]
     pub fn clear_text(&mut self) -> anyhow::Result<()> {
-        let request_id = next_request_id();
-        let operation_start = Instant::now();
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
         let request = tonic::Request::new(shared::proto::ClearTextRequest { request_id });
         let _response = self
             .runtime
             .clone()
             .block_on(self.azookey_client.clear_text(request))?;
-        self.log_client_performance(
+        self.log_client_performance_from_start(
+            performance_start,
             request_id,
             "clear_text",
             "rpc_total",
-            operation_start.elapsed(),
-            "status=success".to_string(),
+            || "status=success".to_string(),
         );
 
         Ok(())
@@ -429,8 +521,8 @@ impl IPCService {
 
     #[tracing::instrument]
     pub fn shrink_text(&mut self, offset: i32) -> anyhow::Result<Candidates> {
-        let request_id = next_request_id();
-        let operation_start = Instant::now();
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
         let request = tonic::Request::new(shared::proto::ShrinkTextRequest { offset, request_id });
         let response = self
             .runtime
@@ -438,20 +530,20 @@ impl IPCService {
             .block_on(self.azookey_client.shrink_text(request))?;
         let candidates =
             Self::candidates_from_composing_text(response.into_inner().composing_text)?;
-        self.log_client_performance(
+        self.log_client_performance_from_start(
+            performance_start,
             request_id,
             "shrink_text",
             "rpc_total",
-            operation_start.elapsed(),
-            format!("status=success;offset={offset}"),
+            || format!("status=success;offset={offset}"),
         );
         Ok(candidates)
     }
 
     #[tracing::instrument]
     pub fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
-        let request_id = next_request_id();
-        let operation_start = Instant::now();
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
         let request = tonic::Request::new(shared::proto::MoveCursorRequest { offset, request_id });
         let response = self
             .runtime
@@ -459,20 +551,20 @@ impl IPCService {
             .block_on(self.azookey_client.move_cursor(request))?;
         let candidates =
             Self::candidates_from_composing_text(response.into_inner().composing_text)?;
-        self.log_client_performance(
+        self.log_client_performance_from_start(
+            performance_start,
             request_id,
             "move_cursor",
             "rpc_total",
-            operation_start.elapsed(),
-            format!("status=success;offset={offset}"),
+            || format!("status=success;offset={offset}"),
         );
         Ok(candidates)
     }
 
     pub fn set_context(&mut self, context: String) -> anyhow::Result<()> {
-        let request_id = next_request_id();
-        let operation_start = Instant::now();
-        let context_len = context.chars().count();
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let context_len = performance_start.map(|_| context.chars().count());
         let request = tonic::Request::new(shared::proto::SetContextRequest {
             context,
             request_id,
@@ -481,12 +573,15 @@ impl IPCService {
             .runtime
             .clone()
             .block_on(self.azookey_client.set_context(request))?;
-        self.log_client_performance(
+        self.log_client_performance_from_start(
+            performance_start,
             request_id,
             "set_context",
             "rpc_total",
-            operation_start.elapsed(),
-            format!("status=success;context_len={context_len}"),
+            || {
+                let context_len = context_len.unwrap_or_default();
+                format!("status=success;context_len={context_len}")
+            },
         );
 
         Ok(())
@@ -497,22 +592,52 @@ impl IPCService {
 impl IPCService {
     #[tracing::instrument]
     pub fn show_window(&mut self) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::EmptyResponse {});
-        self.runtime
-            .clone()
-            .block_on(self.window_client.show_window(request))?;
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let result: anyhow::Result<()> = (|| {
+            let request = tonic::Request::new(shared::proto::EmptyResponse {});
+            self.runtime
+                .clone()
+                .block_on(self.window_client.show_window(request))?;
 
-        Ok(())
+            Ok(())
+        })();
+        self.log_client_performance_from_start(
+            performance_start,
+            request_id,
+            "ui_show_window",
+            "rpc_total",
+            || match &result {
+                Ok(()) => "status=success".to_string(),
+                Err(error) => format!("status=error;error={error:?}"),
+            },
+        );
+        result
     }
 
     #[tracing::instrument]
     pub fn hide_window(&mut self) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::EmptyResponse {});
-        self.runtime
-            .clone()
-            .block_on(self.window_client.hide_window(request))?;
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let result: anyhow::Result<()> = (|| {
+            let request = tonic::Request::new(shared::proto::EmptyResponse {});
+            self.runtime
+                .clone()
+                .block_on(self.window_client.hide_window(request))?;
 
-        Ok(())
+            Ok(())
+        })();
+        self.log_client_performance_from_start(
+            performance_start,
+            request_id,
+            "ui_hide_window",
+            "rpc_total",
+            || match &result {
+                Ok(()) => "status=success".to_string(),
+                Err(error) => format!("status=error;error={error:?}"),
+            },
+        );
+        result
     }
 
     #[tracing::instrument]
@@ -523,51 +648,121 @@ impl IPCService {
         bottom: i32,
         right: i32,
     ) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::SetPositionRequest {
-            position: Some(shared::proto::WindowPosition {
-                top,
-                left,
-                bottom,
-                right,
-            }),
-        });
-        self.runtime
-            .clone()
-            .block_on(self.window_client.set_window_position(request))?;
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let result: anyhow::Result<()> = (|| {
+            let request = tonic::Request::new(shared::proto::SetPositionRequest {
+                position: Some(shared::proto::WindowPosition {
+                    top,
+                    left,
+                    bottom,
+                    right,
+                }),
+            });
+            self.runtime
+                .clone()
+                .block_on(self.window_client.set_window_position(request))?;
 
-        Ok(())
+            Ok(())
+        })();
+        self.log_client_performance_from_start(
+            performance_start,
+            request_id,
+            "ui_set_window_position",
+            "rpc_total",
+            || match &result {
+                Ok(()) => {
+                    format!("status=success;top={top};left={left};bottom={bottom};right={right}")
+                }
+                Err(error) => format!(
+                    "status=error;top={top};left={left};bottom={bottom};right={right};error={error:?}"
+                ),
+            },
+        );
+        result
     }
 
     #[tracing::instrument]
     pub fn set_candidates(&mut self, candidates: Vec<String>) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::SetCandidateRequest { candidates });
-        self.runtime
-            .clone()
-            .block_on(self.window_client.set_candidate(request))?;
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let candidate_count = performance_start.map(|_| candidates.len());
+        let result: anyhow::Result<()> = (|| {
+            let request = tonic::Request::new(shared::proto::SetCandidateRequest { candidates });
+            self.runtime
+                .clone()
+                .block_on(self.window_client.set_candidate(request))?;
 
-        Ok(())
+            Ok(())
+        })();
+        self.log_client_performance_from_start(
+            performance_start,
+            request_id,
+            "ui_set_candidates",
+            "rpc_total",
+            || {
+                let candidate_count = candidate_count.unwrap_or_default();
+                match &result {
+                    Ok(()) => format!("status=success;candidate_count={candidate_count}"),
+                    Err(error) => {
+                        format!("status=error;candidate_count={candidate_count};error={error:?}")
+                    }
+                }
+            },
+        );
+        result
     }
 
     #[tracing::instrument]
     pub fn set_selection(&mut self, index: i32) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::SetSelectionRequest { index });
-        self.runtime
-            .clone()
-            .block_on(self.window_client.set_selection(request))?;
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let result: anyhow::Result<()> = (|| {
+            let request = tonic::Request::new(shared::proto::SetSelectionRequest { index });
+            self.runtime
+                .clone()
+                .block_on(self.window_client.set_selection(request))?;
 
-        Ok(())
+            Ok(())
+        })();
+        self.log_client_performance_from_start(
+            performance_start,
+            request_id,
+            "ui_set_selection",
+            "rpc_total",
+            || match &result {
+                Ok(()) => format!("status=success;index={index}"),
+                Err(error) => format!("status=error;index={index};error={error:?}"),
+            },
+        );
+        result
     }
 
     #[tracing::instrument]
     pub fn set_input_mode(&mut self, mode: &str) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::SetInputModeRequest {
-            mode: mode.to_string(),
-        });
-        self.runtime
-            .clone()
-            .block_on(self.window_client.set_input_mode(request))?;
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let result: anyhow::Result<()> = (|| {
+            let request = tonic::Request::new(shared::proto::SetInputModeRequest {
+                mode: mode.to_string(),
+            });
+            self.runtime
+                .clone()
+                .block_on(self.window_client.set_input_mode(request))?;
 
-        Ok(())
+            Ok(())
+        })();
+        self.log_client_performance_from_start(
+            performance_start,
+            request_id,
+            "ui_set_input_mode",
+            "rpc_total",
+            || match &result {
+                Ok(()) => format!("status=success;mode={mode}"),
+                Err(error) => format!("status=error;mode={mode};error={error:?}"),
+            },
+        );
+        result
     }
 
     #[tracing::instrument(skip(candidates))]
@@ -579,18 +774,46 @@ impl IPCService {
         selected_index: Option<i32>,
         input_mode: Option<&str>,
     ) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::UpdateCandidateWindowRequest {
-            visible,
-            position,
-            candidates: candidates.map(|candidates| shared::proto::CandidateList { candidates }),
-            selected_index,
-            input_mode: input_mode.map(ToString::to_string),
-        });
-        self.runtime
-            .clone()
-            .block_on(self.window_client.update_candidate_window(request))?;
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let position_present = performance_start.map(|_| position.is_some());
+        let candidate_count = performance_start.map(|_| candidates.as_ref().map(Vec::len));
+        let input_mode_present = performance_start.map(|_| input_mode.is_some());
+        let result: anyhow::Result<()> = (|| {
+            let request = tonic::Request::new(shared::proto::UpdateCandidateWindowRequest {
+                visible,
+                position,
+                candidates: candidates
+                    .map(|candidates| shared::proto::CandidateList { candidates }),
+                selected_index,
+                input_mode: input_mode.map(ToString::to_string),
+            });
+            self.runtime
+                .clone()
+                .block_on(self.window_client.update_candidate_window(request))?;
 
-        Ok(())
+            Ok(())
+        })();
+        self.log_client_performance_from_start(
+            performance_start,
+            request_id,
+            "ui_update_candidate_window",
+            "rpc_total",
+            || {
+                let position_present = position_present.unwrap_or_default();
+                let candidate_count = candidate_count.unwrap_or_default();
+                let input_mode_present = input_mode_present.unwrap_or_default();
+                match &result {
+                    Ok(()) => format!(
+                        "status=success;visible={visible:?};position_present={position_present};candidate_count={candidate_count:?};selected_index={selected_index:?};input_mode_present={input_mode_present}"
+                    ),
+                    Err(error) => format!(
+                        "status=error;visible={visible:?};position_present={position_present};candidate_count={candidate_count:?};selected_index={selected_index:?};input_mode_present={input_mode_present};error={error:?}"
+                    ),
+                }
+            },
+        );
+        result
     }
 }
 

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -16,7 +16,11 @@ use std::{cell::Cell, mem::ManuallyDrop, rc::Rc, time::Instant};
 
 use anyhow::Result;
 
-use crate::{engine::state::IMEState, extension::StringExt as _, globals::GUID_DISPLAY_ATTRIBUTE};
+use crate::{
+    engine::{ipc_service::current_input_trace_request_id, state::IMEState},
+    extension::StringExt as _,
+    globals::GUID_DISPLAY_ATTRIBUTE,
+};
 use shared::proto::WindowPosition;
 
 use super::factory::TextServiceFactory;
@@ -62,6 +66,23 @@ impl<'a, T> ITfEditSession_Impl for EditSession_Impl<'a, T> {
 }
 
 impl TextServiceFactory {
+    fn log_candidate_window_position_performance(
+        request_id: u64,
+        stage: &str,
+        start: Instant,
+        details: impl Into<String>,
+    ) {
+        if let Ok(Some(ipc_service)) = IMEState::ipc_service() {
+            ipc_service.log_client_performance(
+                request_id,
+                "candidate_window_position",
+                stage,
+                start.elapsed(),
+                details.into(),
+            );
+        }
+    }
+
     fn close_composition(&self, discard_text: bool) -> Result<()> {
         let text_service = self.borrow()?;
 
@@ -285,6 +306,8 @@ impl TextServiceFactory {
 
     #[tracing::instrument]
     pub fn candidate_window_position(&self) -> Result<Option<WindowPosition>> {
+        let trace_request_id = current_input_trace_request_id();
+        let total_start = trace_request_id.map(|_| Instant::now());
         {
             let mut text_service = match self.borrow_mut() {
                 Ok(text_service) => text_service,
@@ -292,6 +315,14 @@ impl TextServiceFactory {
                     tracing::warn!(
                         "Skip candidate_window_position due to borrow conflict: {error:?}"
                     );
+                    if let (Some(request_id), Some(total_start)) = (trace_request_id, total_start) {
+                        Self::log_candidate_window_position_performance(
+                            request_id,
+                            "total",
+                            total_start,
+                            format!("status=skipped;reason=borrow_conflict;error={error:?}"),
+                        );
+                    }
                     return Ok(None);
                 }
             };
@@ -301,6 +332,14 @@ impl TextServiceFactory {
                 .try_begin_update(Instant::now())
             {
                 tracing::debug!("Skip re-entrant candidate_window_position call");
+                if let (Some(request_id), Some(total_start)) = (trace_request_id, total_start) {
+                    Self::log_candidate_window_position_performance(
+                        request_id,
+                        "total",
+                        total_start,
+                        "status=skipped;reason=reentrant".to_string(),
+                    );
+                }
                 return Ok(None);
             }
         }
@@ -353,6 +392,19 @@ impl TextServiceFactory {
             Err(error) => {
                 tracing::warn!("Failed to reset update_pos guard: {error:?}");
             }
+        }
+
+        if let (Some(request_id), Some(total_start)) = (trace_request_id, total_start) {
+            let details = match &result {
+                Ok(position) => format!("status=success;position_present={}", position.is_some()),
+                Err(error) => format!("status=error;error={error:?}"),
+            };
+            Self::log_candidate_window_position_performance(
+                request_id,
+                "total",
+                total_start,
+                details,
+            );
         }
 
         match result {

--- a/crates/client/src/tsf/surrounded_text.rs
+++ b/crates/client/src/tsf/surrounded_text.rs
@@ -1,7 +1,7 @@
 // reference to the original code:
 // https://github.com/google/mozc/blob/master/src/win32/tip/tip_surrounding_text.cc
 
-use std::{mem::ManuallyDrop, rc::Rc};
+use std::{mem::ManuallyDrop, rc::Rc, time::Instant};
 
 use anyhow::Result;
 use windows::{
@@ -13,11 +13,28 @@ use windows::{
     },
 };
 
-use crate::engine::state::IMEState;
+use crate::engine::{ipc_service::current_input_trace_request_id, state::IMEState};
 
 use super::{edit_session::edit_session, factory::TextServiceFactory};
 
 impl TextServiceFactory {
+    fn log_update_context_performance(
+        request_id: u64,
+        stage: &str,
+        start: Instant,
+        details: impl Into<String>,
+    ) {
+        if let Ok(Some(ipc_service)) = IMEState::ipc_service() {
+            ipc_service.log_client_performance(
+                request_id,
+                "update_context",
+                stage,
+                start.elapsed(),
+                details.into(),
+            );
+        }
+    }
+
     fn to_parent_document_if_exists(
         &self,
         document_manager: Option<ITfDocumentMgr>,
@@ -106,12 +123,15 @@ impl TextServiceFactory {
     }
 
     pub fn update_context(&self, preview: &str) -> Result<()> {
+        let trace_request_id = current_input_trace_request_id();
+        let total_start = trace_request_id.map(|_| Instant::now());
         let result: Result<()> = (|| unsafe {
             let text_service = self.borrow()?;
 
             let context = text_service.context::<ITfContext>()?;
             let parent_context = self.to_parent_context_if_exists(Some(context))?;
 
+            let edit_session_start = trace_request_id.map(|_| Instant::now());
             let preceding_text = edit_session::<String>(
                 text_service.tid,
                 parent_context.clone(),
@@ -175,6 +195,20 @@ impl TextServiceFactory {
                     }
                 }),
             )?;
+            if let (Some(request_id), Some(edit_session_start)) =
+                (trace_request_id, edit_session_start)
+            {
+                Self::log_update_context_performance(
+                    request_id,
+                    "edit_session",
+                    edit_session_start,
+                    format!(
+                        "status=success;preview_len={};preceding_text_present={}",
+                        preview.chars().count(),
+                        preceding_text.is_some()
+                    ),
+                );
+            }
 
             let Some(preceding_text) = preceding_text else {
                 return Ok(());
@@ -188,6 +222,17 @@ impl TextServiceFactory {
 
             Ok(())
         })();
+
+        if let (Some(request_id), Some(total_start)) = (trace_request_id, total_start) {
+            let details = match &result {
+                Ok(()) => format!("status=success;preview_len={}", preview.chars().count()),
+                Err(error) => format!(
+                    "status=error;preview_len={};error={error:?}",
+                    preview.chars().count()
+                ),
+            };
+            Self::log_update_context_performance(request_id, "total", total_start, details);
+        }
 
         if let Err(error) = result {
             tracing::warn!("Failed to update surrounded text context: {error:?}");

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -1408,8 +1408,16 @@ public func free_candidate_list(
     )
     let options = getOptions(context: contextString, zenzaiEnabled: useZenzai)
     serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates begin useZenzai=\(useZenzai) syntheticEndOfText=\(previewState.syntheticEndOfText)")
+    let totalStart = ProcessInfo.processInfo.systemUptime
     let requestStart = ProcessInfo.processInfo.systemUptime
     let converted = converter.requestCandidates(previewPrefixComposingText, options: options)
+    let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
+    performanceLog(
+        operation: "get_composed_text_for_cursor_prefix",
+        stage: "request_candidates",
+        elapsedMs: requestMs,
+        details: "first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);use_zenzai=\(useZenzai);synthetic_end_of_text=\(previewState.syntheticEndOfText);prefix_len=\(prefixHiragana.count);preview_prefix_len=\(previewPrefixHiragana.count);suffix_len=\(suffixAfterCursor.count)"
+    )
     var cursorPrefixResolutionCache: [String: CandidateDisplayResolution] = [:]
     let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
         firstClauseResults: converted.firstClauseResults,
@@ -1436,10 +1444,19 @@ public func free_candidate_list(
         let exactClausePreviewState = makeCandidatePreviewComposingText(
             from: exactClauseComposingText
         )
-        exactClauseResults = converter.requestCandidates(
+        let exactClauseRequestStart = ProcessInfo.processInfo.systemUptime
+        let exactClauseConverted = converter.requestCandidates(
             exactClausePreviewState.composingText,
             options: options
-        ).mainResults
+        )
+        exactClauseResults = exactClauseConverted.mainResults
+        let exactClauseRequestMs = Int((ProcessInfo.processInfo.systemUptime - exactClauseRequestStart) * 1000)
+        performanceLog(
+            operation: "get_composed_text_for_cursor_prefix",
+            stage: "request_candidates_exact_clause",
+            elapsedMs: exactClauseRequestMs,
+            details: "candidate_count=\(exactClauseResults.count);use_zenzai=\(useZenzai);synthetic_end_of_text=\(exactClausePreviewState.syntheticEndOfText);prefix_len=\(prefixHiragana.count);corresponding_count=\(firstClauseCorrespondingCount)"
+        )
     }
     let cursorPrefixResults = exactClauseResults.isEmpty
         ? preliminaryCursorPrefixResults
@@ -1453,11 +1470,11 @@ public func free_candidate_list(
             previewHiragana: previewPrefixHiragana,
             resolutionCache: &cursorPrefixResolutionCache
         )
-    let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
+    let totalMs = Int((ProcessInfo.processInfo.systemUptime - totalStart) * 1000)
     performanceLog(
         operation: "get_composed_text_for_cursor_prefix",
-        stage: "request_candidates",
-        elapsedMs: requestMs,
+        stage: "total_before_ffi_candidates",
+        elapsedMs: totalMs,
         details: "candidate_count=\(cursorPrefixResults.count);first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);exact_clause_candidate_count=\(exactClauseResults.count);use_zenzai=\(useZenzai);synthetic_end_of_text=\(previewState.syntheticEndOfText);prefix_len=\(prefixHiragana.count);preview_prefix_len=\(previewPrefixHiragana.count);suffix_len=\(suffixAfterCursor.count)"
     )
     serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(cursorPrefixResults.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) exactClauseCandidateCount=\(exactClauseResults.count)")


### PR DESCRIPTION
## Summary
- IME 入力 hot path に request id 付きの performance tracing を追加しました。
- `process_key` / `handle_action` / `handle_key`、IPC、candidate window 更新、context 更新などの主要 stage を `server-performance.tsv` で追えるようにしました。
- Rust server / Swift converter 側の `append_text` / `move_cursor` / `clear_text` / `set_context` などと、IME 側の stage を同じ request id で突き合わせられるようにしました。
- VM 上で Issue #85 の入力シナリオを複数回計測し、平均・中央値・p95・標準偏差・外れ値除外込みのレポートを作成しました。

## Background
- Issue: Closes #85
- Related: #81, #54
- #81 の入力引っかかり調査のため、#54 で整備した performance log を使って、IME 入力中のどの処理に時間がかかっているかを分解して見られるようにします。
- 計測時だけ有効化する前提で、通常利用では既定 OFF の server logging / performance logging 経路を利用します。

## Changes
- client performance tracing
  - input event ごとに request id を発行し、同じ入力に紐づく IME / Rust server / Swift converter の stage を追跡可能に変更
  - `process_key` の config read / romaji lookup build / total を計測
  - `handle_action` の action 処理、IPC、candidate window 更新、context 更新、total を計測
  - `handle_key` の end-to-end total を計測
- IPC tracing
  - `append_text` / `remove_text` / `move_cursor` / `shrink_text` / `clear_text` / `set_context` などの RPC total を計測
  - candidate window position / update の所要時間を計測
- Rust server / Swift converter tracing
  - `append_text` / `move_cursor` / `clear_text` / `shrink_text` / `set_context` などの server-side total と Swift FFI stage を計測
  - Swift 側の candidate request 所要時間を request id 付きで記録
- surrounding text / edit session tracing
  - context 更新や edit session 周りの stage を performance log に追加

## Measurement report
- Environment
  - branch: `feature/85-input-latency-measurement`
  - commit: `0f42e94`
  - VM: `Win11`
  - target: custom WinForms TextBox (`AzooKey Measure`)
  - input: VirtualBox scancode injection
- Method
  - 4 scenarios x 12 replicates = 48 total measurements
  - VM UTC timestamp boundaries で scenario ごとの log row を切り出し
  - Tukey 1.5 IQR を scenario + stage 単位で適用し、極端な外れ値を除外
  - 平均 / 中央値 / p95 / 標準偏差 / min / max を stage ごとに集計
- Results summary

| Scenario | Steps | `ime:handle_key/total` mean | p95 | Main internal contributors |
|---|---|---:|---:|---|
| `idle_first_input` | 8 秒 idle 後に `a` | 37.2ms/run | 38.5ms | `append_text` RPC / `swift_get_composed_text` |
| `continuous_input` | `nihongo` 連続入力 | 270.8ms/run | 285ms | `append_text` RPC / `swift_get_composed_text` |
| `space_conversion` | `kanji`, Space, Enter | 214.5ms/run | 217.6ms | `append_text` RPC / `swift_get_composed_text` |
| `clause_navigation` | `watashinonamaeha`, Space, Shift+Left, Shift+Right, Enter | 805.2ms/run | 821ms | `append_text` RPC / `swift_get_composed_text`, plus `move_cursor` |

- Findings
  - recurring bottleneck は `append_text` から `swift_get_composed_text` にかけた composition / candidate 取得経路でした。
  - clause navigation では `move_cursor` も目立ち、`ime:move_cursor/rpc_total` が約 147.3ms/run でした。
  - per-key config read と romaji lookup construction は頻発しますが、この VM ではおおむね 0-1ms/event でした。

## Verification
- [x] Codex review
  - 初回レビューで重大な問題なしを確認
- [x] 差分チェック / format
  - `cargo fmt --check`
  - `git diff --check`
- [x] ローカル Windows VM test
  - `.local/vm_test_client_composition.sh feature/85-input-latency-measurement composition all`
  - Rust: 99 tests passed
  - Swift: 37 tests passed
- [x] ローカル Windows VM build / install
  - `.local/vm_build_master.sh feature/85-input-latency-measurement`
  - artifact: `.local/artifacts/azookey-setup-feature_85-input-latency-measurement-20260608-220348.exe`
  - `.local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-feature_85-input-latency-measurement-20260608-220348.exe`
  - install log: `.local/logs/win11-install-20260608-224553.log`
- [x] ローカル Windows VM performance logging smoke
  - logging ON で `server-performance.tsv` に ime / rust / swift の stage が出力されることを確認
  - logging OFF で `server-performance.tsv` / `server.log` が増えないことを確認
- [x] ローカル Windows VM measurement
  - Issue #85 の 4 scenario を各 12 回計測
  - Tukey 1.5 IQR で外れ値除外
  - report / raw TSV / assigned rows / scenario summary / stage stats を生成
- [x] GitHub Actions build 成功
  - run: pending

## Notes
- performance logging は計測用途のため、通常利用では設定 OFF が前提です。
- stage timings は一部 nested しているため、stage contribution はボトルネックの順位付けに使い、wall-clock total として単純合算しない方針です。
- VM 計測では Notepad の visible-window startup が不安定になったため、同じ TSF 入力先として custom WinForms TextBox を使用しました。
