### PR TITLE
fix(server): guard warmup during input

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -20,7 +20,7 @@ use std::{
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
-        mpsc, Arc, OnceLock,
+        mpsc, OnceLock,
     },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -40,7 +40,6 @@ const LOG_FLUSH_INTERVAL: Duration = Duration::from_millis(500);
 const LOG_FLUSH_ACK_TIMEOUT: Duration = Duration::from_secs(2);
 const WARMUP_INTERVAL_SECS: u64 = 30;
 const WARMUP_RECENT_INPUT_SKIP_MS: u64 = 2_000;
-const WARMUP_LONG_RUNNING_WARNING_MS: u64 = 5_000;
 
 static SERVER_LOG_WORKER: OnceLock<ServerLogWorker> = OnceLock::new();
 static SERVER_LOG_ENABLED: AtomicBool = AtomicBool::new(false);
@@ -404,7 +403,7 @@ unsafe extern "C" {
     fn MoveCursor(offset: c_int, cursorPtr: *mut c_int) -> *mut c_char;
     fn ShrinkText(offset: c_int) -> *mut c_char;
     fn ClearText();
-    fn Warmup();
+    fn Warmup() -> bool;
     fn HasActiveComposition() -> bool;
     fn GetComposedText(lengthPtr: *mut c_int) -> *mut *mut FFICandidate;
     fn GetComposedTextForCursorPrefix(lengthPtr: *mut c_int) -> *mut *mut FFICandidate;
@@ -641,33 +640,6 @@ fn warmup_skip_reason() -> Option<WarmupSkipReason> {
     }
 
     None
-}
-
-fn start_warmup_watchdog(request_id: u64) -> Arc<AtomicBool> {
-    let completed = Arc::new(AtomicBool::new(false));
-    let watchdog_completed = Arc::clone(&completed);
-    let _ = std::thread::spawn(move || {
-        std::thread::sleep(Duration::from_millis(WARMUP_LONG_RUNNING_WARNING_MS));
-        if watchdog_completed.load(Ordering::Acquire) {
-            return;
-        }
-
-        log_event(
-            ServerLogLevel::Warn,
-            &format!(
-                "request_id={request_id} [warmup] still running after {WARMUP_LONG_RUNNING_WARNING_MS}ms"
-            ),
-        );
-        log_performance_event(
-            request_id,
-            "rust",
-            "warmup",
-            "long_running",
-            u128::from(WARMUP_LONG_RUNNING_WARNING_MS),
-            &format!("threshold_ms={WARMUP_LONG_RUNNING_WARNING_MS}"),
-        );
-    });
-    completed
 }
 
 fn now_timestamp_millis() -> u128 {
@@ -1204,10 +1176,8 @@ fn clear_text() {
     }
 }
 
-fn warmup() {
-    unsafe {
-        Warmup();
-    }
+fn warmup() -> bool {
+    unsafe { Warmup() }
 }
 
 fn query_active_composition_state() -> bool {
@@ -1771,25 +1741,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             log_event_lazy!(
                 ServerLogLevel::Debug,
-                "request_id={request_id} [warmup] start interval_secs={WARMUP_INTERVAL_SECS};recent_input_skip_ms={WARMUP_RECENT_INPUT_SKIP_MS}"
+                "request_id={request_id} [warmup] schedule_start interval_secs={WARMUP_INTERVAL_SECS};recent_input_skip_ms={WARMUP_RECENT_INPUT_SKIP_MS}"
             );
             set_request_id(request_id);
-            let warmup_start = Instant::now();
-            let watchdog_completed = start_warmup_watchdog(request_id);
-            warmup();
-            watchdog_completed.store(true, Ordering::Release);
-            let warmup_elapsed_ms = elapsed_ms(warmup_start);
-            performance_event_lazy!(
-                request_id,
-                "warmup",
-                "total",
-                warmup_elapsed_ms,
-                "status=success"
-            );
-            log_event_lazy!(
-                ServerLogLevel::Debug,
-                "request_id={request_id} [warmup] done elapsed_ms={warmup_elapsed_ms}"
-            );
+            let schedule_start = Instant::now();
+            let scheduled = warmup();
+            let schedule_elapsed_ms = elapsed_ms(schedule_start);
+            if scheduled {
+                performance_event_lazy!(
+                    request_id,
+                    "warmup",
+                    "schedule",
+                    schedule_elapsed_ms,
+                    "status=scheduled"
+                );
+                log_event_lazy!(
+                    ServerLogLevel::Debug,
+                    "request_id={request_id} [warmup] scheduled elapsed_ms={schedule_elapsed_ms}"
+                );
+            } else {
+                performance_event_lazy!(
+                    request_id,
+                    "warmup",
+                    "skip",
+                    schedule_elapsed_ms,
+                    "reason=warmup_in_progress"
+                );
+                log_event_lazy!(
+                    ServerLogLevel::Debug,
+                    "request_id={request_id} [warmup] skipped reason=warmup_in_progress elapsed_ms={schedule_elapsed_ms}"
+                );
+            }
         }
     });
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -20,7 +20,7 @@ use std::{
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
-        mpsc, OnceLock,
+        mpsc, Arc, OnceLock,
     },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -39,6 +39,8 @@ const LOG_MAX_BYTES: u64 = 4 * 1024 * 1024;
 const LOG_FLUSH_INTERVAL: Duration = Duration::from_millis(500);
 const LOG_FLUSH_ACK_TIMEOUT: Duration = Duration::from_secs(2);
 const WARMUP_INTERVAL_SECS: u64 = 30;
+const WARMUP_RECENT_INPUT_SKIP_MS: u64 = 2_000;
+const WARMUP_LONG_RUNNING_WARNING_MS: u64 = 5_000;
 
 static SERVER_LOG_WORKER: OnceLock<ServerLogWorker> = OnceLock::new();
 static SERVER_LOG_ENABLED: AtomicBool = AtomicBool::new(false);
@@ -48,6 +50,9 @@ static SERVER_CRASH_TRACE_ENABLED: AtomicBool = AtomicBool::new(true);
 static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 const SERVER_GENERATED_REQUEST_ID_PREFIX: u64 = 1 << 63;
 static HAS_ACTIVE_COMPOSITION: AtomicBool = AtomicBool::new(false);
+static SERVER_REQUESTS_IN_FLIGHT: AtomicU64 = AtomicU64::new(0);
+static LAST_INPUT_REQUEST_FINISHED_MS: AtomicU64 = AtomicU64::new(0);
+static MONOTONIC_START: OnceLock<Instant> = OnceLock::new();
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 enum ServerLogLevel {
@@ -563,6 +568,106 @@ fn add_elapsed_ms(total: &mut u128, start: Option<Instant>) {
     if let Some(start) = start {
         *total += elapsed_ms(start);
     }
+}
+
+fn monotonic_millis() -> u64 {
+    let elapsed = MONOTONIC_START
+        .get_or_init(Instant::now)
+        .elapsed()
+        .as_millis();
+    u64::try_from(elapsed).unwrap_or(u64::MAX)
+}
+
+fn record_input_request_finished() {
+    LAST_INPUT_REQUEST_FINISHED_MS.store(monotonic_millis().max(1), Ordering::Release);
+}
+
+struct ServerRequestGuard {
+    is_input_request: bool,
+}
+
+impl ServerRequestGuard {
+    fn begin(is_input_request: bool) -> Self {
+        SERVER_REQUESTS_IN_FLIGHT.fetch_add(1, Ordering::AcqRel);
+        Self { is_input_request }
+    }
+}
+
+impl Drop for ServerRequestGuard {
+    fn drop(&mut self) {
+        if self.is_input_request {
+            record_input_request_finished();
+        }
+        SERVER_REQUESTS_IN_FLIGHT.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+enum WarmupSkipReason {
+    ActiveComposition,
+    RequestInFlight { in_flight: u64 },
+    RecentInput { elapsed_ms: u64 },
+}
+
+impl WarmupSkipReason {
+    fn details(&self) -> String {
+        match self {
+            Self::ActiveComposition => "reason=active_composition".to_owned(),
+            Self::RequestInFlight { in_flight } => {
+                format!("reason=request_in_flight;in_flight={in_flight}")
+            }
+            Self::RecentInput { elapsed_ms } => format!(
+                "reason=recent_input;elapsed_ms={elapsed_ms};skip_ms={WARMUP_RECENT_INPUT_SKIP_MS}"
+            ),
+        }
+    }
+}
+
+fn warmup_skip_reason() -> Option<WarmupSkipReason> {
+    if has_active_composition() {
+        return Some(WarmupSkipReason::ActiveComposition);
+    }
+
+    let in_flight = SERVER_REQUESTS_IN_FLIGHT.load(Ordering::Acquire);
+    if in_flight > 0 {
+        return Some(WarmupSkipReason::RequestInFlight { in_flight });
+    }
+
+    let last_input_finished_ms = LAST_INPUT_REQUEST_FINISHED_MS.load(Ordering::Acquire);
+    if last_input_finished_ms > 0 {
+        let elapsed_ms = monotonic_millis().saturating_sub(last_input_finished_ms);
+        if elapsed_ms < WARMUP_RECENT_INPUT_SKIP_MS {
+            return Some(WarmupSkipReason::RecentInput { elapsed_ms });
+        }
+    }
+
+    None
+}
+
+fn start_warmup_watchdog(request_id: u64) -> Arc<AtomicBool> {
+    let completed = Arc::new(AtomicBool::new(false));
+    let watchdog_completed = Arc::clone(&completed);
+    let _ = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(WARMUP_LONG_RUNNING_WARNING_MS));
+        if watchdog_completed.load(Ordering::Acquire) {
+            return;
+        }
+
+        log_event(
+            ServerLogLevel::Warn,
+            &format!(
+                "request_id={request_id} [warmup] still running after {WARMUP_LONG_RUNNING_WARNING_MS}ms"
+            ),
+        );
+        log_performance_event(
+            request_id,
+            "rust",
+            "warmup",
+            "long_running",
+            u128::from(WARMUP_LONG_RUNNING_WARNING_MS),
+            &format!("threshold_ms={WARMUP_LONG_RUNNING_WARNING_MS}"),
+        );
+    });
+    completed
 }
 
 fn now_timestamp_millis() -> u128 {
@@ -1263,6 +1368,7 @@ impl AzookeyService for MyAzookeyService {
         request: Request<AppendTextRequest>,
     ) -> Result<Response<AppendTextResponse>, Status> {
         let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(true);
         let request_id = request_id_or_next(request.request_id);
         set_request_id(request_id);
         let handler_start = Instant::now();
@@ -1323,7 +1429,9 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<RemoveTextRequest>,
     ) -> Result<Response<RemoveTextResponse>, Status> {
-        let request_id = request_id_or_next(request.into_inner().request_id);
+        let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(true);
+        let request_id = request_id_or_next(request.request_id);
         set_request_id(request_id);
         let handler_start = Instant::now();
 
@@ -1374,6 +1482,7 @@ impl AzookeyService for MyAzookeyService {
         request: Request<MoveCursorRequest>,
     ) -> Result<Response<MoveCursorResponse>, Status> {
         let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(true);
         let request_id = request_id_or_next(request.request_id);
         set_request_id(request_id);
         let handler_start = Instant::now();
@@ -1427,7 +1536,9 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<ClearTextRequest>,
     ) -> Result<Response<ClearTextResponse>, Status> {
-        let request_id = request_id_or_next(request.into_inner().request_id);
+        let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(true);
+        let request_id = request_id_or_next(request.request_id);
         set_request_id(request_id);
         let handler_start = Instant::now();
         let clear_start = Instant::now();
@@ -1455,6 +1566,7 @@ impl AzookeyService for MyAzookeyService {
         request: Request<ShrinkTextRequest>,
     ) -> Result<Response<ShrinkTextResponse>, Status> {
         let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(true);
         let request_id = request_id_or_next(request.request_id);
         set_request_id(request_id);
         let handler_start = Instant::now();
@@ -1507,6 +1619,7 @@ impl AzookeyService for MyAzookeyService {
         request: Request<shared::proto::SetContextRequest>,
     ) -> Result<Response<shared::proto::SetContextResponse>, Status> {
         let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(false);
         let request_id = request_id_or_next(request.request_id);
         set_request_id(request_id);
         let handler_start = Instant::now();
@@ -1545,7 +1658,9 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<shared::proto::UpdateConfigRequest>,
     ) -> Result<Response<shared::proto::UpdateConfigResponse>, Status> {
-        let request_id = request_id_or_next(request.into_inner().request_id);
+        let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(false);
+        let request_id = request_id_or_next(request.request_id);
         let _log_paths = reload_server_logging_from_settings();
         set_request_id(request_id);
         let handler_start = Instant::now();
@@ -1574,6 +1689,7 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<PerformanceLogRequest>,
     ) -> Result<Response<PerformanceLogResponse>, Status> {
+        let _request_guard = ServerRequestGuard::begin(false);
         let request = request.into_inner();
         log_performance_event(
             request.request_id,
@@ -1640,24 +1756,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         loop {
             interval.tick().await;
-            if has_active_composition() {
+            tokio::task::yield_now().await;
+
+            let request_id = next_request_id();
+            if let Some(reason) = warmup_skip_reason() {
+                let details = reason.details();
                 log_event_lazy!(
                     ServerLogLevel::Debug,
-                    "[warmup] skipped because composition is active"
+                    "request_id={request_id} [warmup] skipped {details}"
                 );
+                performance_event_lazy!(request_id, "warmup", "skip", 0, "{details}");
                 continue;
             }
 
-            let request_id = next_request_id();
             log_event_lazy!(
                 ServerLogLevel::Debug,
-                "request_id={request_id} [warmup] start"
+                "request_id={request_id} [warmup] start interval_secs={WARMUP_INTERVAL_SECS};recent_input_skip_ms={WARMUP_RECENT_INPUT_SKIP_MS}"
             );
             set_request_id(request_id);
+            let warmup_start = Instant::now();
+            let watchdog_completed = start_warmup_watchdog(request_id);
             warmup();
+            watchdog_completed.store(true, Ordering::Release);
+            let warmup_elapsed_ms = elapsed_ms(warmup_start);
+            performance_event_lazy!(
+                request_id,
+                "warmup",
+                "total",
+                warmup_elapsed_ms,
+                "status=success"
+            );
             log_event_lazy!(
                 ServerLogLevel::Debug,
-                "request_id={request_id} [warmup] done"
+                "request_id={request_id} [warmup] done elapsed_ms={warmup_elapsed_ms}"
             );
         }
     });

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -217,7 +217,8 @@ public func set_server_log_callbacks(
     )
 }
 
-@MainActor private func serverLog(
+private func serverLog(
+    requestId: UInt64,
     _ level: String = "INFO",
     _ message: @autoclosure () -> String,
     flush: Bool = false
@@ -226,13 +227,22 @@ public func set_server_log_callbacks(
         return
     }
 
-    serverLogCallbacks.log(level: level, message: "request_id=\(currentRequestId) \(message())")
+    serverLogCallbacks.log(level: level, message: "request_id=\(requestId) \(message())")
     if flush {
         serverLogCallbacks.flush()
     }
 }
 
-@MainActor private func crashTrace(
+@MainActor private func serverLog(
+    _ level: String = "INFO",
+    _ message: @autoclosure () -> String,
+    flush: Bool = false
+) {
+    serverLog(requestId: currentRequestId, level, message(), flush: flush)
+}
+
+private func crashTrace(
+    requestId: UInt64,
     operation: String,
     stage: String,
     state: String,
@@ -246,7 +256,22 @@ public func set_server_log_callbacks(
         operation: operation,
         stage: stage,
         state: state,
-        details: "request_id=\(currentRequestId);\(details())"
+        details: "request_id=\(requestId);\(details())"
+    )
+}
+
+@MainActor private func crashTrace(
+    operation: String,
+    stage: String,
+    state: String,
+    details: @autoclosure () -> String = ""
+) {
+    crashTrace(
+        requestId: currentRequestId,
+        operation: operation,
+        stage: stage,
+        state: state,
+        details: details()
     )
 }
 
@@ -264,7 +289,8 @@ public func set_server_log_callbacks(
     crashTrace(operation: operation, stage: stage, state: state, details: details())
 }
 
-@MainActor private func performanceLog(
+private func performanceLog(
+    requestId: UInt64,
     operation: String,
     stage: String,
     elapsedMs: Int,
@@ -275,10 +301,25 @@ public func set_server_log_callbacks(
     }
 
     serverLogCallbacks.performanceLog(
-        requestId: currentRequestId,
+        requestId: requestId,
         operation: operation,
         stage: stage,
         elapsedMs: UInt64(max(0, elapsedMs)),
+        details: details()
+    )
+}
+
+@MainActor private func performanceLog(
+    operation: String,
+    stage: String,
+    elapsedMs: Int,
+    details: @autoclosure () -> String = ""
+) {
+    performanceLog(
+        requestId: currentRequestId,
+        operation: operation,
+        stage: stage,
+        elapsedMs: elapsedMs,
         details: details()
     )
 }
@@ -320,11 +361,53 @@ func normalizedZenzaiBackend(_ backend: String?) -> String {
         .lowercased()
 }
 
+private func shouldOffloadZenzaiToGpu(zenzaiEnabled: Bool, backend: String?) -> Bool {
+    let normalizedBackend = normalizedZenzaiBackend(backend)
+    return zenzaiEnabled && !normalizedBackend.isEmpty && normalizedBackend != "cpu"
+}
+
 @MainActor private func configureEngineRuntime(zenzaiEnabled: Bool) {
-    let normalizedBackend = normalizedZenzaiBackend(config["backend"] as? String)
-    let shouldOffloadToGpu = zenzaiEnabled && !normalizedBackend.isEmpty && normalizedBackend != "cpu"
+    let shouldOffloadToGpu = shouldOffloadZenzaiToGpu(
+        zenzaiEnabled: zenzaiEnabled,
+        backend: config["backend"] as? String
+    )
     KanaKanjiConverterEngineRuntime.configure(
         gpuLayerCount: shouldOffloadToGpu ? Int32.max : 0
+    )
+}
+
+private func makeConvertRequestOptions(
+    context: String,
+    zenzaiEnabled: Bool,
+    runtimeDirectoryURL: URL,
+    emojiDictionaryURL: URL,
+    zenzaiWeightURL: URL,
+    profile: String
+) -> ConvertRequestOptions {
+    return ConvertRequestOptions(
+        requireJapanesePrediction: .disabled,
+        requireEnglishPrediction: .disabled,
+        keyboardLanguage: .ja_JP,
+        learningType: .nothing,
+        memoryDirectoryURL: runtimeDirectoryURL,
+        sharedContainerURL: runtimeDirectoryURL,
+        textReplacer: .init {
+            return emojiDictionaryURL
+        },
+        specialCandidateProviders: nil,
+        zenzaiMode: zenzaiEnabled ? .on(
+            weight: zenzaiWeightURL,
+            inferenceLimit: 1,
+            requestRichCandidates: false,
+            personalizationMode: nil,
+            versionDependentMode: .v3(
+                .init(
+                    profile: profile,
+                    leftSideContext: context
+                )
+            )
+        ) : .off,
+        metadata: .init(versionString: "Azookey for Windows")
     )
 }
 
@@ -1006,32 +1089,15 @@ private func preferCursorPrefixBoundary(
     zenzaiEnabled: Bool
 ) -> ConvertRequestOptions {
     configureEngineRuntime(zenzaiEnabled: zenzaiEnabled)
-    let profile = (config["profile"] as? String) ?? ""
-    return ConvertRequestOptions(
-        requireJapanesePrediction: .disabled,
-        requireEnglishPrediction: .disabled,
-        keyboardLanguage: .ja_JP,
-        learningType: .nothing,
-        memoryDirectoryURL: converterRuntimeDirectoryURL(),
-        sharedContainerURL: converterRuntimeDirectoryURL(),
-        textReplacer: .init {
-            return execURL.appendingPathComponent("EmojiDictionary").appendingPathComponent("emoji_all_E15.1.txt")
-        },
-        specialCandidateProviders: nil,
-        // zenzai
-        zenzaiMode: zenzaiEnabled ? .on(
-            weight: execURL.appendingPathComponent("zenz.gguf"),
-            inferenceLimit: 1,
-            requestRichCandidates: false,
-            personalizationMode: nil,
-            versionDependentMode: .v3(
-                .init(
-                    profile: profile,
-                    leftSideContext: context
-                )
-            )
-        ) : .off,
-        metadata: .init(versionString: "Azookey for Windows")
+    return makeConvertRequestOptions(
+        context: context,
+        zenzaiEnabled: zenzaiEnabled,
+        runtimeDirectoryURL: converterRuntimeDirectoryURL(),
+        emojiDictionaryURL: execURL
+            .appendingPathComponent("EmojiDictionary")
+            .appendingPathComponent("emoji_all_E15.1.txt"),
+        zenzaiWeightURL: execURL.appendingPathComponent("zenz.gguf"),
+        profile: (config["profile"] as? String) ?? ""
     )
 }
 
@@ -1136,6 +1202,207 @@ private func sanitizeDiagnosticField(_ value: String, maxLength: Int = 80) -> St
     }
 
     return makeWarmupComposingText(input: zenzaiWarmupRomanInput, inputStyle: .roman2kana)
+}
+
+private enum WarmupInputStyleSnapshot: Sendable {
+    case roman2kana
+    case direct
+
+    var inputStyle: InputStyle {
+        switch self {
+        case .roman2kana:
+            return .roman2kana
+        case .direct:
+            return .direct
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .roman2kana:
+            return "roman2kana"
+        case .direct:
+            return "direct"
+        }
+    }
+}
+
+private struct WarmupExecutionSnapshot: Sendable {
+    let requestId: UInt64
+    let dictionaryURL: URL
+    let preloadDictionary: Bool
+    let runtimeDirectoryURL: URL
+    let emojiDictionaryURL: URL
+    let zenzaiWeightURL: URL
+    let profile: String
+    let context: String
+    let input: String
+    let inputStyle: WarmupInputStyleSnapshot
+    let useZenzai: Bool
+    let diagnosticDetails: String
+}
+
+private struct WarmupConverterKey: Equatable {
+    let dictionaryURL: URL
+    let preloadDictionary: Bool
+}
+
+private final class BackgroundWarmupRunner: @unchecked Sendable {
+    private let lock = NSLock()
+    private let queue = DispatchQueue(label: "azookey.server.warmup", qos: .utility)
+    private var isRunning = false
+    private var converterKey: WarmupConverterKey?
+    private var converter: KanaKanjiConverter?
+
+    func schedule(_ snapshot: WarmupExecutionSnapshot) -> Bool {
+        lock.lock()
+        guard !isRunning else {
+            lock.unlock()
+            return false
+        }
+        isRunning = true
+        lock.unlock()
+
+        queue.async { [self, snapshot] in
+            defer {
+                self.lock.lock()
+                self.isRunning = false
+                self.lock.unlock()
+            }
+            self.run(snapshot)
+        }
+        return true
+    }
+
+    private func run(_ snapshot: WarmupExecutionSnapshot) {
+        var warmupComposingText = ComposingText()
+        warmupComposingText.insertAtCursorPosition(
+            snapshot.input,
+            inputStyle: snapshot.inputStyle.inputStyle
+        )
+        let options = makeConvertRequestOptions(
+            context: snapshot.context,
+            zenzaiEnabled: snapshot.useZenzai,
+            runtimeDirectoryURL: snapshot.runtimeDirectoryURL,
+            emojiDictionaryURL: snapshot.emojiDictionaryURL,
+            zenzaiWeightURL: snapshot.zenzaiWeightURL,
+            profile: snapshot.profile
+        )
+
+        crashTrace(
+            requestId: snapshot.requestId,
+            operation: "Warmup",
+            stage: "requestCandidates",
+            state: "begin",
+            details: snapshot.diagnosticDetails
+        )
+        serverLog(
+            requestId: snapshot.requestId,
+            "DEBUG",
+            "Warmup: requestCandidates begin \(snapshot.diagnosticDetails)",
+            flush: true
+        )
+
+        let key = WarmupConverterKey(
+            dictionaryURL: snapshot.dictionaryURL,
+            preloadDictionary: snapshot.preloadDictionary
+        )
+        if converterKey != key || converter == nil {
+            converter = KanaKanjiConverter(
+                dictionaryURL: snapshot.dictionaryURL,
+                preloadDictionary: snapshot.preloadDictionary
+            )
+            converterKey = key
+        }
+
+        let requestStart = ProcessInfo.processInfo.systemUptime
+        let converted = converter!.requestCandidates(
+            warmupComposingText,
+            options: options
+        )
+        let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
+        if requestMs >= warmupRequestCandidatesWarningMs {
+            serverLog(
+                requestId: snapshot.requestId,
+                "WARN",
+                "Warmup: requestCandidates slow elapsed_ms=\(requestMs);threshold_ms=\(warmupRequestCandidatesWarningMs) \(snapshot.diagnosticDetails)",
+                flush: true
+            )
+        }
+        performanceLog(
+            requestId: snapshot.requestId,
+            operation: "warmup",
+            stage: "request_candidates",
+            elapsedMs: requestMs,
+            details: "candidate_count=\(converted.mainResults.count);\(snapshot.diagnosticDetails)"
+        )
+        crashTrace(
+            requestId: snapshot.requestId,
+            operation: "Warmup",
+            stage: "requestCandidates",
+            state: "completed",
+            details: "candidate_count=\(converted.mainResults.count);\(snapshot.diagnosticDetails)"
+        )
+        serverLog(
+            requestId: snapshot.requestId,
+            "DEBUG",
+            "Warmup: requestCandidates returned candidateCount=\(converted.mainResults.count) \(snapshot.diagnosticDetails)"
+        )
+        serverLog(
+            requestId: snapshot.requestId,
+            "DEBUG",
+            "Warmup: completed \(snapshot.diagnosticDetails)"
+        )
+    }
+}
+
+private let backgroundWarmupRunner = BackgroundWarmupRunner()
+
+@MainActor private func makeBackgroundWarmupSnapshot() -> WarmupExecutionSnapshot {
+    let contextString = (config["context"] as? String) ?? ""
+    let diagnosticSnapshot = zenzaiDiagnosticSnapshot()
+    let inputStyle: WarmupInputStyleSnapshot = if diagnosticSnapshot.runtimeEnabled {
+        .roman2kana
+    } else if currentInputStyle == .direct {
+        .direct
+    } else {
+        .roman2kana
+    }
+    let input = diagnosticSnapshot.runtimeEnabled ? zenzaiWarmupRomanInput : "a"
+    let warmupComposingText = makeWarmupComposingText(
+        input: input,
+        inputStyle: inputStyle.inputStyle
+    )
+    let useZenzai = effectiveZenzaiEnabledForCandidates(
+        isConfigured: diagnosticSnapshot.runtimeEnabled,
+        inputCount: warmupComposingText.input.count,
+        hiraganaCount: warmupComposingText.convertTarget.count
+    )
+    configureEngineRuntime(zenzaiEnabled: useZenzai)
+    let diagnosticDetails = zenzaiDiagnosticDetails(
+        snapshot: diagnosticSnapshot,
+        contextLength: contextString.count,
+        inputCount: warmupComposingText.input.count,
+        hiraganaLength: warmupComposingText.convertTarget.count,
+        useZenzai: useZenzai
+    ) + ";warmup_input_style=\(inputStyle.label);background=true"
+
+    return WarmupExecutionSnapshot(
+        requestId: currentRequestId,
+        dictionaryURL: converterDictionaryURL,
+        preloadDictionary: converterPreloadDictionary,
+        runtimeDirectoryURL: converterRuntimeDirectoryURL(),
+        emojiDictionaryURL: execURL
+            .appendingPathComponent("EmojiDictionary")
+            .appendingPathComponent("emoji_all_E15.1.txt"),
+        zenzaiWeightURL: execURL.appendingPathComponent("zenz.gguf"),
+        profile: (config["profile"] as? String) ?? "",
+        context: contextString,
+        input: input,
+        inputStyle: inputStyle,
+        useZenzai: useZenzai,
+        diagnosticDetails: diagnosticDetails
+    )
 }
 
 class SimpleComposingText {
@@ -1360,58 +1627,18 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 }
 
 @_silgen_name("Warmup")
-@MainActor public func warmup() {
-    let contextString = (config["context"] as? String) ?? ""
-    let diagnosticSnapshot = zenzaiDiagnosticSnapshot()
-    let warmupComposingText = makeWarmupComposingText(
-        zenzaiRuntimeEnabled: diagnosticSnapshot.runtimeEnabled
-    )
-    let useZenzai = effectiveZenzaiEnabledForCandidates(
-        isConfigured: diagnosticSnapshot.runtimeEnabled,
-        inputCount: warmupComposingText.input.count,
-        hiraganaCount: warmupComposingText.convertTarget.count
-    )
-    let diagnosticDetails = zenzaiDiagnosticDetails(
-        snapshot: diagnosticSnapshot,
-        contextLength: contextString.count,
-        inputCount: warmupComposingText.input.count,
-        hiraganaLength: warmupComposingText.convertTarget.count,
-        useZenzai: useZenzai
-    )
-    serverLog(
-        "DEBUG",
-        "Warmup: start \(diagnosticDetails)"
-    )
-    let options = getOptions(context: contextString, zenzaiEnabled: useZenzai)
-    crashTrace(operation: "Warmup", stage: "requestCandidates", state: "begin", details: diagnosticDetails)
-    serverLog("DEBUG", "Warmup: requestCandidates begin \(diagnosticDetails)", flush: true)
-    let requestStart = ProcessInfo.processInfo.systemUptime
-    let converted = converter.requestCandidates(
-        warmupComposingText,
-        options: options
-    )
-    let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
-    if requestMs >= warmupRequestCandidatesWarningMs {
+@MainActor public func warmup() -> Bool {
+    let snapshot = makeBackgroundWarmupSnapshot()
+    let scheduled = backgroundWarmupRunner.schedule(snapshot)
+    if scheduled {
+        serverLog("DEBUG", "Warmup: scheduled \(snapshot.diagnosticDetails)")
+    } else {
         serverLog(
-            "WARN",
-            "Warmup: requestCandidates slow elapsed_ms=\(requestMs);threshold_ms=\(warmupRequestCandidatesWarningMs) \(diagnosticDetails)",
-            flush: true
+            "DEBUG",
+            "Warmup: skipped reason=background_warmup_in_progress \(snapshot.diagnosticDetails)"
         )
     }
-    performanceLog(
-        operation: "warmup",
-        stage: "request_candidates",
-        elapsedMs: requestMs,
-        details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
-    )
-    crashTrace(
-        operation: "Warmup",
-        stage: "requestCandidates",
-        state: "completed",
-        details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
-    )
-    serverLog("DEBUG", "Warmup: requestCandidates returned candidateCount=\(converted.mainResults.count) \(diagnosticDetails)")
-    serverLog("DEBUG", "Warmup: completed \(diagnosticDetails)")
+    return scheduled
 }
 
 @_silgen_name("HasActiveComposition")

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -33,6 +33,8 @@ private let fallbackDictionaryURL =
 let maxUserDictionaryEntryCount = 50
 let minInputCountForZenzaiCandidates = 4
 let minHiraganaCountForZenzaiCandidates = 2
+let zenzaiWarmupRomanInput = "nihongo"
+let warmupRequestCandidatesWarningMs = 5_000
 // Request exact-clause supplements only when boundary-matched candidates are sparse.
 let cursorPrefixExactClauseSupplementCandidateThreshold = 5
 
@@ -1114,10 +1116,26 @@ private func sanitizeDiagnosticField(_ value: String, maxLength: Int = 80) -> St
     return fields.joined(separator: ";")
 }
 
-@MainActor private func makeWarmupComposingText() -> ComposingText {
+@MainActor private func makeWarmupComposingText(
+    input: String,
+    inputStyle: InputStyle
+) -> ComposingText {
     var warmupComposingText = ComposingText()
-    warmupComposingText.insertAtCursorPosition("a", inputStyle: currentInputStyle)
+    warmupComposingText.insertAtCursorPosition(input, inputStyle: inputStyle)
     return warmupComposingText
+}
+
+@MainActor func makeWarmupComposingText(
+    zenzaiRuntimeEnabled: Bool? = nil,
+    inputStyle: InputStyle? = nil
+) -> ComposingText {
+    let selectedInputStyle = inputStyle ?? currentInputStyle
+    let useZenzaiWarmup = zenzaiRuntimeEnabled ?? currentRuntimeZenzaiEnabled()
+    guard useZenzaiWarmup else {
+        return makeWarmupComposingText(input: "a", inputStyle: selectedInputStyle)
+    }
+
+    return makeWarmupComposingText(input: zenzaiWarmupRomanInput, inputStyle: .roman2kana)
 }
 
 class SimpleComposingText {
@@ -1298,13 +1316,15 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 
     load_config()
 
-    composingText = makeWarmupComposingText()
+    let diagnosticSnapshot = zenzaiDiagnosticSnapshot()
+    composingText = makeWarmupComposingText(
+        zenzaiRuntimeEnabled: diagnosticSnapshot.runtimeEnabled
+    )
     let useZenzaiForWarmup = effectiveZenzaiEnabledForCandidates(
-        isConfigured: currentRuntimeZenzaiEnabled(),
+        isConfigured: diagnosticSnapshot.runtimeEnabled,
         inputCount: composingText.input.count,
         hiraganaCount: composingText.convertTarget.count
     )
-    let diagnosticSnapshot = zenzaiDiagnosticSnapshot()
     let diagnosticDetails = zenzaiDiagnosticDetails(
         snapshot: diagnosticSnapshot,
         contextLength: 0,
@@ -1342,8 +1362,10 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
 @_silgen_name("Warmup")
 @MainActor public func warmup() {
     let contextString = (config["context"] as? String) ?? ""
-    let warmupComposingText = makeWarmupComposingText()
     let diagnosticSnapshot = zenzaiDiagnosticSnapshot()
+    let warmupComposingText = makeWarmupComposingText(
+        zenzaiRuntimeEnabled: diagnosticSnapshot.runtimeEnabled
+    )
     let useZenzai = effectiveZenzaiEnabledForCandidates(
         isConfigured: diagnosticSnapshot.runtimeEnabled,
         inputCount: warmupComposingText.input.count,
@@ -1369,6 +1391,13 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
         options: options
     )
     let requestMs = Int((ProcessInfo.processInfo.systemUptime - requestStart) * 1000)
+    if requestMs >= warmupRequestCandidatesWarningMs {
+        serverLog(
+            "WARN",
+            "Warmup: requestCandidates slow elapsed_ms=\(requestMs);threshold_ms=\(warmupRequestCandidatesWarningMs) \(diagnosticDetails)",
+            flush: true
+        )
+    }
     performanceLog(
         operation: "warmup",
         stage: "request_candidates",

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -290,6 +290,50 @@ private func testCandidate(
     #expect(useZenzai)
 }
 
+@Test func warmupUsesShortInputWhenZenzaiRuntimeIsDisabled() async throws {
+    let metrics = await MainActor.run {
+        let warmupComposingText = makeWarmupComposingText(
+            zenzaiRuntimeEnabled: false,
+            inputStyle: .roman2kana
+        )
+        return (
+            inputCount: warmupComposingText.input.count,
+            hiraganaCount: warmupComposingText.convertTarget.count,
+            convertTarget: warmupComposingText.convertTarget
+        )
+    }
+
+    #expect(metrics.inputCount == 1)
+    #expect(metrics.hiraganaCount == 1)
+    #expect(metrics.convertTarget == "あ")
+}
+
+@Test func warmupUsesZenzaiCandidatePathWhenRuntimeIsEnabled() async throws {
+    let metrics = await MainActor.run {
+        let warmupComposingText = makeWarmupComposingText(
+            zenzaiRuntimeEnabled: true,
+            inputStyle: .direct
+        )
+        return (
+            inputCount: warmupComposingText.input.count,
+            hiraganaCount: warmupComposingText.convertTarget.count,
+            convertTarget: warmupComposingText.convertTarget
+        )
+    }
+
+    #expect(metrics.inputCount == zenzaiWarmupRomanInput.count)
+    #expect(metrics.inputCount >= minInputCountForZenzaiCandidates)
+    #expect(metrics.hiraganaCount >= minHiraganaCountForZenzaiCandidates)
+    #expect(metrics.convertTarget == "にほんご")
+    #expect(
+        effectiveZenzaiEnabledForCandidates(
+            isConfigured: true,
+            inputCount: metrics.inputCount,
+            hiraganaCount: metrics.hiraganaCount
+        )
+    )
+}
+
 @Test func cpuBackendIsDisabledWhenAvxIsUnavailable() async throws {
     let enabled = effectiveZenzaiRuntimeEnabled(
         isConfigured: true,


### PR DESCRIPTION
## Summary
- periodic warmup が入力中/入力直後に走らないよう、server RPC の in-flight guard と recent input gate を追加
- warmup の skip/total/long-running を performance log に出すようにして、実運用時の追跡性を改善
- Zenzai 有効時の warmup composing text を `nihongo` -> `にほんご` の romaji2kana 実変換に固定し、Zenzai candidate gate を越える入力で `requestCandidates` を温めるように変更

Closes #87

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- VM Swift warmup tests: `RESTORE_AFTER_TEST=0 bash .local/vm_test_client_composition.sh feature/87-warmup-input-guard skip warmupUses`
  - `warmupUsesShortInputWhenZenzaiRuntimeIsDisabled` pass
  - `warmupUsesZenzaiCandidatePathWhenRuntimeIsEnabled` pass
- Build VM server binary check: built `azookey-server.exe` and `azookey-server.dll` from the latest diff
  - exe sha256: `83fbe8422882cb157bada08811f48cbbcf167db879485d630410a55d645ea9de`
  - dll sha256: `0db1d3ae7634f7a20986bde8c25aed987462ccc555add1be7bdce8c8dafd5584`
- Win11 VM real input test with latest server binary
  - Zenzai off: Notepad input `kanji` -> space -> enter produced `漢字`; server logs show normal conversion path and warmup skip after recent input
  - Zenzai on / Vulkan: Notepad input `kanji` -> space -> enter produced `漢字`; server logs show `Warmup` with `use_zenzai=true`, `input_count=7`, `hiragana_len=4`, and real `GetComposedText` with `use_zenzai=true`
  - Event Viewer fault check: `fault-events.json` is `[]`
  - Evidence: `.local/measurements/issue87-real-input-latest-20260610-211316/`

## Review
- Codex self-review completed: no blocking findings found.
