### PR TITLE
perf(server): reduce GetComposedText latency

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -13,6 +13,7 @@ use shared::AppConfig;
 
 use std::{
     backtrace::Backtrace,
+    collections::HashSet,
     ffi::{c_char, c_int, CStr, CString},
     fs::{self, File, OpenOptions},
     io::{BufWriter, Write},
@@ -485,12 +486,34 @@ impl OwnedFfiCandidates {
     unsafe fn candidate_ptr(&self, index: usize) -> *mut FFICandidate {
         *self.ptr.add(index)
     }
+
+    fn free_with_performance(mut self, request_id: u64, operation: &str) {
+        let ptr = self.ptr;
+        let length = self.length;
+        self.ptr = std::ptr::null_mut();
+        self.length = 0;
+
+        let free_start = Instant::now();
+        unsafe {
+            FreeCandidateList(ptr, length);
+        }
+        performance_event_lazy!(
+            request_id,
+            operation,
+            "free_candidate_list",
+            elapsed_ms(free_start),
+            "candidate_count={}",
+            length.max(0)
+        );
+    }
 }
 
 impl Drop for OwnedFfiCandidates {
     fn drop(&mut self) {
-        unsafe {
-            FreeCandidateList(self.ptr, self.length);
+        if !self.ptr.is_null() {
+            unsafe {
+                FreeCandidateList(self.ptr, self.length);
+            }
         }
     }
 }
@@ -530,6 +553,16 @@ fn register_server_log_callbacks() {
 
 fn elapsed_ms(start: Instant) -> u128 {
     start.elapsed().as_millis()
+}
+
+fn performance_instant(enabled: bool) -> Option<Instant> {
+    enabled.then(Instant::now)
+}
+
+fn add_elapsed_ms(total: &mut u128, start: Option<Instant>) {
+    if let Some(start) = start {
+        *total += elapsed_ms(start);
+    }
 }
 
 fn now_timestamp_millis() -> u128 {
@@ -1084,8 +1117,14 @@ fn update_active_composition_state(text: &str) {
     HAS_ACTIVE_COMPOSITION.store(!text.is_empty(), Ordering::Relaxed);
 }
 
-fn get_composed_text(use_cursor_prefix: bool) -> Result<ComposedText, String> {
+fn get_composed_text(use_cursor_prefix: bool, request_id: u64) -> Result<ComposedText, String> {
     let mut length: c_int = 0;
+    let operation = if use_cursor_prefix {
+        "get_composed_text_for_cursor_prefix"
+    } else {
+        "get_composed_text"
+    };
+    let ffi_call_start = Instant::now();
     let result = unsafe {
         if use_cursor_prefix {
             GetComposedTextForCursorPrefix(&mut length)
@@ -1100,9 +1139,21 @@ fn get_composed_text(use_cursor_prefix: bool) -> Result<ComposedText, String> {
     };
     let candidates = unsafe { OwnedFfiCandidates::from_raw(call_name, result, length)? };
     let length = candidates.len();
+    performance_event_lazy!(
+        request_id,
+        operation,
+        "ffi_call",
+        elapsed_ms(ffi_call_start),
+        "candidate_count={length};use_cursor_prefix={use_cursor_prefix}"
+    );
 
     let mut suggestions = Vec::with_capacity(length);
     let mut hiragana = None;
+    let mut seen_texts = HashSet::with_capacity(length);
+    let performance_enabled = should_log_performance();
+    let mut cstr_decode_ms = 0;
+    let mut dedup_ms = 0;
+    let mut duplicate_count = 0usize;
     log_event_lazy!(
         ServerLogLevel::Debug,
         "[{call_name}] candidate_count={length}"
@@ -1130,19 +1181,34 @@ fn get_composed_text(use_cursor_prefix: bool) -> Result<ComposedText, String> {
         }
 
         if hiragana.is_none() && !candidate.hiragana.is_null() {
+            let decode_start = performance_instant(performance_enabled);
             hiragana = Some(
                 unsafe { CStr::from_ptr(candidate.hiragana) }
                     .to_string_lossy()
                     .into_owned(),
             );
+            add_elapsed_ms(&mut cstr_decode_ms, decode_start);
         }
 
+        let text_decode_start = performance_instant(performance_enabled);
         let text = unsafe { CStr::from_ptr(candidate.text) }
             .to_string_lossy()
             .into_owned();
+        add_elapsed_ms(&mut cstr_decode_ms, text_decode_start);
+
+        let dedup_start = performance_instant(performance_enabled);
+        if !seen_texts.insert(text.clone()) {
+            duplicate_count += 1;
+            add_elapsed_ms(&mut dedup_ms, dedup_start);
+            continue;
+        }
+        add_elapsed_ms(&mut dedup_ms, dedup_start);
+
+        let subtext_decode_start = performance_instant(performance_enabled);
         let subtext = unsafe { CStr::from_ptr(candidate.subtext) }
             .to_string_lossy()
             .into_owned();
+        add_elapsed_ms(&mut cstr_decode_ms, subtext_decode_start);
         let corresponding_count = candidate.corresponding_count;
 
         let suggestion = Suggestion {
@@ -1151,14 +1217,25 @@ fn get_composed_text(use_cursor_prefix: bool) -> Result<ComposedText, String> {
             corresponding_count,
         };
 
-        if suggestions
-            .iter()
-            .any(|s: &Suggestion| s.text == suggestion.text)
-        {
-            continue;
-        }
         suggestions.push(suggestion);
     }
+    performance_event_lazy!(
+        request_id,
+        operation,
+        "cstr_decode",
+        cstr_decode_ms,
+        "candidate_count={length};unique_candidate_count={};duplicate_count={duplicate_count}",
+        suggestions.len()
+    );
+    performance_event_lazy!(
+        request_id,
+        operation,
+        "dedup",
+        dedup_ms,
+        "candidate_count={length};unique_candidate_count={};duplicate_count={duplicate_count}",
+        suggestions.len()
+    );
+    candidates.free_with_performance(request_id, operation);
 
     Ok(ComposedText {
         hiragana,
@@ -1206,8 +1283,8 @@ impl AzookeyService for MyAzookeyService {
             "input_len={input_len};input_style={input_style}"
         );
         let get_composed_start = Instant::now();
-        let composed_text =
-            get_composed_text(false).map_err(|error| status_from_error("append_text", error))?;
+        let composed_text = get_composed_text(false, request_id)
+            .map_err(|error| status_from_error("append_text", error))?;
         performance_event_lazy!(
             request_id,
             "append_text",
@@ -1262,8 +1339,8 @@ impl AzookeyService for MyAzookeyService {
             composing_text.text.chars().count()
         );
         let get_composed_start = Instant::now();
-        let composed_text =
-            get_composed_text(false).map_err(|error| status_from_error("remove_text", error))?;
+        let composed_text = get_composed_text(false, request_id)
+            .map_err(|error| status_from_error("remove_text", error))?;
         performance_event_lazy!(
             request_id,
             "remove_text",
@@ -1316,7 +1393,7 @@ impl AzookeyService for MyAzookeyService {
             composing_text.text.chars().count()
         );
         let get_composed_start = Instant::now();
-        let composed_text = get_composed_text(use_cursor_prefix)
+        let composed_text = get_composed_text(use_cursor_prefix, request_id)
             .map_err(|error| status_from_error("move_cursor", error))?;
         performance_event_lazy!(
             request_id,
@@ -1396,8 +1473,8 @@ impl AzookeyService for MyAzookeyService {
             composing_text.text.chars().count()
         );
         let get_composed_start = Instant::now();
-        let composed_text =
-            get_composed_text(false).map_err(|error| status_from_error("shrink_text", error))?;
+        let composed_text = get_composed_text(false, request_id)
+            .map_err(|error| status_from_error("shrink_text", error))?;
         performance_event_lazy!(
             request_id,
             "shrink_text",

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -248,6 +248,20 @@ public func set_server_log_callbacks(
     )
 }
 
+@MainActor private func candidateCrashTrace(
+    useZenzai: Bool,
+    operation: String,
+    stage: String,
+    state: String,
+    details: @autoclosure () -> String = ""
+) {
+    guard useZenzai else {
+        return
+    }
+
+    crashTrace(operation: operation, stage: stage, state: state, details: details())
+}
+
 @MainActor private func performanceLog(
     operation: String,
     stage: String,
@@ -265,6 +279,14 @@ public func set_server_log_callbacks(
         elapsedMs: UInt64(max(0, elapsedMs)),
         details: details()
     )
+}
+
+private func performanceNow() -> TimeInterval {
+    ProcessInfo.processInfo.systemUptime
+}
+
+private func elapsedPerformanceMilliseconds(since start: TimeInterval) -> Int {
+    Int((performanceNow() - start) * 1000)
 }
 
 private func settingsPath() -> URL? {
@@ -780,22 +802,6 @@ private func preferCursorPrefixBoundary(
     return resolved
 }
 
-@MainActor private func debugLogResolvedCorrespondingCount(
-    scope: String,
-    candidateIndex: Int,
-    candidateTotal: Int,
-    candidateComposingCount: ComposingCount,
-    resolvedCorrespondingCount: Int,
-    inputCount: Int,
-    isZenzaiEnabled: Bool
-) {
-    let mode = isZenzaiEnabled ? "zenzai" : "standard"
-    serverLog(
-        "DEBUG",
-        "[\(scope)] mode=\(mode) candidate[\(candidateIndex + 1)/\(candidateTotal)] composingCount=\(candidateComposingCount) resolvedCorrespondingCount=\(resolvedCorrespondingCount) inputCount=\(inputCount)"
-    )
-}
-
 @MainActor func cursorPrefixCandidateResults(
     mainResults: [Candidate],
     firstClauseResults: [Candidate],
@@ -1130,18 +1136,23 @@ struct SComposingText {
 }
 
 func constructCandidateString(candidate: Candidate, hiragana: String) -> String {
-    var remainingHiragana = hiragana
     var result = ""
-    
+    result.reserveCapacity(hiragana.count)
+
+    var remainingStart = hiragana.startIndex
+    var remainingCount = hiragana.count
     for data in candidate.data {
-        if remainingHiragana.count < data.ruby.count {
-            result += remainingHiragana
+        let rubyCount = data.ruby.count
+        if remainingCount < rubyCount {
+            result += hiragana[remainingStart...]
             break
         }
-        remainingHiragana.removeFirst(data.ruby.count)
+
+        remainingStart = hiragana.index(remainingStart, offsetBy: rubyCount)
+        remainingCount -= rubyCount
         result += data.word
     }
-    
+
     return result
 }
 
@@ -1382,13 +1393,13 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 @_silgen_name("AppendText")
 @MainActor public func append_text(
     input: UnsafePointer<CChar>,
-    cursorPtr: UnsafeMutablePointer<Int>
+    cursorPtr: UnsafeMutablePointer<CInt>
 ) -> UnsafeMutablePointer<CChar> {
     let inputString = String(cString: input)
     serverLog("DEBUG", "AppendText: start inputLength=\(inputString.count) inputStyle=\(String(describing: currentInputStyle))")
     composingText.insertAtCursorPosition(inputString, inputStyle: currentInputStyle)
 
-    cursorPtr.pointee = composingText.convertTargetCursorPosition
+    cursorPtr.pointee = CInt(composingText.convertTargetCursorPosition)
     serverLog(
         "DEBUG",
         "AppendText: completed cursor=\(cursorPtr.pointee) hiraganaLength=\(composingText.convertTarget.count) inputCount=\(composingText.input.count)"
@@ -1399,13 +1410,13 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 @_silgen_name("AppendTextDirect")
 @MainActor public func append_text_direct(
     input: UnsafePointer<CChar>,
-    cursorPtr: UnsafeMutablePointer<Int>
+    cursorPtr: UnsafeMutablePointer<CInt>
 ) -> UnsafeMutablePointer<CChar> {
     let inputString = String(cString: input)
     serverLog("DEBUG", "AppendTextDirect: start inputLength=\(inputString.count)")
     composingText.insertAtCursorPosition(inputString, inputStyle: .direct)
 
-    cursorPtr.pointee = composingText.convertTargetCursorPosition
+    cursorPtr.pointee = CInt(composingText.convertTargetCursorPosition)
     serverLog(
         "DEBUG",
         "AppendTextDirect: completed cursor=\(cursorPtr.pointee) hiraganaLength=\(composingText.convertTarget.count)"
@@ -1415,12 +1426,12 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 
 @_silgen_name("RemoveText")
 @MainActor public func remove_text(
-    cursorPtr: UnsafeMutablePointer<Int>
+    cursorPtr: UnsafeMutablePointer<CInt>
 ) -> UnsafeMutablePointer<CChar> {
     serverLog("DEBUG", "RemoveText: start")
     composingText.deleteBackwardFromCursorPosition(count: 1)
 
-    cursorPtr.pointee = composingText.convertTargetCursorPosition
+    cursorPtr.pointee = CInt(composingText.convertTargetCursorPosition)
     serverLog(
         "DEBUG",
         "RemoveText: completed cursor=\(cursorPtr.pointee) hiraganaLength=\(composingText.convertTarget.count) inputCount=\(composingText.input.count)"
@@ -1431,19 +1442,19 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 @_silgen_name("MoveCursor")
 @MainActor public func move_cursor(
     offset: Int32,
-    cursorPtr: UnsafeMutablePointer<Int>
+    cursorPtr: UnsafeMutablePointer<CInt>
 ) -> UnsafeMutablePointer<CChar> {
     serverLog("DEBUG", "MoveCursor: start offset=\(offset)")
     if offset == 125 {
         composingTextSnapshots.removeAll()
-        cursorPtr.pointee = composingText.convertTargetCursorPosition
+        cursorPtr.pointee = CInt(composingText.convertTargetCursorPosition)
         serverLog("DEBUG", "MoveCursor: clear snapshots")
         return _strdup(composingText.convertTarget)!
     }
 
     if offset == 126 {
         composingTextSnapshots.append(composingText)
-        cursorPtr.pointee = composingText.convertTargetCursorPosition
+        cursorPtr.pointee = CInt(composingText.convertTargetCursorPosition)
         serverLog("DEBUG", "MoveCursor: push snapshot count=\(composingTextSnapshots.count)")
         return _strdup(composingText.convertTarget)!
     }
@@ -1452,7 +1463,7 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
         if let restored = composingTextSnapshots.popLast() {
             composingText = restored
         }
-        cursorPtr.pointee = composingText.convertTargetCursorPosition
+        cursorPtr.pointee = CInt(composingText.convertTargetCursorPosition)
         serverLog("DEBUG", "MoveCursor: pop snapshot remaining=\(composingTextSnapshots.count)")
         return _strdup(composingText.convertTarget)!
     }
@@ -1460,7 +1471,7 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     let cursor = composingText.moveCursorFromCursorPosition(count: Int(offset))
     serverLog("DEBUG", "MoveCursor: offset=\(offset) cursor=\(cursor)")
 
-    cursorPtr.pointee = cursor
+    cursorPtr.pointee = CInt(cursor)
     serverLog("DEBUG", "MoveCursor: completed cursor=\(cursor)")
     return _strdup(composingText.convertTarget)!
 }
@@ -1475,10 +1486,14 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 
 func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
     let pointer = UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?>.allocate(capacity: list.count)
-    for (i, item) in list.enumerated() {
-        let candidatePtr = UnsafeMutablePointer<FFICandidate>.allocate(capacity: 1)
-        candidatePtr.initialize(to: item)
-        pointer.advanced(by: i).initialize(to: candidatePtr)
+    guard !list.isEmpty else {
+        return pointer
+    }
+
+    let candidateStorage = UnsafeMutablePointer<FFICandidate>.allocate(capacity: list.count)
+    candidateStorage.initialize(from: list, count: list.count)
+    for i in 0..<list.count {
+        pointer.advanced(by: i).initialize(to: candidateStorage.advanced(by: i))
     }
     return pointer
 }
@@ -1506,7 +1521,19 @@ public func free_candidate_list(
         return
     }
 
-    for index in 0..<Int(length) {
+    let count = Int(length)
+    guard count > 0 else {
+        ptr.deallocate()
+        return
+    }
+
+    let candidateStorage = ptr[0]
+    let isContiguousCandidateStorage = candidateStorage.map { storage in
+        (0..<count).allSatisfy { index in
+            ptr[index] == storage.advanced(by: index)
+        }
+    } ?? false
+    for index in 0..<count {
         guard let candidatePtr = ptr[index] else {
             continue
         }
@@ -1515,16 +1542,29 @@ public func free_candidate_list(
         free(candidate.text)
         free(candidate.subtext)
         free(candidate.hiragana)
-        candidatePtr.deinitialize(count: 1)
-        candidatePtr.deallocate()
     }
 
-    ptr.deinitialize(count: Int(length))
+    if isContiguousCandidateStorage, let candidateStorage {
+        candidateStorage.deinitialize(count: count)
+        candidateStorage.deallocate()
+    } else {
+        for index in 0..<count {
+            guard let candidatePtr = ptr[index] else {
+                continue
+            }
+            candidatePtr.deinitialize(count: 1)
+            candidatePtr.deallocate()
+        }
+    }
+
+    ptr.deinitialize(count: count)
     ptr.deallocate()
 }
 
 @_silgen_name("GetComposedText")
-@MainActor public func get_composed_text(lengthPtr: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
+@MainActor public func get_composed_text(lengthPtr: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
+    let functionStart = performanceNow()
+    let performanceEnabled = serverLogCallbacks.isPerformanceLogEnabled()
     let originalHiragana = composingText.convertTarget
     let contextString = (config["context"] as? String) ?? ""
     let diagnosticSnapshot = zenzaiDiagnosticSnapshot()
@@ -1551,62 +1591,117 @@ public func free_candidate_list(
         "GetComposedText: start \(diagnosticDetails)"
     )
     let options = getOptions(context: contextString, zenzaiEnabled: useZenzai)
-    crashTrace(operation: "GetComposedText", stage: "requestCandidates", state: "begin", details: diagnosticDetails)
-    serverLog("DEBUG", "GetComposedText: requestCandidates begin \(diagnosticDetails)", flush: true)
-    let requestStart = ProcessInfo.processInfo.systemUptime
+    candidateCrashTrace(
+        useZenzai: useZenzai,
+        operation: "GetComposedText",
+        stage: "requestCandidates",
+        state: "begin",
+        details: diagnosticDetails
+    )
+    serverLog("DEBUG", "GetComposedText: requestCandidates begin \(diagnosticDetails)")
+    if performanceEnabled {
+        performanceLog(
+            operation: "get_composed_text",
+            stage: "prepare_request",
+            elapsedMs: elapsedPerformanceMilliseconds(since: functionStart),
+            details: diagnosticDetails
+        )
+    }
+    let requestStart = performanceNow()
     let converted = converter.requestCandidates(previewComposingText, options: options)
-    let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
+    let requestMs = elapsedPerformanceMilliseconds(since: requestStart)
     performanceLog(
         operation: "get_composed_text",
         stage: "request_candidates",
         elapsedMs: requestMs,
         details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
     )
-    crashTrace(
+    candidateCrashTrace(
+        useZenzai: useZenzai,
         operation: "GetComposedText",
         stage: "requestCandidates",
         state: "completed",
         details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
     )
     serverLog("DEBUG", "GetComposedText: requestCandidates returned candidateCount=\(converted.mainResults.count) \(diagnosticDetails)")
-    crashTrace(
+    candidateCrashTrace(
+        useZenzai: useZenzai,
         operation: "GetComposedText",
         stage: "postprocessCandidates",
         state: "begin",
         details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
     )
+    let buildStart = performanceEnabled ? performanceNow() : 0
+    var constructCandidateStringMs = 0
+    var resolveCandidateCompositionMs = 0
+    var strdupCandidatesMs = 0
+    var resolutionCache: [String: CandidateDisplayResolution] = [:]
     var result: [FFICandidate] = []
+    result.reserveCapacity(converted.mainResults.count)
 
     for i in 0..<converted.mainResults.count {
         let candidate = converted.mainResults[i]
-        serverLog("DEBUG", "GetComposedText: candidate[\(i + 1)/\(converted.mainResults.count)] start")
 
-        let text = strdup(constructCandidateString(candidate: candidate, hiragana: previewHiragana))
-        serverLog("DEBUG", "GetComposedText: candidate[\(i + 1)] textReady")
-        let hiragana = strdup(previewHiragana)
+        let constructStart = performanceEnabled ? performanceNow() : 0
+        let candidateText = constructCandidateString(candidate: candidate, hiragana: previewHiragana)
+        if performanceEnabled {
+            constructCandidateStringMs += elapsedPerformanceMilliseconds(since: constructStart)
+        }
+
+        let resolveStart = performanceEnabled ? performanceNow() : 0
         let resolvedCandidate = resolveCandidateCompositionForDisplay(
             originalComposingText: composingText,
             previewComposingText: previewComposingText,
-            candidateComposingCount: candidate.composingCount
-        )
-        let correspondingCount = resolvedCandidate.correspondingCount
-        debugLogResolvedCorrespondingCount(
-            scope: "GetComposedText",
-            candidateIndex: i,
-            candidateTotal: converted.mainResults.count,
             candidateComposingCount: candidate.composingCount,
-            resolvedCorrespondingCount: correspondingCount,
-            inputCount: composingText.input.count,
-            isZenzaiEnabled: useZenzai
+            resolutionCache: &resolutionCache
         )
-        let subtext = strdup(resolvedCandidate.remainingConvertTarget)
-        serverLog("DEBUG", "GetComposedText: candidate[\(i + 1)] subtextReady")
+        if performanceEnabled {
+            resolveCandidateCompositionMs += elapsedPerformanceMilliseconds(since: resolveStart)
+        }
+        let correspondingCount = resolvedCandidate.correspondingCount
+
+        let strdupStart = performanceEnabled ? performanceNow() : 0
+        let text = _strdup(candidateText)
+        let subtext = _strdup(resolvedCandidate.remainingConvertTarget)
+        let hiragana = i == 0 ? _strdup(previewHiragana) : nil
+        if performanceEnabled {
+            strdupCandidatesMs += elapsedPerformanceMilliseconds(since: strdupStart)
+        }
 
         result.append(FFICandidate(text: text, subtext: subtext, hiragana: hiragana, correspondingCount: Int32(correspondingCount)))
     }
 
-    lengthPtr.pointee = result.count
-    crashTrace(
+    lengthPtr.pointee = CInt(result.count)
+    let listPointer = to_list_pointer(result)
+    if performanceEnabled {
+        let stringAllocationCount = result.isEmpty ? 0 : result.count * 2 + 1
+        performanceLog(
+            operation: "get_composed_text",
+            stage: "construct_candidate_string",
+            elapsedMs: constructCandidateStringMs,
+            details: "candidate_count=\(result.count);main_candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
+        )
+        performanceLog(
+            operation: "get_composed_text",
+            stage: "resolve_candidate_composition",
+            elapsedMs: resolveCandidateCompositionMs,
+            details: "candidate_count=\(result.count);cache_entries=\(resolutionCache.count);\(diagnosticDetails)"
+        )
+        performanceLog(
+            operation: "get_composed_text",
+            stage: "strdup_candidates",
+            elapsedMs: strdupCandidatesMs,
+            details: "candidate_count=\(result.count);string_allocations=\(stringAllocationCount);\(diagnosticDetails)"
+        )
+        performanceLog(
+            operation: "get_composed_text",
+            stage: "build_ffi_candidates_total",
+            elapsedMs: elapsedPerformanceMilliseconds(since: buildStart),
+            details: "candidate_count=\(result.count);main_candidate_count=\(converted.mainResults.count);cache_entries=\(resolutionCache.count);string_allocations=\(stringAllocationCount);\(diagnosticDetails)"
+        )
+    }
+    candidateCrashTrace(
+        useZenzai: useZenzai,
         operation: "GetComposedText",
         stage: "postprocessCandidates",
         state: "completed",
@@ -1615,11 +1710,13 @@ public func free_candidate_list(
     serverLog("DEBUG", "GetComposedText: postprocessCandidates completed candidateCount=\(result.count) mainCandidateCount=\(converted.mainResults.count) \(diagnosticDetails)")
     serverLog("DEBUG", "GetComposedText: completed candidateCount=\(result.count) \(diagnosticDetails)")
 
-    return to_list_pointer(result)
+    return listPointer
 }
 
 @_silgen_name("GetComposedTextForCursorPrefix")
-@MainActor public func get_composed_text_for_cursor_prefix(lengthPtr: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
+@MainActor public func get_composed_text_for_cursor_prefix(lengthPtr: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
+    let functionStart = performanceNow()
+    let performanceEnabled = serverLogCallbacks.isPerformanceLogEnabled()
     let hiragana = composingText.convertTarget
     let suffixAfterCursor = String(hiragana.dropFirst(composingText.convertTargetCursorPosition))
     let prefixComposingText = composingText.prefixToCursorPosition()
@@ -1652,31 +1749,42 @@ public func free_candidate_list(
         "GetComposedTextForCursorPrefix: start suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
     let options = getOptions(context: contextString, zenzaiEnabled: useZenzai)
-    crashTrace(
+    candidateCrashTrace(
+        useZenzai: useZenzai,
         operation: "GetComposedTextForCursorPrefix",
         stage: "requestCandidates",
         state: "begin",
         details: "suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
-    serverLog("DEBUG", "GetComposedTextForCursorPrefix: requestCandidates begin suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)", flush: true)
-    let totalStart = ProcessInfo.processInfo.systemUptime
-    let requestStart = ProcessInfo.processInfo.systemUptime
+    serverLog("DEBUG", "GetComposedTextForCursorPrefix: requestCandidates begin suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)")
+    if performanceEnabled {
+        performanceLog(
+            operation: "get_composed_text_for_cursor_prefix",
+            stage: "prepare_request",
+            elapsedMs: elapsedPerformanceMilliseconds(since: functionStart),
+            details: "suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+        )
+    }
+    let totalStart = performanceNow()
+    let requestStart = performanceNow()
     let converted = converter.requestCandidates(previewPrefixComposingText, options: options)
-    let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
+    let requestMs = elapsedPerformanceMilliseconds(since: requestStart)
     performanceLog(
         operation: "get_composed_text_for_cursor_prefix",
         stage: "request_candidates",
         elapsedMs: requestMs,
         details: "first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
-    crashTrace(
+    candidateCrashTrace(
+        useZenzai: useZenzai,
         operation: "GetComposedTextForCursorPrefix",
         stage: "requestCandidates",
         state: "completed",
         details: "first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
     serverLog("DEBUG", "GetComposedTextForCursorPrefix: requestCandidates returned firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)")
-    crashTrace(
+    candidateCrashTrace(
+        useZenzai: useZenzai,
         operation: "GetComposedTextForCursorPrefix",
         stage: "postprocessCandidates",
         state: "begin",
@@ -1717,7 +1825,8 @@ public func free_candidate_list(
             useZenzai: useZenzai,
             syntheticEndOfText: exactClausePreviewState.syntheticEndOfText
         )
-        crashTrace(
+        candidateCrashTrace(
+            useZenzai: useZenzai,
             operation: "GetComposedTextForCursorPrefix",
             stage: "requestCandidatesExactClause",
             state: "begin",
@@ -1725,23 +1834,23 @@ public func free_candidate_list(
         )
         serverLog(
             "DEBUG",
-            "GetComposedTextForCursorPrefix: requestCandidates exactClause begin correspondingCount=\(firstClauseCorrespondingCount) \(exactClauseDiagnosticDetails)",
-            flush: true
+            "GetComposedTextForCursorPrefix: requestCandidates exactClause begin correspondingCount=\(firstClauseCorrespondingCount) \(exactClauseDiagnosticDetails)"
         )
-        let exactClauseRequestStart = ProcessInfo.processInfo.systemUptime
+        let exactClauseRequestStart = performanceNow()
         let exactClauseConverted = converter.requestCandidates(
             exactClausePreviewState.composingText,
             options: options
         )
         exactClauseResults = exactClauseConverted.mainResults
-        let exactClauseRequestMs = Int((ProcessInfo.processInfo.systemUptime - exactClauseRequestStart) * 1000)
+        let exactClauseRequestMs = elapsedPerformanceMilliseconds(since: exactClauseRequestStart)
         performanceLog(
             operation: "get_composed_text_for_cursor_prefix",
             stage: "request_candidates_exact_clause",
             elapsedMs: exactClauseRequestMs,
             details: "candidate_count=\(exactClauseResults.count);corresponding_count=\(firstClauseCorrespondingCount);\(exactClauseDiagnosticDetails)"
         )
-        crashTrace(
+        candidateCrashTrace(
+            useZenzai: useZenzai,
             operation: "GetComposedTextForCursorPrefix",
             stage: "requestCandidatesExactClause",
             state: "completed",
@@ -1752,7 +1861,8 @@ public func free_candidate_list(
             "GetComposedTextForCursorPrefix: requestCandidates exactClause returned candidateCount=\(exactClauseResults.count) correspondingCount=\(firstClauseCorrespondingCount) \(exactClauseDiagnosticDetails)"
         )
     }
-    crashTrace(
+    candidateCrashTrace(
+        useZenzai: useZenzai,
         operation: "GetComposedTextForCursorPrefix",
         stage: "postprocessCandidates",
         state: "begin",
@@ -1770,47 +1880,72 @@ public func free_candidate_list(
             previewHiragana: previewPrefixHiragana,
             resolutionCache: &cursorPrefixResolutionCache
         )
-    let totalMs = Int((ProcessInfo.processInfo.systemUptime - totalStart) * 1000)
+    let totalMs = elapsedPerformanceMilliseconds(since: totalStart)
     performanceLog(
         operation: "get_composed_text_for_cursor_prefix",
         stage: "total_before_ffi_candidates",
         elapsedMs: totalMs,
         details: "candidate_count=\(cursorPrefixResults.count);first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);exact_clause_candidate_count=\(exactClauseResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
+    let buildStart = performanceEnabled ? performanceNow() : 0
+    var resolveCandidateCompositionMs = 0
+    var strdupCandidatesMs = 0
     var result: [FFICandidate] = []
+    result.reserveCapacity(cursorPrefixResults.count)
+    let ffiHiragana = previewPrefixHiragana + suffixAfterCursor
 
     for i in 0..<cursorPrefixResults.count {
         let cursorPrefixResult = cursorPrefixResults[i]
         let candidate = cursorPrefixResult.candidate
-        serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)/\(cursorPrefixResults.count)] start")
 
-        let text = strdup(cursorPrefixResult.displayText)
-        serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)] textReady")
-        let hiragana = strdup(previewPrefixHiragana + suffixAfterCursor)
+        let resolveStart = performanceEnabled ? performanceNow() : 0
         let resolvedCandidate = resolveCandidateCompositionForDisplay(
             originalComposingText: prefixComposingText,
             previewComposingText: previewPrefixComposingText,
             candidateComposingCount: candidate.composingCount,
             resolutionCache: &cursorPrefixResolutionCache
         )
+        if performanceEnabled {
+            resolveCandidateCompositionMs += elapsedPerformanceMilliseconds(since: resolveStart)
+        }
         let correspondingCount = resolvedCandidate.correspondingCount
-        debugLogResolvedCorrespondingCount(
-            scope: "GetComposedTextForCursorPrefix",
-            candidateIndex: i,
-            candidateTotal: cursorPrefixResults.count,
-            candidateComposingCount: candidate.composingCount,
-            resolvedCorrespondingCount: correspondingCount,
-            inputCount: prefixComposingText.input.count,
-            isZenzaiEnabled: useZenzai
-        )
-        let subtext = strdup(resolvedCandidate.remainingConvertTarget + suffixAfterCursor)
-        serverLog("DEBUG", "GetComposedTextForCursorPrefix: candidate[\(i + 1)] subtextReady")
+
+        let strdupStart = performanceEnabled ? performanceNow() : 0
+        let text = _strdup(cursorPrefixResult.displayText)
+        let subtext = _strdup(resolvedCandidate.remainingConvertTarget + suffixAfterCursor)
+        let hiragana = i == 0 ? _strdup(ffiHiragana) : nil
+        if performanceEnabled {
+            strdupCandidatesMs += elapsedPerformanceMilliseconds(since: strdupStart)
+        }
 
         result.append(FFICandidate(text: text, subtext: subtext, hiragana: hiragana, correspondingCount: Int32(correspondingCount)))
     }
 
-    lengthPtr.pointee = result.count
-    crashTrace(
+    lengthPtr.pointee = CInt(result.count)
+    let listPointer = to_list_pointer(result)
+    if performanceEnabled {
+        let stringAllocationCount = result.isEmpty ? 0 : result.count * 2 + 1
+        performanceLog(
+            operation: "get_composed_text_for_cursor_prefix",
+            stage: "resolve_candidate_composition",
+            elapsedMs: resolveCandidateCompositionMs,
+            details: "candidate_count=\(result.count);cache_entries=\(cursorPrefixResolutionCache.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+        )
+        performanceLog(
+            operation: "get_composed_text_for_cursor_prefix",
+            stage: "strdup_candidates",
+            elapsedMs: strdupCandidatesMs,
+            details: "candidate_count=\(result.count);string_allocations=\(stringAllocationCount);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+        )
+        performanceLog(
+            operation: "get_composed_text_for_cursor_prefix",
+            stage: "build_ffi_candidates_total",
+            elapsedMs: elapsedPerformanceMilliseconds(since: buildStart),
+            details: "candidate_count=\(result.count);first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);exact_clause_candidate_count=\(exactClauseResults.count);cache_entries=\(cursorPrefixResolutionCache.count);string_allocations=\(stringAllocationCount);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+        )
+    }
+    candidateCrashTrace(
+        useZenzai: useZenzai,
         operation: "GetComposedTextForCursorPrefix",
         stage: "postprocessCandidates",
         state: "completed",
@@ -1819,7 +1954,7 @@ public func free_candidate_list(
     serverLog("DEBUG", "GetComposedTextForCursorPrefix: postprocessCandidates completed candidateCount=\(result.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) exactClauseCandidateCount=\(exactClauseResults.count) suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)")
     serverLog("DEBUG", "GetComposedTextForCursorPrefix: completed candidateCount=\(result.count) suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)")
 
-    return to_list_pointer(result)
+    return listPointer
 }
 
 @_silgen_name("ShrinkText")

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -104,6 +104,72 @@ private func testCandidate(
     ]
 
     free_candidate_list(to_list_pointer(candidates), Int32(candidates.count))
+
+    let nilHiraganaText = try #require(_strdup("candidate"))
+    let nilHiraganaSubtext = try #require(_strdup("remaining"))
+    let nilHiraganaCandidates = [
+        FFICandidate(
+            text: nilHiraganaText,
+            subtext: nilHiraganaSubtext,
+            hiragana: nil,
+            correspondingCount: 1
+        )
+    ]
+
+    free_candidate_list(to_list_pointer(nilHiraganaCandidates), Int32(nilHiraganaCandidates.count))
+
+    let legacyText = try #require(_strdup("legacy"))
+    let legacySubtext = try #require(_strdup("remaining"))
+    let legacyHiragana = try #require(_strdup("かな"))
+    let legacyCandidate = UnsafeMutablePointer<FFICandidate>.allocate(capacity: 1)
+    legacyCandidate.initialize(
+        to: FFICandidate(
+            text: legacyText,
+            subtext: legacySubtext,
+            hiragana: legacyHiragana,
+            correspondingCount: 1
+        )
+    )
+    let legacyList = UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?>.allocate(capacity: 1)
+    legacyList.initialize(to: legacyCandidate)
+    free_candidate_list(legacyList, 1)
+}
+
+@Test func constructCandidateStringAdvancesByRubyWithoutMutatingRemainder() async throws {
+    let candidate = Candidate(
+        text: "今日は",
+        value: -1,
+        composingCount: .inputCount(5),
+        lastMid: MIDData.一般.mid,
+        data: [
+            DicdataElement(
+                word: "今日",
+                ruby: "きょう",
+                cid: CIDData.一般名詞.cid,
+                mid: MIDData.一般.mid,
+                value: -1
+            ),
+            DicdataElement(
+                word: "は",
+                ruby: "は",
+                cid: CIDData.一般名詞.cid,
+                mid: MIDData.一般.mid,
+                value: -1
+            ),
+        ]
+    )
+
+    #expect(constructCandidateString(candidate: candidate, hiragana: "きょうは") == "今日は")
+}
+
+@Test func constructCandidateStringFallsBackToRemainingHiraganaWhenRubyOverruns() async throws {
+    let candidate = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(2)
+    )
+
+    #expect(constructCandidateString(candidate: candidate, hiragana: "きょ") == "きょ")
 }
 
 @Test func supportsNextInputCarryForTsuRules() async throws {

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -118,21 +118,36 @@ private func testCandidate(
 
     free_candidate_list(to_list_pointer(nilHiraganaCandidates), Int32(nilHiraganaCandidates.count))
 
-    let legacyText = try #require(_strdup("legacy"))
-    let legacySubtext = try #require(_strdup("remaining"))
-    let legacyHiragana = try #require(_strdup("かな"))
-    let legacyCandidate = UnsafeMutablePointer<FFICandidate>.allocate(capacity: 1)
-    legacyCandidate.initialize(
+    let firstLegacyText = try #require(_strdup("legacy"))
+    let firstLegacySubtext = try #require(_strdup("remaining"))
+    let firstLegacyHiragana = try #require(_strdup("かな"))
+    let firstLegacyCandidate = UnsafeMutablePointer<FFICandidate>.allocate(capacity: 1)
+    firstLegacyCandidate.initialize(
         to: FFICandidate(
-            text: legacyText,
-            subtext: legacySubtext,
-            hiragana: legacyHiragana,
+            text: firstLegacyText,
+            subtext: firstLegacySubtext,
+            hiragana: firstLegacyHiragana,
             correspondingCount: 1
         )
     )
-    let legacyList = UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?>.allocate(capacity: 1)
-    legacyList.initialize(to: legacyCandidate)
-    free_candidate_list(legacyList, 1)
+
+    let secondLegacyText = try #require(_strdup("legacy-second"))
+    let secondLegacySubtext = try #require(_strdup("remaining-second"))
+    let secondLegacyCandidate = UnsafeMutablePointer<FFICandidate>.allocate(capacity: 1)
+    secondLegacyCandidate.initialize(
+        to: FFICandidate(
+            text: secondLegacyText,
+            subtext: secondLegacySubtext,
+            hiragana: nil,
+            correspondingCount: 1
+        )
+    )
+
+    let legacyList = UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?>.allocate(capacity: 3)
+    legacyList.advanced(by: 0).initialize(to: firstLegacyCandidate)
+    legacyList.advanced(by: 1).initialize(to: nil)
+    legacyList.advanced(by: 2).initialize(to: secondLegacyCandidate)
+    free_candidate_list(legacyList, 3)
 }
 
 @Test func constructCandidateStringAdvancesByRubyWithoutMutatingRemainder() async throws {


### PR DESCRIPTION
## Summary
- `GetComposedText` / `GetComposedTextForCursorPrefix` の candidate request 後処理と FFI 変換経路を、Swift / Rust 両側で request id 付きに分解計測できるようにしました。
- Swift 側の FFI candidate list 構築と Rust 側の decode / dedup / free を見直し、hot path の同期 crash trace / debug log / flush を削減しました。
- VM 上で入力経路のログを確認し、複数回の AppendText probe で平均 / p95 / max を比較しました。

## Background
- Related: #93
- #93 の計測で recurring bottleneck が `append_text` から `swift_get_composed_text` にかけた composition / candidate 取得経路にあることが分かっていました。
- 今回は `GetComposedText` の候補生成後処理と FFI 変換に絞り、候補 request 後の string construction / composition resolution / strdup / C string decode / dedup / free を分解して、遅延要因を切り分けます。

## Changes
- Swift converter tracing / postprocess
  - `prepare_request` / `request_candidates` / `construct_candidate_string` / `resolve_candidate_composition` / `strdup_candidates` / `build_ffi_candidates_total` を performance log に追加
  - `constructCandidateString` を prefix mutation ではなく index advancement で処理するように変更
  - standard `GetComposedText` path の同期 crash trace 書き込みを抑制し、Zenzai path の breadcrumbs は維持
  - per-candidate DEBUG log と hot path の flush を削減
- Swift FFI candidate list
  - exported FFI の length / cursor pointer を `UnsafeMutablePointer<CInt>` に統一
  - `to_list_pointer` を連続 `FFICandidate` storage + pointer array allocation に変更
  - `free_candidate_list` は連続 allocation と legacy / non-contiguous pointer array の両方を解放できるように変更
- Rust server decode / dedup / free
  - `ffi_call` / `cstr_decode` / `dedup` / `free_candidate_list` を performance log に追加
  - Swift 側から `hiragana` を first candidate のみ渡し、Rust 側で decode / reuse
  - candidate text dedup を `HashSet` 化し、重複候補の subtext decode を回避
  - `OwnedFfiCandidates::free_with_performance` で明示 free を計測し、Drop との二重解放を避けるように変更
- tests
  - `FreeCandidateList` の nil / empty / populated / legacy fallback 系を追加
  - `constructCandidateString` の ruby index advancement と fallback の回帰テストを追加

## Measurement report
- Reports
  - GUI input smoke: `.local/measurements/issue93-smoke-reboot-20260610-082422/report.md`
  - before final log/crash-trace reduction: `.local/measurements/issue93-direct-probe-final-20260610-112235/report.md`
  - after reduction: `.local/measurements/issue93-direct-probe-after-crashtrace-20260610-121041/report.md`
- Method
  - VM 上の入力 smoke で `GetComposedText` 系の performance log が出ることを確認
  - installed server に対して repeated AppendText probe を実行し、84 回の `get_composed_text` call を平均 / p95 / max で集計
  - logging / crash trace の影響を切り分けるため、final reduction 前後の report を比較
- Results summary

| stage | before mean | before p95 | before max | after mean | after p95 | after max |
|---|---:|---:|---:|---:|---:|---:|
| `rust:get_composed_text/ffi_call` | 89.32ms | 222ms | 817ms | 35.52ms | 42ms | 52ms |
| `swift:get_composed_text/prepare_request` | 52.49ms | 109ms | 796ms | 30.18ms | 46ms | 47ms |
| `swift:get_composed_text/request_candidates` | 8.40ms | 62ms | 109ms | 2.88ms | 16ms | 31ms |
| `swift:get_composed_text/build_ffi_candidates_total` | 5.04ms | 16ms | 31ms | 2.04ms | 16ms | 32ms |
| `rust:get_composed_text/cstr_decode` | 0.00ms | 0ms | 0ms | 0.00ms | 0ms | 0ms |
| `rust:get_composed_text/dedup` | 0.00ms | 0ms | 0ms | 0.00ms | 0ms | 0ms |
| `rust:get_composed_text/free_candidate_list` | 0.00ms | 0ms | 0ms | 0.00ms | 0ms | 0ms |

- Findings
  - ms 粒度では Rust 側の C string decode / dedup / free は主要因ではなく、candidate postprocess / FFI build も平均数 ms 程度でした。
  - 大きな spike は Swift の measured request/build 外側、特に standard path の同期 crash trace と hot debug log / flush の影響が大きいと判断しました。
  - final reduction 後は `ffi_call` が mean 35.52ms / p95 42ms / max 52ms に収まり、server log size も約 1.15MB から約 167KB へ減りました。

## Verification
- [x] Codex review
  - 初回レビューで Swift FFI pointer ABI の P1 と `FreeCandidateList` fallback の P2 を検出し修正
  - 最終レビューで「重大な問題なし」を確認
- [x] 差分チェック / format
  - `cargo fmt --check`
  - `git diff --check`
  - `git diff --cached --check`
- [x] ローカル test
  - `PROTOC=.local/protoc/bin/protoc cargo test -p shared`
  - result: 11 tests passed
- [x] ローカル Windows VM build
  - `.local/vm_build_master.sh feature/93-get-composed-text-latency`
  - artifact: `.local/artifacts/azookey-setup-feature_93-get-composed-text-latency-20260610-112612.exe`
- [x] ローカル Windows VM install / repeated input measurement
  - install log: `.local/logs/win11-install-20260610-120853.log`
  - report: `.local/measurements/issue93-direct-probe-after-crashtrace-20260610-121041/report.md`
- [x] ローカル Windows VM composition test
  - `.local/vm_test_client_composition.sh feature/93-get-composed-text-latency composition all`
  - Rust: 99 tests passed
  - Swift: 39 tests passed
- [ ] GitHub Actions build 成功
  - run: pending

## Notes
- repeated measurement は再現性を優先して installed server への AppendText probe で実施しています。GUI 経由の入力 smoke は log 出力確認として実施済みです。
- standard path の crash trace 書き込みを抑制したため、標準変換でのクラッシュ直前 stage 診断は従来より薄くなります。Zenzai path の candidate breadcrumbs は維持しています。
- performance stage は一部 nested しているため、各 stage の値は遅延経路の切り分けに使い、単純合算しない方針です。
