### PR TITLE
fix(logging): add crash trace breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,31 +169,6 @@ UNINSTALL_AFTER_INSTALL=1 scripts/vm_stage_for_manual_test.sh <installer-path|la
 
 検証用 VM はクリーンなスナップショットから起動し、インストールログを `.local/logs/` に回収します。`UNINSTALL_AFTER_INSTALL=1` を指定した場合はアンインストールログも回収します。手動確認を続ける場合は `SHUTDOWN_AFTER_INSTALL=0` を指定して、インストール後も VM を起動したままにできます。
 
-#### azookey-server.exe の crash 調査
-
-設定画面の Debug では server log の有効化、ログレベル、クラッシュトレースを設定できます。通常運用では crash trace は既定で有効、server log level は `warn` です。この状態では 1 キーごとの `AppendText` / `GetComposedText` や `server-performance.tsv` は記録せず、候補生成の直前状態だけを `%APPDATA%\Azookey\logs\server-crash-trace.json` に小さく上書きします。再起動時に前回の trace が `state: "begin"` のまま残っていた場合は、上書き前に `server-crash-trace.previous.json` へ退避します。
-
-詳細な調査が必要な場合は server log を有効にし、log level を `debug` にすると、`%APPDATA%\Azookey\logs\server.log` と `server-performance.tsv` に request id、候補生成処理、Zenzai backend などが記録されます。`azookey-server.exe` が強制終了した場合は、最後に記録された `requestCandidates begin` / `returned`、または `server-crash-trace.json` / `server-crash-trace.previous.json` の `state: "begin"` と Windows Event Viewer の faulting module を照合します。
-
-`server-crash-trace.json` は native crash でも直前処理を残すため、`requestCandidates` の直前に同期書き込みします。SSD への書き込みを抑えるため、通常の per-key 詳細ログではなく 1 つの小さな JSON ファイルの上書きに限定しています。ただし、process が crash trace 書き込みに入る前、たとえば DLL load 中や Rust `main()` より前に停止した場合は、`launcher-crash-trace.json` / `launcher-crash-trace.previous.json` に残る startup trace までが手がかりになります。
-
-Event Viewer は GUI から「Windows ログ > Application」を開くか、PowerShell で次のように確認します。
-
-```powershell
-$start = (Get-Date).AddHours(-1)
-Get-WinEvent -FilterHashtable @{ LogName = "Application"; ProviderName = "Application Error"; StartTime = $start } |
-  Where-Object { $_.Message -like "*azookey-server.exe*" } |
-  Select-Object -First 5 TimeCreated, Id, ProviderName, Message |
-  Format-List
-
-Get-WinEvent -FilterHashtable @{ LogName = "Application"; ProviderName = "Windows Error Reporting"; StartTime = $start } |
-  Where-Object { $_.Message -like "*azookey-server.exe*" } |
-  Select-Object -First 5 TimeCreated, Id, ProviderName, Message |
-  Format-List
-```
-
-`Faulting module name` が `llama.dll` などの Zenzai backend 由来か、Swift/Rust server 側かを確認し、同じ入力を Zenzai off / CPU / Vulkan / CUDA で比較します。
-
 # 関連
 
 - [azooKey/azooKey](https://github.com/azooKey/azooKey): iOS / iPadOS向けの日本語キーボードアプリ

--- a/README.md
+++ b/README.md
@@ -169,6 +169,31 @@ UNINSTALL_AFTER_INSTALL=1 scripts/vm_stage_for_manual_test.sh <installer-path|la
 
 検証用 VM はクリーンなスナップショットから起動し、インストールログを `.local/logs/` に回収します。`UNINSTALL_AFTER_INSTALL=1` を指定した場合はアンインストールログも回収します。手動確認を続ける場合は `SHUTDOWN_AFTER_INSTALL=0` を指定して、インストール後も VM を起動したままにできます。
 
+#### azookey-server.exe の crash 調査
+
+設定画面の Debug では server log の有効化、ログレベル、クラッシュトレースを設定できます。通常運用では crash trace は既定で有効、server log level は `warn` です。この状態では 1 キーごとの `AppendText` / `GetComposedText` や `server-performance.tsv` は記録せず、候補生成の直前状態だけを `%APPDATA%\Azookey\logs\server-crash-trace.json` に小さく上書きします。再起動時に前回の trace が `state: "begin"` のまま残っていた場合は、上書き前に `server-crash-trace.previous.json` へ退避します。
+
+詳細な調査が必要な場合は server log を有効にし、log level を `debug` にすると、`%APPDATA%\Azookey\logs\server.log` と `server-performance.tsv` に request id、候補生成処理、Zenzai backend などが記録されます。`azookey-server.exe` が強制終了した場合は、最後に記録された `requestCandidates begin` / `returned`、または `server-crash-trace.json` / `server-crash-trace.previous.json` の `state: "begin"` と Windows Event Viewer の faulting module を照合します。
+
+`server-crash-trace.json` は native crash でも直前処理を残すため、`requestCandidates` の直前に同期書き込みします。SSD への書き込みを抑えるため、通常の per-key 詳細ログではなく 1 つの小さな JSON ファイルの上書きに限定しています。ただし、process が crash trace 書き込みに入る前、たとえば DLL load 中や Rust `main()` より前に停止した場合は、`launcher-crash-trace.json` / `launcher-crash-trace.previous.json` に残る startup trace までが手がかりになります。
+
+Event Viewer は GUI から「Windows ログ > Application」を開くか、PowerShell で次のように確認します。
+
+```powershell
+$start = (Get-Date).AddHours(-1)
+Get-WinEvent -FilterHashtable @{ LogName = "Application"; ProviderName = "Application Error"; StartTime = $start } |
+  Where-Object { $_.Message -like "*azookey-server.exe*" } |
+  Select-Object -First 5 TimeCreated, Id, ProviderName, Message |
+  Format-List
+
+Get-WinEvent -FilterHashtable @{ LogName = "Application"; ProviderName = "Windows Error Reporting"; StartTime = $start } |
+  Where-Object { $_.Message -like "*azookey-server.exe*" } |
+  Select-Object -First 5 TimeCreated, Id, ProviderName, Message |
+  Format-List
+```
+
+`Faulting module name` が `llama.dll` などの Zenzai backend 由来か、Swift/Rust server 側かを確認し、同じ入力を Zenzai off / CPU / Vulkan / CUDA で比較します。
+
 # 関連
 
 - [azooKey/azooKey](https://github.com/azooKey/azooKey): iOS / iPadOS向けの日本語キーボードアプリ

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -86,7 +86,10 @@ pub(crate) fn client_performance_log_enabled() -> bool {
         .unwrap_or(true);
     if should_refresh {
         cache.enabled = AppConfig::read()
-            .map(|config| config.debug.server_log_enabled)
+            .map(|config| {
+                config.debug.server_log_enabled
+                    && config.debug.server_log_level.eq_ignore_ascii_case("debug")
+            })
             .unwrap_or(false);
         cache.last_checked = Some(Instant::now());
     }

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -1,7 +1,8 @@
 use shared::{zenzai_cpu_backend_supported, AppConfig};
 use std::collections::VecDeque;
 use std::ffi::c_void;
-use std::io::{BufRead, BufReader};
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::ptr::addr_of_mut;
@@ -36,6 +37,8 @@ const SERVER_WATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LAUNCHER_PIPE_PATH: &str = r"\\.\pipe\azookey_launcher";
 const LAUNCHER_RESTART_COMMAND: &str = "restart-server";
 const LAUNCHER_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+const LAUNCHER_CRASH_TRACE_FILE_NAME: &str = "launcher-crash-trace.json";
+const LAUNCHER_PREVIOUS_CRASH_TRACE_FILE_NAME: &str = "launcher-crash-trace.previous.json";
 
 fn main() -> anyhow::Result<()> {
     let cpu_backend_supported = zenzai_cpu_backend_supported();
@@ -135,7 +138,42 @@ fn start_server_process(install_dir: &Path, cpu_backend_supported: bool) -> anyh
         if cpu_backend_supported { "1" } else { "0" },
     );
 
-    spawn_process(command, "azookey-server.exe", "[server]")
+    let startup_details = format!(
+        "backend={};backend_dir={};zenzai_enable={};cpu_backend_supported={}",
+        config.zenzai.backend,
+        backend_dir(&config),
+        config.zenzai.enable,
+        cpu_backend_supported
+    );
+    write_launcher_crash_trace(
+        &config,
+        "server_startup",
+        "spawning",
+        "begin",
+        &startup_details,
+    );
+    match spawn_process(command, "azookey-server.exe", "[server]") {
+        Ok(child) => {
+            write_launcher_crash_trace(
+                &config,
+                "server_startup",
+                "spawned",
+                "begin",
+                &format!("child_pid={};{startup_details}", child.id()),
+            );
+            Ok(child)
+        }
+        Err(error) => {
+            write_launcher_crash_trace(
+                &config,
+                "server_startup",
+                "spawn",
+                "error",
+                &format!("{startup_details};error={error:?}"),
+            );
+            Err(error)
+        }
+    }
 }
 
 fn start_ui_process(install_dir: &Path) -> anyhow::Result<Child> {
@@ -160,6 +198,125 @@ fn process_command(install_dir: &Path, exe: &str) -> Command {
     };
     command.current_dir(install_dir);
     command
+}
+
+fn resolve_log_path(file_name: &str) -> Option<std::path::PathBuf> {
+    env::var("APPDATA").ok().map(|appdata| {
+        std::path::PathBuf::from(appdata)
+            .join("Azookey")
+            .join("logs")
+            .join(file_name)
+    })
+}
+
+fn json_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            ch if ch.is_control() => escaped.push(' '),
+            ch => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn crash_trace_is_in_progress(trace: &str) -> bool {
+    trace.contains("\"state\":\"begin\"") || trace.contains("\"state\": \"begin\"")
+}
+
+fn preserve_launcher_crash_trace_if_incomplete(config: &AppConfig) {
+    if !config.debug.server_crash_trace_enabled {
+        return;
+    }
+
+    let Some(source_path) = resolve_log_path(LAUNCHER_CRASH_TRACE_FILE_NAME) else {
+        return;
+    };
+    let Ok(trace) = fs::read_to_string(source_path) else {
+        return;
+    };
+    if !crash_trace_is_in_progress(&trace) {
+        return;
+    }
+
+    let Some(previous_path) = resolve_log_path(LAUNCHER_PREVIOUS_CRASH_TRACE_FILE_NAME) else {
+        return;
+    };
+    if let Some(parent) = previous_path.parent() {
+        if let Err(error) = fs::create_dir_all(parent) {
+            eprintln!("[launcher] failed to create previous crash trace directory: {error}");
+            return;
+        }
+    }
+    if let Err(error) = fs::write(previous_path, trace.as_bytes()) {
+        eprintln!("[launcher] failed to preserve previous crash trace: {error}");
+    }
+}
+
+fn write_launcher_crash_trace(
+    config: &AppConfig,
+    operation: &str,
+    stage: &str,
+    state: &str,
+    details: &str,
+) {
+    if !config.debug.server_crash_trace_enabled {
+        return;
+    }
+
+    if stage == "spawning" && state == "begin" {
+        preserve_launcher_crash_trace_if_incomplete(config);
+    }
+
+    let Some(path) = resolve_log_path(LAUNCHER_CRASH_TRACE_FILE_NAME) else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        if let Err(error) = fs::create_dir_all(parent) {
+            eprintln!("[launcher] failed to create crash trace directory: {error}");
+            return;
+        }
+    }
+
+    let trace = format!(
+        concat!(
+            "{{\n",
+            "  \"timestamp_ms\": {},\n",
+            "  \"process_id\": {},\n",
+            "  \"component\": \"launcher\",\n",
+            "  \"operation\": \"{}\",\n",
+            "  \"stage\": \"{}\",\n",
+            "  \"state\": \"{}\",\n",
+            "  \"details\": \"{}\"\n",
+            "}}\n"
+        ),
+        now_timestamp_millis(),
+        std::process::id(),
+        json_escape(operation),
+        json_escape(stage),
+        json_escape(state),
+        json_escape(details),
+    );
+
+    match File::create(path).and_then(|mut file| {
+        file.write_all(trace.as_bytes())?;
+        file.flush()
+    }) {
+        Ok(()) => {}
+        Err(error) => eprintln!("[launcher] failed to write crash trace: {error}"),
+    }
+}
+
+fn now_timestamp_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
 }
 
 fn spawn_process(mut command: Command, exe: &str, prefix: &str) -> anyhow::Result<Child> {

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -229,6 +229,10 @@ fn crash_trace_is_in_progress(trace: &str) -> bool {
     trace.contains("\"state\":\"begin\"") || trace.contains("\"state\": \"begin\"")
 }
 
+fn crash_trace_is_completed(trace: &str) -> bool {
+    trace.contains("\"state\":\"completed\"") || trace.contains("\"state\": \"completed\"")
+}
+
 fn preserve_launcher_crash_trace_if_incomplete(config: &AppConfig) {
     if !config.debug.server_crash_trace_enabled {
         return;
@@ -276,6 +280,14 @@ fn write_launcher_crash_trace(
     let Some(path) = resolve_log_path(LAUNCHER_CRASH_TRACE_FILE_NAME) else {
         return;
     };
+    if stage == "spawned"
+        && state == "begin"
+        && fs::read_to_string(&path)
+            .map(|trace| crash_trace_is_completed(&trace))
+            .unwrap_or(false)
+    {
+        return;
+    }
     if let Some(parent) = path.parent() {
         if let Err(error) = fs::create_dir_all(parent) {
             eprintln!("[launcher] failed to create crash trace directory: {error}");

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -68,6 +68,16 @@ impl AsyncWrite for TonicNamedPipeServer {
 
 impl TonicNamedPipeServer {
     pub fn new(path: &str) -> impl Stream<Item = io::Result<TonicNamedPipeServer>> {
+        Self::new_with_first_pipe_callback(path, || {})
+    }
+
+    pub fn new_with_first_pipe_callback<F>(
+        path: &str,
+        on_first_pipe_created: F,
+    ) -> impl Stream<Item = io::Result<TonicNamedPipeServer>>
+    where
+        F: FnOnce() + Send + 'static,
+    {
         // set security attributes to allow ipc from sandboxed processes
         // see https://nathancorvussolis.blogspot.com/2018/05/windows-ime-security.html
 
@@ -91,12 +101,16 @@ impl TonicNamedPipeServer {
             });
 
             stream! {
+                let mut on_first_pipe_created = Some(on_first_pipe_created);
                 let mut server = ServerOptions::new()
                     .first_pipe_instance(true)
                     .create_with_security_attributes_raw(
                         &name,
                         addr_of_mut!(security_attributes) as *mut c_void
                     )?;
+                if let Some(on_first_pipe_created) = on_first_pipe_created.take() {
+                    on_first_pipe_created();
+                }
 
                 loop {
                     server.connect().await?;

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -18,7 +18,7 @@ use std::{
     io::{BufWriter, Write},
     path::PathBuf,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
         mpsc, OnceLock,
     },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -28,6 +28,10 @@ const USE_ZENZAI: bool = true;
 const INPUT_STYLE_DIRECT: i32 = 1;
 const SERVER_LOG_FILE_NAME: &str = "server.log";
 const SERVER_PERFORMANCE_LOG_FILE_NAME: &str = "server-performance.tsv";
+const SERVER_CRASH_TRACE_FILE_NAME: &str = "server-crash-trace.json";
+const SERVER_PREVIOUS_CRASH_TRACE_FILE_NAME: &str = "server-crash-trace.previous.json";
+const LAUNCHER_CRASH_TRACE_FILE_NAME: &str = "launcher-crash-trace.json";
+const LAUNCHER_PREVIOUS_CRASH_TRACE_FILE_NAME: &str = "launcher-crash-trace.previous.json";
 const SERVER_PERFORMANCE_LOG_HEADER: &str =
     "timestamp_ms\trequest_id\tcomponent\toperation\tstage\telapsed_ms\tdetails";
 const LOG_MAX_BYTES: u64 = 4 * 1024 * 1024;
@@ -38,6 +42,8 @@ const WARMUP_INTERVAL_SECS: u64 = 30;
 static SERVER_LOG_WORKER: OnceLock<ServerLogWorker> = OnceLock::new();
 static SERVER_LOG_ENABLED: AtomicBool = AtomicBool::new(false);
 static SERVER_PERFORMANCE_LOG_ENABLED: AtomicBool = AtomicBool::new(false);
+static SERVER_LOG_LEVEL: AtomicU8 = AtomicU8::new(ServerLogLevel::Warn as u8);
+static SERVER_CRASH_TRACE_ENABLED: AtomicBool = AtomicBool::new(true);
 static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 const SERVER_GENERATED_REQUEST_ID_PREFIX: u64 = 1 << 63;
 static HAS_ACTIVE_COMPOSITION: AtomicBool = AtomicBool::new(false);
@@ -59,6 +65,16 @@ impl ServerLogLevel {
             Self::Warn => "WARN",
             Self::Info => "INFO",
             Self::Debug => "DEBUG",
+        }
+    }
+
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Error,
+            2 => Self::Warn,
+            3 => Self::Info,
+            4 => Self::Debug,
+            _ => Self::Off,
         }
     }
 }
@@ -321,10 +337,13 @@ fn should_log(level: ServerLogLevel) -> bool {
     }
 
     SERVER_LOG_ENABLED.load(Ordering::Relaxed)
+        && level <= ServerLogLevel::from_u8(SERVER_LOG_LEVEL.load(Ordering::Relaxed))
 }
 
 fn should_log_performance() -> bool {
     SERVER_PERFORMANCE_LOG_ENABLED.load(Ordering::Relaxed)
+        && ServerLogLevel::from_u8(SERVER_LOG_LEVEL.load(Ordering::Relaxed))
+            >= ServerLogLevel::Debug
 }
 
 macro_rules! log_event_lazy {
@@ -389,9 +408,18 @@ unsafe extern "C" {
     fn SetRequestId(request_id: u64);
     fn SetServerLogCallbacks(
         log_enabled: extern "C" fn() -> bool,
+        log_level_enabled: extern "C" fn(*const c_char) -> bool,
         performance_log_enabled: extern "C" fn() -> bool,
         write_log: extern "C" fn(*const c_char, *const c_char),
         write_performance_log: extern "C" fn(u64, *const c_char, *const c_char, u64, *const c_char),
+        flush_log: extern "C" fn(),
+        crash_trace_enabled: extern "C" fn() -> bool,
+        write_crash_trace: extern "C" fn(
+            *const c_char,
+            *const c_char,
+            *const c_char,
+            *const c_char,
+        ),
     );
 }
 
@@ -489,9 +517,13 @@ fn register_server_log_callbacks() {
     unsafe {
         SetServerLogCallbacks(
             AzookeyServerLogEnabled,
+            AzookeyServerLogLevelEnabled,
             AzookeyServerPerformanceLogEnabled,
             AzookeyServerLogFromSwift,
             AzookeyServerPerformanceLogFromSwift,
+            AzookeyServerLogFlushFromSwift,
+            AzookeyServerCrashTraceEnabled,
+            AzookeyServerCrashTraceFromSwift,
         );
     }
 }
@@ -523,8 +555,12 @@ fn resolve_log_path(file_name: &str) -> PathBuf {
     }
 }
 
-fn configure_server_logging(enabled: bool) -> Option<LogPaths> {
-    let paths = enabled.then(|| LogPaths {
+fn configure_server_logging(config: &AppConfig) -> Option<LogPaths> {
+    let level = server_log_level_from_str(&config.debug.server_log_level);
+    SERVER_LOG_LEVEL.store(level as u8, Ordering::Relaxed);
+    SERVER_CRASH_TRACE_ENABLED.store(config.debug.server_crash_trace_enabled, Ordering::Relaxed);
+
+    let paths = config.debug.server_log_enabled.then(|| LogPaths {
         server_log: resolve_log_path(SERVER_LOG_FILE_NAME),
         performance_log: resolve_log_path(SERVER_PERFORMANCE_LOG_FILE_NAME),
     });
@@ -550,10 +586,8 @@ fn configure_server_logging(enabled: bool) -> Option<LogPaths> {
 }
 
 fn reload_server_logging_from_settings() -> Option<LogPaths> {
-    let enabled = AppConfig::read()
-        .map(|config| config.debug.server_log_enabled)
-        .unwrap_or(false);
-    configure_server_logging(enabled)
+    let config = AppConfig::read().unwrap_or_default();
+    configure_server_logging(&config)
 }
 
 fn flush_server_logs() {
@@ -581,6 +615,159 @@ fn log_event_with_component(component: Option<&str>, level: ServerLogLevel, mess
     let line = format!("[{}] [{}] {}", now_timestamp_millis(), level_label, message);
 
     send_server_log_command(ServerLogCommand::WriteLog(line));
+}
+
+fn crash_trace_enabled() -> bool {
+    SERVER_CRASH_TRACE_ENABLED.load(Ordering::Relaxed)
+}
+
+fn json_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            ch if ch.is_control() => escaped.push(' '),
+            ch => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn compact_trace_for_log(trace: &str) -> String {
+    let compact = trace.split_whitespace().collect::<Vec<_>>().join(" ");
+    const MAX_TRACE_LOG_CHARS: usize = 512;
+    if compact.chars().count() <= MAX_TRACE_LOG_CHARS {
+        return compact;
+    }
+    compact.chars().take(MAX_TRACE_LOG_CHARS).collect()
+}
+
+fn crash_trace_is_in_progress(trace: &str) -> bool {
+    trace.contains("\"state\":\"begin\"") || trace.contains("\"state\": \"begin\"")
+}
+
+fn preserve_crash_trace_if_incomplete(
+    source_file_name: &str,
+    previous_file_name: &str,
+) -> Option<String> {
+    if !crash_trace_enabled() {
+        return None;
+    }
+
+    let source_path = resolve_log_path(source_file_name);
+    let Ok(trace) = fs::read_to_string(&source_path) else {
+        return None;
+    };
+    if !crash_trace_is_in_progress(&trace) {
+        return None;
+    }
+
+    let previous_path = resolve_log_path(previous_file_name);
+    if let Some(parent) = previous_path.parent() {
+        if let Err(error) = fs::create_dir_all(parent) {
+            eprintln!("Failed to create previous crash trace directory: {error}");
+            return Some(trace);
+        }
+    }
+    if let Err(error) = fs::write(&previous_path, trace.as_bytes()) {
+        eprintln!("Failed to preserve previous crash trace: {error}");
+    }
+    Some(trace)
+}
+
+fn log_previous_crash_trace(label: &str, trace: &str) {
+    log_event(
+        ServerLogLevel::Warn,
+        &format!(
+            "{label} was still in progress: {}",
+            compact_trace_for_log(trace)
+        ),
+    );
+}
+
+fn log_previous_crash_trace_if_incomplete(file_name: &str, label: &str) {
+    if !crash_trace_enabled() {
+        return;
+    }
+
+    let path = resolve_log_path(file_name);
+    let Ok(trace) = fs::read_to_string(path) else {
+        return;
+    };
+    if crash_trace_is_in_progress(&trace) {
+        log_previous_crash_trace(label, &trace);
+    }
+}
+
+fn write_crash_trace_file(
+    file_name: &str,
+    component: &str,
+    operation: &str,
+    stage: &str,
+    state: &str,
+    details: &str,
+) {
+    if !crash_trace_enabled() {
+        return;
+    }
+
+    let path = resolve_log_path(file_name);
+    if let Some(parent) = path.parent() {
+        if let Err(error) = fs::create_dir_all(parent) {
+            eprintln!("Failed to create crash trace directory: {error}");
+            return;
+        }
+    }
+
+    let trace = format!(
+        concat!(
+            "{{\n",
+            "  \"timestamp_ms\": {},\n",
+            "  \"process_id\": {},\n",
+            "  \"component\": \"{}\",\n",
+            "  \"operation\": \"{}\",\n",
+            "  \"stage\": \"{}\",\n",
+            "  \"state\": \"{}\",\n",
+            "  \"details\": \"{}\"\n",
+            "}}\n"
+        ),
+        now_timestamp_millis(),
+        std::process::id(),
+        json_escape(component),
+        json_escape(operation),
+        json_escape(stage),
+        json_escape(state),
+        json_escape(details),
+    );
+
+    match File::create(path).and_then(|mut file| {
+        file.write_all(trace.as_bytes())?;
+        file.flush()
+    }) {
+        Ok(()) => {}
+        Err(error) => eprintln!("Failed to write crash trace: {error}"),
+    }
+}
+
+fn write_server_crash_trace(
+    component: &str,
+    operation: &str,
+    stage: &str,
+    state: &str,
+    details: &str,
+) {
+    write_crash_trace_file(
+        SERVER_CRASH_TRACE_FILE_NAME,
+        component,
+        operation,
+        stage,
+        state,
+        details,
+    );
 }
 
 fn sanitize_performance_field(value: &str) -> String {
@@ -631,11 +818,12 @@ fn optional_cstr_lossy(ptr: *const c_char) -> String {
 
 fn server_log_level_from_str(level: &str) -> ServerLogLevel {
     match level.to_ascii_uppercase().as_str() {
+        "OFF" => ServerLogLevel::Off,
         "ERROR" => ServerLogLevel::Error,
         "WARN" | "WARNING" => ServerLogLevel::Warn,
         "INFO" => ServerLogLevel::Info,
         "DEBUG" => ServerLogLevel::Debug,
-        _ => ServerLogLevel::Info,
+        _ => ServerLogLevel::Warn,
     }
 }
 
@@ -645,17 +833,22 @@ pub extern "C" fn AzookeyServerLogEnabled() -> bool {
 }
 
 #[no_mangle]
+pub extern "C" fn AzookeyServerLogLevelEnabled(level: *const c_char) -> bool {
+    should_log(server_log_level_from_str(&optional_cstr_lossy(level)))
+}
+
+#[no_mangle]
 pub extern "C" fn AzookeyServerPerformanceLogEnabled() -> bool {
     should_log_performance()
 }
 
 #[no_mangle]
 pub extern "C" fn AzookeyServerLogFromSwift(level: *const c_char, message: *const c_char) {
-    if !AzookeyServerLogEnabled() {
+    let level = server_log_level_from_str(&optional_cstr_lossy(level));
+    if !should_log(level) {
         return;
     }
 
-    let level = server_log_level_from_str(&optional_cstr_lossy(level));
     let message = optional_cstr_lossy(message);
     log_event_with_component(Some("SWIFT"), level, &message);
 }
@@ -678,6 +871,32 @@ pub extern "C" fn AzookeyServerPerformanceLogFromSwift(
         &optional_cstr_lossy(operation),
         &optional_cstr_lossy(stage),
         elapsed_ms as u128,
+        &optional_cstr_lossy(details),
+    );
+}
+
+#[no_mangle]
+pub extern "C" fn AzookeyServerLogFlushFromSwift() {
+    flush_server_logs();
+}
+
+#[no_mangle]
+pub extern "C" fn AzookeyServerCrashTraceEnabled() -> bool {
+    crash_trace_enabled()
+}
+
+#[no_mangle]
+pub extern "C" fn AzookeyServerCrashTraceFromSwift(
+    operation: *const c_char,
+    stage: *const c_char,
+    state: *const c_char,
+    details: *const c_char,
+) {
+    write_server_crash_trace(
+        "swift",
+        &optional_cstr_lossy(operation),
+        &optional_cstr_lossy(stage),
+        &optional_cstr_lossy(state),
         &optional_cstr_lossy(details),
     );
 }
@@ -706,6 +925,13 @@ fn install_panic_hook() {
             .unwrap_or_else(|| "<unknown>".to_owned());
 
         let backtrace = Backtrace::force_capture();
+        write_server_crash_trace(
+            "rust",
+            "panic",
+            "panic_hook",
+            "error",
+            &format!("payload={payload};location={location}"),
+        );
         log_event(
             ServerLogLevel::Error,
             &format!("payload={payload}; location={location}; backtrace={backtrace}"),
@@ -1272,7 +1498,19 @@ impl AzookeyService for MyAzookeyService {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     install_panic_hook();
-    if let Some(log_paths) = reload_server_logging_from_settings() {
+    let log_paths = reload_server_logging_from_settings();
+    if let Some(trace) = preserve_crash_trace_if_incomplete(
+        SERVER_CRASH_TRACE_FILE_NAME,
+        SERVER_PREVIOUS_CRASH_TRACE_FILE_NAME,
+    ) {
+        log_previous_crash_trace("previous server crash trace", &trace);
+    }
+    log_previous_crash_trace_if_incomplete(
+        LAUNCHER_PREVIOUS_CRASH_TRACE_FILE_NAME,
+        "previous launcher startup crash trace",
+    );
+    write_server_crash_trace("rust", "server_startup", "main", "begin", "");
+    if let Some(log_paths) = log_paths {
         log_event(
             ServerLogLevel::Info,
             &format!(
@@ -1318,23 +1556,48 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 continue;
             }
 
-            log_event_lazy!(ServerLogLevel::Debug, "[warmup] start");
-            set_request_id(0);
+            let request_id = next_request_id();
+            log_event_lazy!(
+                ServerLogLevel::Debug,
+                "request_id={request_id} [warmup] start"
+            );
+            set_request_id(request_id);
             warmup();
-            log_event_lazy!(ServerLogLevel::Debug, "[warmup] done");
+            log_event_lazy!(
+                ServerLogLevel::Debug,
+                "request_id={request_id} [warmup] done"
+            );
         }
     });
 
-    log_event_lazy!(ServerLogLevel::Info, "AzookeyServer listening");
     let reflection_service = ReflectionBuilder::configure()
         .register_encoded_file_descriptor_set(shared::proto::FILE_DESCRIPTOR_SET)
         .build_v1()
         .map_err(std::io::Error::other)?;
 
+    let incoming = TonicNamedPipeServer::new_with_first_pipe_callback("azookey_server", || {
+        log_event_lazy!(ServerLogLevel::Info, "AzookeyServer listening");
+        write_server_crash_trace(
+            "rust",
+            "server_startup",
+            "listening",
+            "completed",
+            "pipe=azookey_server",
+        );
+        write_crash_trace_file(
+            LAUNCHER_CRASH_TRACE_FILE_NAME,
+            "rust",
+            "server_startup",
+            "server_listening",
+            "completed",
+            &format!("server_pid={};pipe=azookey_server", std::process::id()),
+        );
+    });
+
     Server::builder()
         .add_service(AzookeyServiceServer::new(service))
         .add_service(reflection_service)
-        .serve_with_incoming(TonicNamedPipeServer::new("azookey_server"))
+        .serve_with_incoming(incoming)
         .await
         .map_err(|error| {
             log_event(

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -689,17 +689,32 @@ fn log_previous_crash_trace(label: &str, trace: &str) {
     );
 }
 
-fn log_previous_crash_trace_if_incomplete(file_name: &str, label: &str) {
+fn log_and_consume_previous_crash_trace_if_incomplete(file_name: &str, label: &str) {
     if !crash_trace_enabled() {
         return;
     }
 
     let path = resolve_log_path(file_name);
-    let Ok(trace) = fs::read_to_string(path) else {
+    let Ok(trace) = fs::read_to_string(&path) else {
         return;
     };
     if crash_trace_is_in_progress(&trace) {
+        let should_consume = should_log(ServerLogLevel::Warn);
         log_previous_crash_trace(label, &trace);
+        if should_consume {
+            flush_server_logs();
+            match fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    log_event(
+                        ServerLogLevel::Warn,
+                        &format!("failed to clear consumed {label}: {error}"),
+                    );
+                    flush_server_logs();
+                }
+            }
+        }
     }
 }
 
@@ -1505,7 +1520,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ) {
         log_previous_crash_trace("previous server crash trace", &trace);
     }
-    log_previous_crash_trace_if_incomplete(
+    log_and_consume_previous_crash_trace_if_incomplete(
         LAUNCHER_PREVIOUS_CRASH_TRACE_FILE_NAME,
         "previous launcher startup crash trace",
     );

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -520,10 +520,15 @@ mod tests {
 
     #[test]
     fn debug_server_log_defaults_to_off() {
-        assert!(!DebugConfig::default().server_log_enabled);
+        let default_config = DebugConfig::default();
+        assert!(!default_config.server_log_enabled);
+        assert_eq!(default_config.server_log_level, "warn");
+        assert!(default_config.server_crash_trace_enabled);
 
         let deserialized: DebugConfig = serde_json::from_str("{}").unwrap();
         assert!(!deserialized.server_log_enabled);
+        assert_eq!(deserialized.server_log_level, "warn");
+        assert!(deserialized.server_crash_trace_enabled);
     }
 
     #[test]
@@ -753,10 +758,24 @@ pub struct ShortcutConfig {
     pub alt_backquote_toggle: bool,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DebugConfig {
     #[serde(default)]
     pub server_log_enabled: bool,
+    #[serde(default = "default_server_log_level")]
+    pub server_log_level: String,
+    #[serde(default = "default_server_crash_trace_enabled")]
+    pub server_crash_trace_enabled: bool,
+}
+
+impl Default for DebugConfig {
+    fn default() -> Self {
+        Self {
+            server_log_enabled: false,
+            server_log_level: default_server_log_level(),
+            server_crash_trace_enabled: default_server_crash_trace_enabled(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -813,6 +832,14 @@ impl Default for NumpadInputMode {
 }
 
 fn default_shortcut_enabled() -> bool {
+    true
+}
+
+fn default_server_log_level() -> String {
+    "warn".to_string()
+}
+
+fn default_server_crash_trace_enabled() -> bool {
     true
 }
 

--- a/frontend/src/components/debug-settings.tsx
+++ b/frontend/src/components/debug-settings.tsx
@@ -1,25 +1,56 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { FileText, RefreshCcw, Server } from "lucide-react";
+import { FileText, RefreshCcw, Server, ShieldAlert, SlidersHorizontal } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { saveConfigWithToast } from "@/lib/config";
 
+type ServerLogLevel = "off" | "error" | "warn" | "info" | "debug";
+
 type DebugConfigState = {
     server_log_enabled: boolean;
+    server_log_level: ServerLogLevel;
+    server_crash_trace_enabled: boolean;
 };
 
 const DEFAULT_DEBUG_CONFIG: DebugConfigState = {
     server_log_enabled: false,
+    server_log_level: "warn",
+    server_crash_trace_enabled: true,
 };
+
+const SERVER_LOG_LEVELS = new Set<ServerLogLevel>([
+    "off",
+    "error",
+    "warn",
+    "info",
+    "debug",
+]);
+
+const normalizeServerLogLevel = (value: unknown): ServerLogLevel =>
+    typeof value === "string" && SERVER_LOG_LEVELS.has(value as ServerLogLevel)
+        ? (value as ServerLogLevel)
+        : DEFAULT_DEBUG_CONFIG.server_log_level;
 
 const normalizeDebugConfig = (value?: Record<string, unknown>): DebugConfigState => ({
     server_log_enabled:
         typeof value?.server_log_enabled === "boolean"
             ? value.server_log_enabled
             : DEFAULT_DEBUG_CONFIG.server_log_enabled,
+    server_log_level: normalizeServerLogLevel(value?.server_log_level),
+    server_crash_trace_enabled:
+        typeof value?.server_crash_trace_enabled === "boolean"
+            ? value.server_crash_trace_enabled
+            : DEFAULT_DEBUG_CONFIG.server_crash_trace_enabled,
 });
 
 export const DebugSettings = () => {
@@ -57,18 +88,30 @@ export const DebugSettings = () => {
         }
     };
 
-    const updateServerLogEnabled = async (enabled: boolean) => {
+    const updateDebugConfig = async (patch: Partial<DebugConfigState>) => {
         const data = await saveConfigWithToast((config) => {
             config.debug = {
                 ...DEFAULT_DEBUG_CONFIG,
                 ...(config.debug ?? {}),
-                server_log_enabled: enabled,
+                ...patch,
             };
         });
 
         if (data) {
             setDebugConfig(normalizeDebugConfig(data.debug));
         }
+    };
+
+    const updateServerLogEnabled = async (enabled: boolean) => {
+        await updateDebugConfig({ server_log_enabled: enabled });
+    };
+
+    const updateServerLogLevel = async (level: ServerLogLevel) => {
+        await updateDebugConfig({ server_log_level: level });
+    };
+
+    const updateCrashTraceEnabled = async (enabled: boolean) => {
+        await updateDebugConfig({ server_crash_trace_enabled: enabled });
     };
 
     return (
@@ -85,6 +128,43 @@ export const DebugSettings = () => {
                 <Switch
                     checked={debugConfig.server_log_enabled}
                     onCheckedChange={(checked) => void updateServerLogEnabled(checked)}
+                />
+            </div>
+            <div className="flex items-center gap-4 rounded-md border p-4">
+                <SlidersHorizontal />
+                <div className="flex-1 space-y-1">
+                    <p className="text-sm font-medium leading-none">ログレベル</p>
+                    <p className="text-xs text-muted-foreground">
+                        Debug でキー入力と性能計測ログを記録します
+                    </p>
+                </div>
+                <Select
+                    value={debugConfig.server_log_level}
+                    onValueChange={(value) => void updateServerLogLevel(value as ServerLogLevel)}
+                >
+                    <SelectTrigger className="w-36">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="off">Off</SelectItem>
+                        <SelectItem value="error">Error</SelectItem>
+                        <SelectItem value="warn">Warn</SelectItem>
+                        <SelectItem value="info">Info</SelectItem>
+                        <SelectItem value="debug">Debug</SelectItem>
+                    </SelectContent>
+                </Select>
+            </div>
+            <div className="flex items-center gap-4 rounded-md border p-4">
+                <ShieldAlert />
+                <div className="flex-1 space-y-1">
+                    <p className="text-sm font-medium leading-none">クラッシュトレース</p>
+                    <p className="text-xs text-muted-foreground">
+                        直前の候補生成状態だけを小さなファイルに残します
+                    </p>
+                </div>
+                <Switch
+                    checked={debugConfig.server_crash_trace_enabled}
+                    onCheckedChange={(checked) => void updateCrashTraceEnabled(checked)}
                 />
             </div>
             <div className="flex items-center gap-4 rounded-md border p-4">

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -1569,6 +1569,12 @@ public func free_candidate_list(
         details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
     )
     serverLog("DEBUG", "GetComposedText: requestCandidates returned candidateCount=\(converted.mainResults.count) \(diagnosticDetails)")
+    crashTrace(
+        operation: "GetComposedText",
+        stage: "postprocessCandidates",
+        state: "begin",
+        details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
+    )
     var result: [FFICandidate] = []
 
     for i in 0..<converted.mainResults.count {
@@ -1600,6 +1606,13 @@ public func free_candidate_list(
     }
 
     lengthPtr.pointee = result.count
+    crashTrace(
+        operation: "GetComposedText",
+        stage: "postprocessCandidates",
+        state: "completed",
+        details: "candidate_count=\(result.count);main_candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
+    )
+    serverLog("DEBUG", "GetComposedText: postprocessCandidates completed candidateCount=\(result.count) mainCandidateCount=\(converted.mainResults.count) \(diagnosticDetails)")
     serverLog("DEBUG", "GetComposedText: completed candidateCount=\(result.count) \(diagnosticDetails)")
 
     return to_list_pointer(result)

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -39,6 +39,9 @@ let cursorPrefixExactClauseSupplementCandidateThreshold = 5
 @MainActor var currentRequestId: UInt64 = 0
 
 public typealias ServerLogEnabledCallback = @convention(c) () -> Bool
+public typealias ServerLogLevelEnabledCallback = @convention(c) (
+    UnsafePointer<CChar>?
+) -> Bool
 public typealias ServerLogWriteCallback = @convention(c) (
     UnsafePointer<CChar>?,
     UnsafePointer<CChar>?
@@ -50,33 +53,58 @@ public typealias ServerPerformanceLogWriteCallback = @convention(c) (
     UInt64,
     UnsafePointer<CChar>?
 ) -> Void
+public typealias ServerLogFlushCallback = @convention(c) () -> Void
+public typealias ServerCrashTraceWriteCallback = @convention(c) (
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?
+) -> Void
 
 private final class ServerLogCallbacks: @unchecked Sendable {
     private let lock = NSLock()
     private var logEnabled: ServerLogEnabledCallback?
+    private var logLevelEnabled: ServerLogLevelEnabledCallback?
     private var performanceLogEnabled: ServerLogEnabledCallback?
     private var writeLog: ServerLogWriteCallback?
     private var writePerformanceLog: ServerPerformanceLogWriteCallback?
+    private var flushLog: ServerLogFlushCallback?
+    private var crashTraceEnabled: ServerLogEnabledCallback?
+    private var writeCrashTrace: ServerCrashTraceWriteCallback?
 
     func configure(
         logEnabled: ServerLogEnabledCallback?,
+        logLevelEnabled: ServerLogLevelEnabledCallback?,
         performanceLogEnabled: ServerLogEnabledCallback?,
         writeLog: ServerLogWriteCallback?,
-        writePerformanceLog: ServerPerformanceLogWriteCallback?
+        writePerformanceLog: ServerPerformanceLogWriteCallback?,
+        flushLog: ServerLogFlushCallback?,
+        crashTraceEnabled: ServerLogEnabledCallback?,
+        writeCrashTrace: ServerCrashTraceWriteCallback?
     ) {
         lock.lock()
         self.logEnabled = logEnabled
+        self.logLevelEnabled = logLevelEnabled
         self.performanceLogEnabled = performanceLogEnabled
         self.writeLog = writeLog
         self.writePerformanceLog = writePerformanceLog
+        self.flushLog = flushLog
+        self.crashTraceEnabled = crashTraceEnabled
+        self.writeCrashTrace = writeCrashTrace
         lock.unlock()
     }
 
-    func isLogEnabled() -> Bool {
+    func isLogEnabled(level: String) -> Bool {
         lock.lock()
-        let callback = logEnabled
+        let fallbackCallback = logEnabled
+        let levelCallback = logLevelEnabled
         lock.unlock()
-        return callback?() ?? false
+        if let levelCallback {
+            return level.withCString { levelPointer in
+                levelCallback(levelPointer)
+            }
+        }
+        return fallbackCallback?() ?? false
     }
 
     func isPerformanceLogEnabled() -> Bool {
@@ -125,6 +153,41 @@ private final class ServerLogCallbacks: @unchecked Sendable {
             }
         }
     }
+
+    func flush() {
+        lock.lock()
+        let callback = flushLog
+        lock.unlock()
+
+        callback?()
+    }
+
+    func isCrashTraceEnabled() -> Bool {
+        lock.lock()
+        let callback = crashTraceEnabled
+        lock.unlock()
+        return callback?() ?? false
+    }
+
+    func crashTrace(operation: String, stage: String, state: String, details: String) {
+        lock.lock()
+        let callback = writeCrashTrace
+        lock.unlock()
+
+        guard let callback else {
+            return
+        }
+
+        operation.withCString { operationPointer in
+            stage.withCString { stagePointer in
+                state.withCString { statePointer in
+                    details.withCString { detailsPointer in
+                        callback(operationPointer, stagePointer, statePointer, detailsPointer)
+                    }
+                }
+            }
+        }
+    }
 }
 
 private let serverLogCallbacks = ServerLogCallbacks()
@@ -132,24 +195,57 @@ private let serverLogCallbacks = ServerLogCallbacks()
 @_silgen_name("SetServerLogCallbacks")
 public func set_server_log_callbacks(
     _ logEnabled: ServerLogEnabledCallback?,
+    _ logLevelEnabled: ServerLogLevelEnabledCallback?,
     _ performanceLogEnabled: ServerLogEnabledCallback?,
     _ writeLog: ServerLogWriteCallback?,
-    _ writePerformanceLog: ServerPerformanceLogWriteCallback?
+    _ writePerformanceLog: ServerPerformanceLogWriteCallback?,
+    _ flushLog: ServerLogFlushCallback?,
+    _ crashTraceEnabled: ServerLogEnabledCallback?,
+    _ writeCrashTrace: ServerCrashTraceWriteCallback?
 ) {
     serverLogCallbacks.configure(
         logEnabled: logEnabled,
+        logLevelEnabled: logLevelEnabled,
         performanceLogEnabled: performanceLogEnabled,
         writeLog: writeLog,
-        writePerformanceLog: writePerformanceLog
+        writePerformanceLog: writePerformanceLog,
+        flushLog: flushLog,
+        crashTraceEnabled: crashTraceEnabled,
+        writeCrashTrace: writeCrashTrace
     )
 }
 
-private func serverLog(_ level: String = "INFO", _ message: @autoclosure () -> String) {
-    guard serverLogCallbacks.isLogEnabled() else {
+@MainActor private func serverLog(
+    _ level: String = "INFO",
+    _ message: @autoclosure () -> String,
+    flush: Bool = false
+) {
+    guard serverLogCallbacks.isLogEnabled(level: level) else {
         return
     }
 
-    serverLogCallbacks.log(level: level, message: message())
+    serverLogCallbacks.log(level: level, message: "request_id=\(currentRequestId) \(message())")
+    if flush {
+        serverLogCallbacks.flush()
+    }
+}
+
+@MainActor private func crashTrace(
+    operation: String,
+    stage: String,
+    state: String,
+    details: @autoclosure () -> String = ""
+) {
+    guard serverLogCallbacks.isCrashTraceEnabled() else {
+        return
+    }
+
+    serverLogCallbacks.crashTrace(
+        operation: operation,
+        stage: stage,
+        state: state,
+        details: "request_id=\(currentRequestId);\(details())"
+    )
 }
 
 @MainActor private func performanceLog(
@@ -939,6 +1035,79 @@ private func preferCursorPrefixBoundary(
     )
 }
 
+private struct ZenzaiDiagnosticSnapshot {
+    let configuredEnabled: Bool
+    let backend: String
+    let normalizedBackend: String
+    let profileLength: Int
+    let cpuBackendSupported: Bool
+    let runtimeEnabled: Bool
+}
+
+@MainActor private func zenzaiDiagnosticSnapshot() -> ZenzaiDiagnosticSnapshot {
+    let configuredEnabled = (config["enable"] as? Bool) ?? false
+    let backend = (config["backend"] as? String) ?? "cpu"
+    let profile = (config["profile"] as? String) ?? ""
+    let cpuBackendSupported = cpuZenzaiBackendSupportedFromEnvironment()
+    return ZenzaiDiagnosticSnapshot(
+        configuredEnabled: configuredEnabled,
+        backend: backend,
+        normalizedBackend: normalizedZenzaiBackend(backend),
+        profileLength: profile.count,
+        cpuBackendSupported: cpuBackendSupported,
+        runtimeEnabled: effectiveZenzaiRuntimeEnabled(
+            isConfigured: configuredEnabled,
+            backend: backend,
+            cpuBackendSupported: cpuBackendSupported
+        )
+    )
+}
+
+private func sanitizeDiagnosticField(_ value: String, maxLength: Int = 80) -> String {
+    let text = String(value.map { character -> Character in
+        switch character {
+        case "\t", "\r", "\n", ";":
+            return " "
+        default:
+            return character
+        }
+    })
+    if text.count <= maxLength {
+        return text
+    }
+    return String(text.prefix(maxLength))
+}
+
+@MainActor private func zenzaiDiagnosticDetails(
+    snapshot: ZenzaiDiagnosticSnapshot,
+    contextLength: Int,
+    inputCount: Int,
+    hiraganaLength: Int,
+    previewHiraganaLength: Int? = nil,
+    useZenzai: Bool,
+    syntheticEndOfText: Bool? = nil
+) -> String {
+    var fields = [
+        "configured_zenzai=\(snapshot.configuredEnabled)",
+        "runtime_zenzai=\(snapshot.runtimeEnabled)",
+        "use_zenzai=\(useZenzai)",
+        "backend=\(sanitizeDiagnosticField(snapshot.normalizedBackend))",
+        "backend_raw=\(sanitizeDiagnosticField(snapshot.backend))",
+        "cpu_backend_supported=\(snapshot.cpuBackendSupported)",
+        "profile_len=\(snapshot.profileLength)",
+        "context_len=\(contextLength)",
+        "input_count=\(inputCount)",
+        "hiragana_len=\(hiraganaLength)",
+    ]
+    if let previewHiraganaLength {
+        fields.append("preview_hiragana_len=\(previewHiraganaLength)")
+    }
+    if let syntheticEndOfText {
+        fields.append("synthetic_end_of_text=\(syntheticEndOfText)")
+    }
+    return fields.joined(separator: ";")
+}
+
 @MainActor private func makeWarmupComposingText() -> ComposingText {
     var warmupComposingText = ComposingText()
     warmupComposingText.insertAtCursorPosition("a", inputStyle: currentInputStyle)
@@ -1124,15 +1293,33 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
         inputCount: composingText.input.count,
         hiraganaCount: composingText.convertTarget.count
     )
-    converter.requestCandidates(
-        composingText,
-        options: getOptions(zenzaiEnabled: useZenzaiForWarmup)
+    let diagnosticSnapshot = zenzaiDiagnosticSnapshot()
+    let diagnosticDetails = zenzaiDiagnosticDetails(
+        snapshot: diagnosticSnapshot,
+        contextLength: 0,
+        inputCount: composingText.input.count,
+        hiraganaLength: composingText.convertTarget.count,
+        useZenzai: useZenzaiForWarmup
     )
+    let options = getOptions(zenzaiEnabled: useZenzaiForWarmup)
+    crashTrace(operation: "Initialize", stage: "requestCandidates", state: "begin", details: diagnosticDetails)
+    serverLog("DEBUG", "Initialize: requestCandidates begin \(diagnosticDetails)", flush: true)
+    let converted = converter.requestCandidates(
+        composingText,
+        options: options
+    )
+    crashTrace(
+        operation: "Initialize",
+        stage: "requestCandidates",
+        state: "completed",
+        details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
+    )
+    serverLog("DEBUG", "Initialize: requestCandidates returned candidateCount=\(converted.mainResults.count) \(diagnosticDetails)")
     composingText = ComposingText()
     composingTextSnapshots.removeAll()
     serverLog(
         "INFO",
-        "Initialize: completed inputStyle=\(String(describing: currentInputStyle)) warmupUseZenzai=\(useZenzaiForWarmup)"
+        "Initialize: completed inputStyle=\(String(describing: currentInputStyle)) warmupUseZenzai=\(useZenzaiForWarmup) \(diagnosticDetails)"
     )
 }
 
@@ -1145,28 +1332,46 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 @MainActor public func warmup() {
     let contextString = (config["context"] as? String) ?? ""
     let warmupComposingText = makeWarmupComposingText()
+    let diagnosticSnapshot = zenzaiDiagnosticSnapshot()
     let useZenzai = effectiveZenzaiEnabledForCandidates(
-        isConfigured: currentRuntimeZenzaiEnabled(),
+        isConfigured: diagnosticSnapshot.runtimeEnabled,
         inputCount: warmupComposingText.input.count,
         hiraganaCount: warmupComposingText.convertTarget.count
     )
+    let diagnosticDetails = zenzaiDiagnosticDetails(
+        snapshot: diagnosticSnapshot,
+        contextLength: contextString.count,
+        inputCount: warmupComposingText.input.count,
+        hiraganaLength: warmupComposingText.convertTarget.count,
+        useZenzai: useZenzai
+    )
     serverLog(
         "DEBUG",
-        "Warmup: start hiraganaLength=\(warmupComposingText.convertTarget.count) inputCount=\(warmupComposingText.input.count) contextLength=\(contextString.count) useZenzai=\(useZenzai)"
+        "Warmup: start \(diagnosticDetails)"
     )
+    let options = getOptions(context: contextString, zenzaiEnabled: useZenzai)
+    crashTrace(operation: "Warmup", stage: "requestCandidates", state: "begin", details: diagnosticDetails)
+    serverLog("DEBUG", "Warmup: requestCandidates begin \(diagnosticDetails)", flush: true)
     let requestStart = ProcessInfo.processInfo.systemUptime
-    _ = converter.requestCandidates(
+    let converted = converter.requestCandidates(
         warmupComposingText,
-        options: getOptions(context: contextString, zenzaiEnabled: useZenzai)
+        options: options
     )
     let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
     performanceLog(
         operation: "warmup",
         stage: "request_candidates",
         elapsedMs: requestMs,
-        details: "use_zenzai=\(useZenzai);hiragana_len=\(warmupComposingText.convertTarget.count);input_count=\(warmupComposingText.input.count)"
+        details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
     )
-    serverLog("DEBUG", "Warmup: completed")
+    crashTrace(
+        operation: "Warmup",
+        stage: "requestCandidates",
+        state: "completed",
+        details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
+    )
+    serverLog("DEBUG", "Warmup: requestCandidates returned candidateCount=\(converted.mainResults.count) \(diagnosticDetails)")
+    serverLog("DEBUG", "Warmup: completed \(diagnosticDetails)")
 }
 
 @_silgen_name("HasActiveComposition")
@@ -1180,12 +1385,12 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     cursorPtr: UnsafeMutablePointer<Int>
 ) -> UnsafeMutablePointer<CChar> {
     let inputString = String(cString: input)
-    serverLog("INFO", "AppendText: start inputLength=\(inputString.count) inputStyle=\(String(describing: currentInputStyle))")
+    serverLog("DEBUG", "AppendText: start inputLength=\(inputString.count) inputStyle=\(String(describing: currentInputStyle))")
     composingText.insertAtCursorPosition(inputString, inputStyle: currentInputStyle)
 
     cursorPtr.pointee = composingText.convertTargetCursorPosition
     serverLog(
-        "INFO",
+        "DEBUG",
         "AppendText: completed cursor=\(cursorPtr.pointee) hiraganaLength=\(composingText.convertTarget.count) inputCount=\(composingText.input.count)"
     )
     return _strdup(composingText.convertTarget)!
@@ -1197,12 +1402,12 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     cursorPtr: UnsafeMutablePointer<Int>
 ) -> UnsafeMutablePointer<CChar> {
     let inputString = String(cString: input)
-    serverLog("INFO", "AppendTextDirect: start inputLength=\(inputString.count)")
+    serverLog("DEBUG", "AppendTextDirect: start inputLength=\(inputString.count)")
     composingText.insertAtCursorPosition(inputString, inputStyle: .direct)
 
     cursorPtr.pointee = composingText.convertTargetCursorPosition
     serverLog(
-        "INFO",
+        "DEBUG",
         "AppendTextDirect: completed cursor=\(cursorPtr.pointee) hiraganaLength=\(composingText.convertTarget.count)"
     )
     return _strdup(composingText.convertTarget)!
@@ -1212,12 +1417,12 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 @MainActor public func remove_text(
     cursorPtr: UnsafeMutablePointer<Int>
 ) -> UnsafeMutablePointer<CChar> {
-    serverLog("INFO", "RemoveText: start")
+    serverLog("DEBUG", "RemoveText: start")
     composingText.deleteBackwardFromCursorPosition(count: 1)
 
     cursorPtr.pointee = composingText.convertTargetCursorPosition
     serverLog(
-        "INFO",
+        "DEBUG",
         "RemoveText: completed cursor=\(cursorPtr.pointee) hiraganaLength=\(composingText.convertTarget.count) inputCount=\(composingText.input.count)"
     )
     return _strdup(composingText.convertTarget)!
@@ -1228,18 +1433,18 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     offset: Int32,
     cursorPtr: UnsafeMutablePointer<Int>
 ) -> UnsafeMutablePointer<CChar> {
-    serverLog("INFO", "MoveCursor: start offset=\(offset)")
+    serverLog("DEBUG", "MoveCursor: start offset=\(offset)")
     if offset == 125 {
         composingTextSnapshots.removeAll()
         cursorPtr.pointee = composingText.convertTargetCursorPosition
-        serverLog("INFO", "MoveCursor: clear snapshots")
+        serverLog("DEBUG", "MoveCursor: clear snapshots")
         return _strdup(composingText.convertTarget)!
     }
 
     if offset == 126 {
         composingTextSnapshots.append(composingText)
         cursorPtr.pointee = composingText.convertTargetCursorPosition
-        serverLog("INFO", "MoveCursor: push snapshot count=\(composingTextSnapshots.count)")
+        serverLog("DEBUG", "MoveCursor: push snapshot count=\(composingTextSnapshots.count)")
         return _strdup(composingText.convertTarget)!
     }
 
@@ -1248,7 +1453,7 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
             composingText = restored
         }
         cursorPtr.pointee = composingText.convertTargetCursorPosition
-        serverLog("INFO", "MoveCursor: pop snapshot remaining=\(composingTextSnapshots.count)")
+        serverLog("DEBUG", "MoveCursor: pop snapshot remaining=\(composingTextSnapshots.count)")
         return _strdup(composingText.convertTarget)!
     }
 
@@ -1256,16 +1461,16 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     serverLog("DEBUG", "MoveCursor: offset=\(offset) cursor=\(cursor)")
 
     cursorPtr.pointee = cursor
-    serverLog("INFO", "MoveCursor: completed cursor=\(cursor)")
+    serverLog("DEBUG", "MoveCursor: completed cursor=\(cursor)")
     return _strdup(composingText.convertTarget)!
 }
 
 @_silgen_name("ClearText")
 @MainActor public func clear_text() {
-    serverLog("INFO", "ClearText: start")
+    serverLog("DEBUG", "ClearText: start")
     composingText = ComposingText()
     composingTextSnapshots.removeAll()
-    serverLog("INFO", "ClearText: completed")
+    serverLog("DEBUG", "ClearText: completed")
 }
 
 func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
@@ -1322,21 +1527,32 @@ public func free_candidate_list(
 @MainActor public func get_composed_text(lengthPtr: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
     let originalHiragana = composingText.convertTarget
     let contextString = (config["context"] as? String) ?? ""
-    let runtimeZenzaiEnabled = currentRuntimeZenzaiEnabled()
+    let diagnosticSnapshot = zenzaiDiagnosticSnapshot()
+    let runtimeZenzaiEnabled = diagnosticSnapshot.runtimeEnabled
     let previewState = makeCandidatePreviewComposingText(from: composingText)
     let previewComposingText = previewState.composingText
     let previewHiragana = previewComposingText.convertTarget
-    serverLog(
-        "INFO",
-        "GetComposedText: start hiraganaLength=\(originalHiragana.count) previewHiraganaLength=\(previewHiragana.count) inputCount=\(composingText.input.count) contextLength=\(contextString.count) runtimeZenzaiEnabled=\(runtimeZenzaiEnabled) syntheticEndOfText=\(previewState.syntheticEndOfText)"
-    )
     let useZenzai = effectiveZenzaiEnabledForCandidates(
         isConfigured: runtimeZenzaiEnabled,
         inputCount: composingText.input.count,
         hiraganaCount: originalHiragana.count
     )
+    let diagnosticDetails = zenzaiDiagnosticDetails(
+        snapshot: diagnosticSnapshot,
+        contextLength: contextString.count,
+        inputCount: composingText.input.count,
+        hiraganaLength: originalHiragana.count,
+        previewHiraganaLength: previewHiragana.count,
+        useZenzai: useZenzai,
+        syntheticEndOfText: previewState.syntheticEndOfText
+    )
+    serverLog(
+        "DEBUG",
+        "GetComposedText: start \(diagnosticDetails)"
+    )
     let options = getOptions(context: contextString, zenzaiEnabled: useZenzai)
-    serverLog("INFO", "GetComposedText: requestCandidates begin useZenzai=\(useZenzai) syntheticEndOfText=\(previewState.syntheticEndOfText)")
+    crashTrace(operation: "GetComposedText", stage: "requestCandidates", state: "begin", details: diagnosticDetails)
+    serverLog("DEBUG", "GetComposedText: requestCandidates begin \(diagnosticDetails)", flush: true)
     let requestStart = ProcessInfo.processInfo.systemUptime
     let converted = converter.requestCandidates(previewComposingText, options: options)
     let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
@@ -1344,9 +1560,15 @@ public func free_candidate_list(
         operation: "get_composed_text",
         stage: "request_candidates",
         elapsedMs: requestMs,
-        details: "candidate_count=\(converted.mainResults.count);use_zenzai=\(useZenzai);synthetic_end_of_text=\(previewState.syntheticEndOfText);hiragana_len=\(originalHiragana.count);preview_hiragana_len=\(previewHiragana.count)"
+        details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
     )
-    serverLog("INFO", "GetComposedText: requestCandidates returned candidateCount=\(converted.mainResults.count)")
+    crashTrace(
+        operation: "GetComposedText",
+        stage: "requestCandidates",
+        state: "completed",
+        details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
+    )
+    serverLog("DEBUG", "GetComposedText: requestCandidates returned candidateCount=\(converted.mainResults.count) \(diagnosticDetails)")
     var result: [FFICandidate] = []
 
     for i in 0..<converted.mainResults.count {
@@ -1378,7 +1600,7 @@ public func free_candidate_list(
     }
 
     lengthPtr.pointee = result.count
-    serverLog("INFO", "GetComposedText: completed candidateCount=\(result.count) useZenzai=\(useZenzai)")
+    serverLog("DEBUG", "GetComposedText: completed candidateCount=\(result.count) \(diagnosticDetails)")
 
     return to_list_pointer(result)
 }
@@ -1396,18 +1618,34 @@ public func free_candidate_list(
     let prefixHiragana = prefixComposingText.convertTarget
     let previewPrefixHiragana = previewPrefixComposingText.convertTarget
     let contextString = (config["context"] as? String) ?? ""
-    let runtimeZenzaiEnabled = currentRuntimeZenzaiEnabled()
-    serverLog(
-        "INFO",
-        "GetComposedTextForCursorPrefix: start prefixLength=\(prefixHiragana.count) previewPrefixLength=\(previewPrefixHiragana.count) suffixLength=\(suffixAfterCursor.count) inputCount=\(prefixComposingText.input.count) contextLength=\(contextString.count) runtimeZenzaiEnabled=\(runtimeZenzaiEnabled) syntheticEndOfText=\(previewState.syntheticEndOfText)"
-    )
+    let diagnosticSnapshot = zenzaiDiagnosticSnapshot()
+    let runtimeZenzaiEnabled = diagnosticSnapshot.runtimeEnabled
     let useZenzai = effectiveZenzaiEnabledForCandidates(
         isConfigured: runtimeZenzaiEnabled,
         inputCount: prefixComposingText.input.count,
         hiraganaCount: prefixHiragana.count
     )
+    let diagnosticDetails = zenzaiDiagnosticDetails(
+        snapshot: diagnosticSnapshot,
+        contextLength: contextString.count,
+        inputCount: prefixComposingText.input.count,
+        hiraganaLength: prefixHiragana.count,
+        previewHiraganaLength: previewPrefixHiragana.count,
+        useZenzai: useZenzai,
+        syntheticEndOfText: previewState.syntheticEndOfText
+    )
+    serverLog(
+        "DEBUG",
+        "GetComposedTextForCursorPrefix: start suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+    )
     let options = getOptions(context: contextString, zenzaiEnabled: useZenzai)
-    serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates begin useZenzai=\(useZenzai) syntheticEndOfText=\(previewState.syntheticEndOfText)")
+    crashTrace(
+        operation: "GetComposedTextForCursorPrefix",
+        stage: "requestCandidates",
+        state: "begin",
+        details: "suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+    )
+    serverLog("DEBUG", "GetComposedTextForCursorPrefix: requestCandidates begin suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)", flush: true)
     let totalStart = ProcessInfo.processInfo.systemUptime
     let requestStart = ProcessInfo.processInfo.systemUptime
     let converted = converter.requestCandidates(previewPrefixComposingText, options: options)
@@ -1416,7 +1654,20 @@ public func free_candidate_list(
         operation: "get_composed_text_for_cursor_prefix",
         stage: "request_candidates",
         elapsedMs: requestMs,
-        details: "first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);use_zenzai=\(useZenzai);synthetic_end_of_text=\(previewState.syntheticEndOfText);prefix_len=\(prefixHiragana.count);preview_prefix_len=\(previewPrefixHiragana.count);suffix_len=\(suffixAfterCursor.count)"
+        details: "first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+    )
+    crashTrace(
+        operation: "GetComposedTextForCursorPrefix",
+        stage: "requestCandidates",
+        state: "completed",
+        details: "first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+    )
+    serverLog("DEBUG", "GetComposedTextForCursorPrefix: requestCandidates returned firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)")
+    crashTrace(
+        operation: "GetComposedTextForCursorPrefix",
+        stage: "postprocessCandidates",
+        state: "begin",
+        details: "phase=first_clause;first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
     var cursorPrefixResolutionCache: [String: CandidateDisplayResolution] = [:]
     let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
@@ -1444,6 +1695,26 @@ public func free_candidate_list(
         let exactClausePreviewState = makeCandidatePreviewComposingText(
             from: exactClauseComposingText
         )
+        let exactClauseDiagnosticDetails = zenzaiDiagnosticDetails(
+            snapshot: diagnosticSnapshot,
+            contextLength: contextString.count,
+            inputCount: exactClauseComposingText.input.count,
+            hiraganaLength: exactClauseComposingText.convertTarget.count,
+            previewHiraganaLength: exactClausePreviewState.composingText.convertTarget.count,
+            useZenzai: useZenzai,
+            syntheticEndOfText: exactClausePreviewState.syntheticEndOfText
+        )
+        crashTrace(
+            operation: "GetComposedTextForCursorPrefix",
+            stage: "requestCandidatesExactClause",
+            state: "begin",
+            details: "corresponding_count=\(firstClauseCorrespondingCount);\(exactClauseDiagnosticDetails)"
+        )
+        serverLog(
+            "DEBUG",
+            "GetComposedTextForCursorPrefix: requestCandidates exactClause begin correspondingCount=\(firstClauseCorrespondingCount) \(exactClauseDiagnosticDetails)",
+            flush: true
+        )
         let exactClauseRequestStart = ProcessInfo.processInfo.systemUptime
         let exactClauseConverted = converter.requestCandidates(
             exactClausePreviewState.composingText,
@@ -1455,9 +1726,25 @@ public func free_candidate_list(
             operation: "get_composed_text_for_cursor_prefix",
             stage: "request_candidates_exact_clause",
             elapsedMs: exactClauseRequestMs,
-            details: "candidate_count=\(exactClauseResults.count);use_zenzai=\(useZenzai);synthetic_end_of_text=\(exactClausePreviewState.syntheticEndOfText);prefix_len=\(prefixHiragana.count);corresponding_count=\(firstClauseCorrespondingCount)"
+            details: "candidate_count=\(exactClauseResults.count);corresponding_count=\(firstClauseCorrespondingCount);\(exactClauseDiagnosticDetails)"
+        )
+        crashTrace(
+            operation: "GetComposedTextForCursorPrefix",
+            stage: "requestCandidatesExactClause",
+            state: "completed",
+            details: "candidate_count=\(exactClauseResults.count);corresponding_count=\(firstClauseCorrespondingCount);\(exactClauseDiagnosticDetails)"
+        )
+        serverLog(
+            "DEBUG",
+            "GetComposedTextForCursorPrefix: requestCandidates exactClause returned candidateCount=\(exactClauseResults.count) correspondingCount=\(firstClauseCorrespondingCount) \(exactClauseDiagnosticDetails)"
         )
     }
+    crashTrace(
+        operation: "GetComposedTextForCursorPrefix",
+        stage: "postprocessCandidates",
+        state: "begin",
+        details: "phase=merge;preliminary_candidate_count=\(preliminaryCursorPrefixResults.count);exact_clause_candidate_count=\(exactClauseResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+    )
     let cursorPrefixResults = exactClauseResults.isEmpty
         ? preliminaryCursorPrefixResults
         : cursorPrefixCandidateDisplayResults(
@@ -1475,9 +1762,8 @@ public func free_candidate_list(
         operation: "get_composed_text_for_cursor_prefix",
         stage: "total_before_ffi_candidates",
         elapsedMs: totalMs,
-        details: "candidate_count=\(cursorPrefixResults.count);first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);exact_clause_candidate_count=\(exactClauseResults.count);use_zenzai=\(useZenzai);synthetic_end_of_text=\(previewState.syntheticEndOfText);prefix_len=\(prefixHiragana.count);preview_prefix_len=\(previewPrefixHiragana.count);suffix_len=\(suffixAfterCursor.count)"
+        details: "candidate_count=\(cursorPrefixResults.count);first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);exact_clause_candidate_count=\(exactClauseResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
-    serverLog("INFO", "GetComposedTextForCursorPrefix: requestCandidates returned candidateCount=\(cursorPrefixResults.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) exactClauseCandidateCount=\(exactClauseResults.count)")
     var result: [FFICandidate] = []
 
     for i in 0..<cursorPrefixResults.count {
@@ -1511,7 +1797,14 @@ public func free_candidate_list(
     }
 
     lengthPtr.pointee = result.count
-    serverLog("INFO", "GetComposedTextForCursorPrefix: completed candidateCount=\(result.count) useZenzai=\(useZenzai)")
+    crashTrace(
+        operation: "GetComposedTextForCursorPrefix",
+        stage: "postprocessCandidates",
+        state: "completed",
+        details: "candidate_count=\(result.count);first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);exact_clause_candidate_count=\(exactClauseResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+    )
+    serverLog("DEBUG", "GetComposedTextForCursorPrefix: postprocessCandidates completed candidateCount=\(result.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) exactClauseCandidateCount=\(exactClauseResults.count) suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)")
+    serverLog("DEBUG", "GetComposedTextForCursorPrefix: completed candidateCount=\(result.count) suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)")
 
     return to_list_pointer(result)
 }
@@ -1520,12 +1813,12 @@ public func free_candidate_list(
 @MainActor public func shrink_text(
     offset: Int32
 ) -> UnsafeMutablePointer<CChar>  {
-    serverLog("INFO", "ShrinkText: start offset=\(offset)")
+    serverLog("DEBUG", "ShrinkText: start offset=\(offset)")
     var afterComposingText = composingText
     afterComposingText.prefixComplete(composingCount: .inputCount(Int(offset)))
     composingText = afterComposingText
 
-    serverLog("INFO", "ShrinkText: completed hiraganaLength=\(composingText.convertTarget.count) inputCount=\(composingText.input.count)")
+    serverLog("DEBUG", "ShrinkText: completed hiraganaLength=\(composingText.convertTarget.count) inputCount=\(composingText.input.count)")
     return _strdup(composingText.convertTarget)!
 }
 
@@ -1535,5 +1828,5 @@ public func free_candidate_list(
 ) {
     let contextString = String(cString: context)
     config["context"] = contextString
-    serverLog("INFO", "SetContext: contextLength=\(contextString.count)")
+    serverLog("DEBUG", "SetContext: contextLength=\(contextString.count)")
 }


### PR DESCRIPTION
## Summary
- server log に `off` / `error` / `warn` / `info` / `debug` のログレベルを追加し、通常運用では 1 キーごとの詳細ログを出さないようにしました。
- crash trace を既定 ON にし、`requestCandidates` / startup / warmup などの直前状態を小さな JSON として残すようにしました。
- `server-crash-trace.json` / `.previous.json` と `launcher-crash-trace.json` / `.previous.json` を分離し、server crash 後の再起動で未完了 trace が上書きされる前に退避されるようにしました。
- Issue #88 の VM 入力調査結果と、強制終了時に crash trace が残ることの VM 検証をまとめました。

## Background
- Issue: Closes #88
- Related: #81, #85, #54
- #81 の `azookey-server.exe` 強制終了について、process ごと落ちる native crash では Rust の `Result` / tonic error では捕捉できません。
- #85 の計測では通常入力・変換・文節調整で `requestCandidates` 系が重いことが分かっていたため、今回は crash 直前の処理を `requestCandidates` / Zenzai backend / warmup or normal input まで絞れるようにします。
- 詳細ログを常時出すと入力 hot path と SSD 書き込みに影響するため、通常時は小さい crash trace のみを残し、詳細ログは debug level の調査時だけ有効にします。

## Changes
- debug settings
  - `debug.server_log_level` を追加し、設定画面から `off` / `error` / `warn` / `info` / `debug` を選択可能に変更
  - `debug.server_crash_trace_enabled` を追加し、crash trace は既定 ON に変更
  - `debug.server_log_enabled` は既定 OFF、`server_log_level` は既定 `warn`
- Rust server logging / crash trace
  - normal log と performance log に level gate を追加
  - per-key / per-candidate / performance TSV は debug level のみ出力
  - `server-crash-trace.json` に startup / requestCandidates / warmup の begin/completed を記録
  - 起動時に前回の `state: "begin"` trace を `server-crash-trace.previous.json` へ退避
  - named pipe first instance 作成後に startup trace を completed にする callback を追加
- launcher crash trace
  - launcher 側の server spawn trace を `launcher-crash-trace.json` に分離
  - server listening 到達時に Rust server から launcher trace を completed に更新
  - launcher restart 前に incomplete な launcher trace を `.previous.json` へ退避
- Swift converter crash breadcrumbs
  - `Initialize` / `Warmup` / `GetComposedText` / `GetComposedTextForCursorPrefix` / exact clause candidate request に crash trace を追加
  - `requestCandidates` の begin / returned / completed と、Zenzai enable / backend / profile length / context length / input length を記録
  - `GetComposedTextForCursorPrefix` は `requestCandidates` と postprocess / FFI candidate list construction を分けて記録

## Investigation report
- Report: `.local/measurements/issue88-20260609-0946/report.md`
- Method
  - VM 上の custom WinForms TextBox に VirtualBox scancode injection で入力
  - `kanji` + Space/Enter の通常変換と、`watashinonamaeha` + Space + Shift+Left/Right の文節調整を中心に確認
  - Zenzai off / CPU / Vulkan / CUDA の backend 差分を確認
- Results

| scenario | input | backend | requestCandidates begin/returned | Event Viewer | process |
|---|---|---|---:|---|---|
| `off-normal` | `kanji` + Space/Enter | Zenzai off | 10 / 10 | `[]` | 生存 |
| `cpu-normal` | `kanji` + Space/Enter | CPU | 13 / 13 | `[]` | 生存 |
| `vulkan-normal` | `kanji` + Space/Enter | Vulkan | 10 / 10 | `[]` | 生存 |
| `cuda-normal` | `kanji` + Space/Enter | CUDA | なし | `[]` | 生存、ただし server pipe 未作成 |
| `off-clause` | `watashinonamaeha` + Space + Shift+Left/Right | Zenzai off | 25 / 25 | `[]` | 生存 |
| `vulkan-clause` | `watashinonamaeha` + Space + Shift+Left/Right | Vulkan | 25 / 25 | `[]` | 生存 |

- Findings
  - Zenzai off / CPU / Vulkan の normal/clause では crash / panic / Event Viewer fault は再現しませんでした。
  - clause scenario では `GetComposedTextForCursorPrefix` も通り、off-clause で prefix request 2 回、vulkan-clause で prefix request 2 回 + exactClause 2 回を確認しました。
  - CUDA は process は残るものの `server.log` / `server-performance.tsv` が生成されず、`\\.\pipe\azookey_server` への接続も timeout しました。VM では crash ではなく、CUDA backend 起動途中で listening 前に停止した状態と判断しています。

## Crash trace VM verification
- Report: `.local/measurements/issue88-crash-trace-vm-20260609-2117/report.md`
- Artifact: `.local/artifacts/azookey-setup-feature_88-request-candidates-crash-tracing-20260609-202750.exe`
- Normal input
  - command: `MEASURE_DIR=.local/measurements/issue88-crash-trace-vm-20260609-2117 WARMUP_WAIT_SEC=5 bash .local/issue88_input_probe.sh off-normal`
  - `input.exit`: `0`
  - `server.log`: `0` bytes
  - `server-performance.tsv`: header only, `69` bytes
  - `launcher-crash-trace.json`: `server_startup/server_listening/completed`
  - `server-crash-trace.json`: `Warmup/requestCandidates/completed`
- Forced server termination
  - installed `Azookey Startup` scheduled task から launcher 経由で起動
  - `server-crash-trace.json` が `server_startup/main/begin` になった直後に `azookey-server.exe` を `Stop-Process -Force`
  - launcher の自動再起動後に trace を回収
  - `server-crash-trace.killed.json` と `server-crash-trace.previous.json` が同一の `server_startup/main/begin` として残ることを確認
  - restarted server は `launcher-crash-trace.json` で `server_startup/server_listening/completed` まで到達

## Verification
- [x] Codex review
  - 初回レビューで server trace を launcher が上書きする P1、cursor prefix trace 範囲の P2 を検出し修正
  - 再レビューで named pipe 作成前 completed の P2、FFI candidate list 前 completed の P3 を検出し修正
  - 最終レビューで blocking issues なしを確認
- [x] 差分チェック / format
  - `cargo fmt --all`
  - `git diff --check`
  - `git diff --cached --check`
- [x] ローカル test
  - `PROTOC=.local/tmp/protoc/bin/protoc cargo test -p shared`
  - result: 11 tests passed
- [x] ローカル Windows VM Swift test
  - `ALLOW_DIRTY_WORKTREE=1 bash .local/vm_test_client_composition.sh feature/88-request-candidates-crash-tracing skip all`
  - result: Swift 37 tests passed
- [x] ローカル Windows VM build
  - `ALLOW_DIRTY_WORKTREE=1 bash .local/vm_build_master.sh feature/88-request-candidates-crash-tracing`
  - artifact: `.local/artifacts/azookey-setup-feature_88-request-candidates-crash-tracing-20260609-202750.exe`
- [x] ローカル Windows VM install / input smoke / forced-kill trace verification
  - install log: `.local/logs/win11-install-20260609-211724.log`
  - normal input: crash trace JSON が残り、通常 detailed log は出ないことを確認
  - forced kill: incomplete server startup trace が `.previous.json` に退避されることを確認
- [ ] GitHub Actions build 成功
  - run: pending

## Notes
- crash trace は `write_all + flush` の小さい同期 JSON 書き込みです。native crash 前の breadcrumbs を残すため、完全な crash 後書き込みではなく、危険な処理の直前/直後に上書きします。
- SSD 書き込みを抑えるため、per-key 詳細ログや performance TSV は debug level のみ出す方針です。
- atomic rename / fsync ではないため、電源断や書き込み途中の異常では空/部分 JSON の可能性は残ります。
- `state=completed` 後の crash は incomplete 退避対象ではありません。その場合は最後の completed trace と Event Viewer の faulting module を照合します。
