### PR TITLE
fix(client): recover IPC state after server restart

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -45,6 +45,8 @@ jobs:
     
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Node cache
       uses: actions/setup-node@v4

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1545,6 +1545,45 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn append_result_indicates_server_reset(
+        previous_raw_input: &str,
+        previous_candidates: &Candidates,
+        appended_text: &str,
+        appended_candidates: &Candidates,
+    ) -> bool {
+        if previous_raw_input.is_empty()
+            || previous_candidates.is_empty_composition()
+            || appended_candidates.is_empty_composition()
+        {
+            return false;
+        }
+
+        let appended_len = appended_text.chars().count() as i32;
+        appended_len > 0
+            && appended_candidates
+                .corresponding_count
+                .iter()
+                .copied()
+                .max()
+                .is_some_and(|count| count > 0 && count <= appended_len)
+    }
+
+    #[inline]
+    fn has_client_composition_state(
+        raw_input: &str,
+        preview: &str,
+        suffix: &str,
+        fixed_prefix: &str,
+        candidates: &Candidates,
+    ) -> bool {
+        !raw_input.is_empty()
+            || !preview.is_empty()
+            || !suffix.is_empty()
+            || !fixed_prefix.is_empty()
+            || !candidates.is_empty_composition()
+    }
+
+    #[inline]
     fn current_raw_input_suffix(raw_input: &str, corresponding_count: i32) -> String {
         let split_at = Self::byte_index_after_chars(raw_input, corresponding_count.max(0) as usize);
         let adjusted_split_at = Self::adjust_single_n_raw_input_boundary(raw_input, split_at);
@@ -2634,6 +2673,10 @@ impl TextServiceFactory {
         deferred_sync: Option<ClauseNavigationReadyUiSync>,
         move_effect: ClauseActionEffect,
     ) -> Option<ClauseNavigationReadyUiSync> {
+        if move_effect.server_reset {
+            return None;
+        }
+
         if move_effect.applied {
             deferred_sync.map(|sync| ClauseNavigationReadyUiSync {
                 update_pos: move_effect.update_pos,
@@ -3517,6 +3560,73 @@ impl TextServiceFactory {
             let mut transition = transition;
             let mut deferred_clause_navigation_ready_ui_sync = None;
 
+            macro_rules! reset_after_empty_server_composition {
+                ($reason:expr) => {{
+                    tracing::warn!(
+                        reason = $reason,
+                        "Reset stale client composition after server returned empty composition"
+                    );
+
+                    transition = CompositionState::None;
+                    selection_index = 0;
+                    corresponding_count = 0;
+                    temporary_latin = false;
+                    temporary_latin_shift_pending = false;
+                    preview.clear();
+                    suffix.clear();
+                    raw_input.clear();
+                    raw_hiragana.clear();
+                    fixed_prefix.clear();
+                    candidates = Candidates::default();
+                    clause_snapshots.clear();
+                    future_clause_snapshots.clear();
+                    current_clause_is_split_derived = false;
+                    current_clause_is_direct_split_remainder = false;
+                    current_clause_has_split_left_neighbor = false;
+                    current_clause_split_group_id = None;
+                    next_split_group_id = 0;
+
+                    self.discard_composition_text()?;
+                    ipc_service.update_candidate_window(
+                        Some(false),
+                        None,
+                        Some(vec![]),
+                        Some(0),
+                        None,
+                    )?;
+                    ipc_service.clear_text()?;
+                }};
+            }
+
+            macro_rules! reset_stale_composition_before_fresh_append {
+                ($reason:expr) => {{
+                    tracing::warn!(
+                        reason = $reason,
+                        "Reset stale client composition before applying fresh append"
+                    );
+
+                    transition = CompositionState::Composing;
+                    corresponding_count = 0;
+                    temporary_latin = false;
+                    temporary_latin_shift_pending = false;
+                    preview.clear();
+                    suffix.clear();
+                    raw_input.clear();
+                    raw_hiragana.clear();
+                    fixed_prefix.clear();
+                    clause_snapshots.clear();
+                    future_clause_snapshots.clear();
+                    current_clause_is_split_derived = false;
+                    current_clause_is_direct_split_remainder = false;
+                    current_clause_has_split_left_neighbor = false;
+                    current_clause_split_group_id = None;
+                    next_split_group_id = 0;
+
+                    self.discard_composition_text()?;
+                    self.start_composition()?;
+                }};
+            }
+
             self.update_context(&preview)?;
 
             for (action_index, action) in actions.iter().enumerate() {
@@ -3596,8 +3706,30 @@ impl TextServiceFactory {
                         current_clause_is_direct_split_remainder = false;
                         current_clause_has_split_left_neighbor = false;
                         current_clause_split_group_id = None;
-                        candidates =
+                        let appended_candidates =
                             ipc_service.append_text_with_context(text.clone(), &candidates)?;
+                        let session_changed = ipc_service.take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            );
+                        let server_reset_recovered = session_changed
+                            || Self::append_result_indicates_server_reset(
+                                &raw_input,
+                                &candidates,
+                                &text,
+                                &appended_candidates,
+                            );
+                        candidates = appended_candidates;
+                        if server_reset_recovered {
+                            reset_stale_composition_before_fresh_append!(
+                                "append_text recovered after server reset"
+                            );
+                            selection_index = 0;
+                        }
                         raw_input.push_str(&text);
                         if let Some(selected) = Self::select_candidate(&candidates, selection_index)
                         {
@@ -3616,6 +3748,10 @@ impl TextServiceFactory {
                                 &app_config,
                                 &transition,
                             )?;
+                        } else if candidates.is_empty_composition() {
+                            reset_after_empty_server_composition!(
+                                "append_text returned empty composition"
+                            );
                         }
                     }
                     ClientAction::AppendTextRaw(text) => {
@@ -3628,8 +3764,30 @@ impl TextServiceFactory {
                         current_clause_is_direct_split_remainder = false;
                         current_clause_has_split_left_neighbor = false;
                         current_clause_split_group_id = None;
-                        candidates =
+                        let appended_candidates =
                             ipc_service.append_text_with_context(text.clone(), &candidates)?;
+                        let session_changed = ipc_service.take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            );
+                        let server_reset_recovered = session_changed
+                            || Self::append_result_indicates_server_reset(
+                                &raw_input,
+                                &candidates,
+                                text,
+                                &appended_candidates,
+                            );
+                        candidates = appended_candidates;
+                        if server_reset_recovered {
+                            reset_stale_composition_before_fresh_append!(
+                                "append_text_raw recovered after server reset"
+                            );
+                            selection_index = 0;
+                        }
                         raw_input.push_str(text);
                         if let Some(selected) = Self::select_candidate(&candidates, selection_index)
                         {
@@ -3648,6 +3806,10 @@ impl TextServiceFactory {
                                 &app_config,
                                 &transition,
                             )?;
+                        } else if candidates.is_empty_composition() {
+                            reset_after_empty_server_composition!(
+                                "append_text_raw returned empty composition"
+                            );
                         }
                     }
                     ClientAction::AppendTextDirect(text) => {
@@ -3660,8 +3822,30 @@ impl TextServiceFactory {
                         current_clause_is_direct_split_remainder = false;
                         current_clause_has_split_left_neighbor = false;
                         current_clause_split_group_id = None;
-                        candidates = ipc_service
+                        let appended_candidates = ipc_service
                             .append_text_direct_with_context(text.clone(), &candidates)?;
+                        let session_changed = ipc_service.take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            );
+                        let server_reset_recovered = session_changed
+                            || Self::append_result_indicates_server_reset(
+                                &raw_input,
+                                &candidates,
+                                text,
+                                &appended_candidates,
+                            );
+                        candidates = appended_candidates;
+                        if server_reset_recovered {
+                            reset_stale_composition_before_fresh_append!(
+                                "append_text_direct recovered after server reset"
+                            );
+                            selection_index = 0;
+                        }
                         raw_input.push_str(text);
                         if let Some(selected) = Self::select_candidate(&candidates, selection_index)
                         {
@@ -3680,6 +3864,10 @@ impl TextServiceFactory {
                                 &app_config,
                                 &transition,
                             )?;
+                        } else if candidates.is_empty_composition() {
+                            reset_after_empty_server_composition!(
+                                "append_text_direct returned empty composition"
+                            );
                         }
                     }
                     ClientAction::CommitTextDirect(text) => {
@@ -3697,8 +3885,36 @@ impl TextServiceFactory {
                         current_clause_is_direct_split_remainder = false;
                         current_clause_has_split_left_neighbor = false;
                         current_clause_split_group_id = None;
+                        if ipc_service.take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            )
+                        {
+                            reset_after_empty_server_composition!(
+                                "server session changed before remove_text"
+                            );
+                            continue;
+                        }
                         raw_input.pop();
                         candidates = ipc_service.remove_text()?;
+                        if ipc_service.take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            )
+                        {
+                            reset_after_empty_server_composition!(
+                                "remove_text detected server session change"
+                            );
+                            continue;
+                        }
                         if let Some(selected) = Self::select_candidate(&candidates, selection_index)
                         {
                             selection_index = selected.index;
@@ -3757,7 +3973,35 @@ impl TextServiceFactory {
                         }
                     }
                     ClientAction::MoveCursor(offset) => {
+                        if ipc_service.take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            )
+                        {
+                            reset_after_empty_server_composition!(
+                                "server session changed before move_cursor"
+                            );
+                            continue;
+                        }
                         candidates = ipc_service.move_cursor(*offset)?;
+                        if ipc_service.take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            )
+                        {
+                            reset_after_empty_server_composition!(
+                                "move_cursor detected server session change"
+                            );
+                            continue;
+                        }
                         if let Some(selected) = Self::select_candidate(&candidates, selection_index)
                         {
                             selection_index = selected.index;
@@ -3775,9 +4019,27 @@ impl TextServiceFactory {
                                 None,
                                 true,
                             )?;
+                        } else if candidates.is_empty_composition() {
+                            reset_after_empty_server_composition!(
+                                "move_cursor returned empty composition"
+                            );
                         }
                     }
                     ClientAction::EnsureClauseNavigationReady => {
+                        if ipc_service.take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            )
+                        {
+                            reset_after_empty_server_composition!(
+                                "server session changed before clause_navigation_ready"
+                            );
+                            continue;
+                        }
                         Self::log_clause_action_state(
                             "before",
                             action,
@@ -3821,7 +4083,11 @@ impl TextServiceFactory {
                             effect
                         };
 
-                        if effect.applied {
+                        if effect.server_reset {
+                            reset_after_empty_server_composition!(
+                                "clause_navigation_ready returned empty composition"
+                            );
+                        } else if effect.applied {
                             let defer_ui_sync = Self::should_defer_clause_navigation_ready_sync(
                                 actions,
                                 action_index,
@@ -3887,6 +4153,20 @@ impl TextServiceFactory {
                         }
                     }
                     ClientAction::MoveClause(direction) => {
+                        if ipc_service.take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            )
+                        {
+                            reset_after_empty_server_composition!(
+                                "server session changed before move_clause"
+                            );
+                            continue;
+                        }
                         Self::log_clause_action_state(
                             "before",
                             action,
@@ -3935,7 +4215,11 @@ impl TextServiceFactory {
                                 deferred_clause_navigation_ready_ui_sync.take(),
                                 effect,
                             );
-                        if effect.applied {
+                        if effect.server_reset {
+                            reset_after_empty_server_composition!(
+                                "move_clause returned empty composition"
+                            );
+                        } else if effect.applied {
                             self.sync_clause_action_ui(
                                 &preview,
                                 &suffix,
@@ -4001,6 +4285,20 @@ impl TextServiceFactory {
                         }
                     }
                     ClientAction::AdjustBoundary(direction) => {
+                        if ipc_service.take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            )
+                        {
+                            reset_after_empty_server_composition!(
+                                "server session changed before adjust_boundary"
+                            );
+                            continue;
+                        }
                         Self::log_clause_action_state(
                             "before",
                             action,
@@ -4044,7 +4342,20 @@ impl TextServiceFactory {
                             effect
                         };
 
-                        if effect.applied {
+                        if effect.server_reset
+                            || (ipc_service.take_server_reset_recovered()
+                                && Self::has_client_composition_state(
+                                    &raw_input,
+                                    &preview,
+                                    &suffix,
+                                    &fixed_prefix,
+                                    &candidates,
+                                ))
+                        {
+                            reset_after_empty_server_composition!(
+                                "adjust_boundary detected server reset"
+                            );
+                        } else if effect.applied {
                             self.sync_clause_action_ui(
                                 &preview,
                                 &suffix,
@@ -4234,28 +4545,68 @@ impl TextServiceFactory {
                         let mut updated_raw_input = shrunk_raw_input.clone();
                         updated_raw_input.push_str(text);
 
-                        let shrunk_candidates = ipc_service.shrink_text(corresponding_count)?;
                         let text = match mode {
                             InputMode::Kana => {
                                 resolved_symbol_text.unwrap_or_else(|| text.to_string())
                             }
                             InputMode::Latin => text.to_string(),
                         };
-                        candidates =
-                            ipc_service.append_text_with_context(text, &shrunk_candidates)?;
+                        let session_changed_before_shrink = ipc_service
+                            .take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            );
+                        let shrunk_candidates = if session_changed_before_shrink {
+                            Candidates::default()
+                        } else {
+                            ipc_service.shrink_text(corresponding_count)?
+                        };
+                        let mut fresh_append_after_server_reset = session_changed_before_shrink
+                            || shrunk_candidates.is_empty_composition();
+                        if fresh_append_after_server_reset {
+                            let reset_reason = if session_changed_before_shrink {
+                                "server session changed before shrink_text"
+                            } else {
+                                "shrink_text returned empty composition before append"
+                            };
+                            reset_stale_composition_before_fresh_append!(reset_reason);
+                            updated_raw_input.clear();
+                            updated_raw_input.push_str(&text);
+                        }
+                        candidates = ipc_service
+                            .append_text_with_context(text.clone(), &shrunk_candidates)?;
+                        if ipc_service.take_server_reset_recovered() {
+                            if !fresh_append_after_server_reset {
+                                reset_stale_composition_before_fresh_append!(
+                                    "shrink_text append recovered after server reset"
+                                );
+                            }
+                            updated_raw_input.clear();
+                            updated_raw_input.push_str(&text);
+                            fresh_append_after_server_reset = true;
+                        }
                         raw_input = updated_raw_input;
                         selection_index = 0;
 
-                        if let Some(selected) = Self::select_candidate(&candidates, selection_index)
+                        let recovered = if let Some(selected) =
+                            Self::select_candidate(&candidates, selection_index)
                         {
-                            self.shift_start(&preview, &selected.text)?;
-
+                            let previous_preview = preview.clone();
                             selection_index = selected.index;
                             corresponding_count = selected.corresponding_count;
                             preview = selected.text.clone();
                             suffix = selected.sub_text.clone();
                             raw_hiragana = selected.hiragana;
 
+                            if fresh_append_after_server_reset {
+                                self.set_text(&preview, &suffix)?;
+                            } else {
+                                self.shift_start(&previous_preview, &selected.text)?;
+                            }
                             self.sync_candidate_window_update(
                                 &mut ipc_service,
                                 &candidates,
@@ -4263,9 +4614,19 @@ impl TextServiceFactory {
                                 None,
                                 true,
                             )?;
-                        }
+                            true
+                        } else if candidates.is_empty_composition() {
+                            reset_after_empty_server_composition!(
+                                "shrink_text returned empty composition"
+                            );
+                            false
+                        } else {
+                            true
+                        };
 
-                        transition = CompositionState::Composing;
+                        if recovered {
+                            transition = CompositionState::Composing;
+                        }
                     }
                     ClientAction::ShrinkTextRaw(text) => {
                         fixed_prefix.clear();
@@ -4282,22 +4643,62 @@ impl TextServiceFactory {
                             Self::current_raw_input_suffix(&raw_input, corresponding_count);
                         updated_raw_input.push_str(text);
 
-                        let shrunk_candidates = ipc_service.shrink_text(corresponding_count)?;
+                        let session_changed_before_shrink = ipc_service
+                            .take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            );
+                        let shrunk_candidates = if session_changed_before_shrink {
+                            Candidates::default()
+                        } else {
+                            ipc_service.shrink_text(corresponding_count)?
+                        };
+                        let mut fresh_append_after_server_reset = session_changed_before_shrink
+                            || shrunk_candidates.is_empty_composition();
+                        if fresh_append_after_server_reset {
+                            let reset_reason = if session_changed_before_shrink {
+                                "server session changed before shrink_text_raw"
+                            } else {
+                                "shrink_text_raw returned empty composition before append"
+                            };
+                            reset_stale_composition_before_fresh_append!(reset_reason);
+                            updated_raw_input.clear();
+                            updated_raw_input.push_str(text);
+                        }
                         candidates = ipc_service
                             .append_text_with_context(text.clone(), &shrunk_candidates)?;
+                        if ipc_service.take_server_reset_recovered() {
+                            if !fresh_append_after_server_reset {
+                                reset_stale_composition_before_fresh_append!(
+                                    "shrink_text_raw append recovered after server reset"
+                                );
+                            }
+                            updated_raw_input.clear();
+                            updated_raw_input.push_str(text);
+                            fresh_append_after_server_reset = true;
+                        }
                         raw_input = updated_raw_input;
                         selection_index = 0;
 
-                        if let Some(selected) = Self::select_candidate(&candidates, selection_index)
+                        let recovered = if let Some(selected) =
+                            Self::select_candidate(&candidates, selection_index)
                         {
-                            self.shift_start(&preview, &selected.text)?;
-
+                            let previous_preview = preview.clone();
                             selection_index = selected.index;
                             corresponding_count = selected.corresponding_count;
                             preview = selected.text.clone();
                             suffix = selected.sub_text.clone();
                             raw_hiragana = selected.hiragana;
 
+                            if fresh_append_after_server_reset {
+                                self.set_text(&preview, &suffix)?;
+                            } else {
+                                self.shift_start(&previous_preview, &selected.text)?;
+                            }
                             self.sync_candidate_window_update(
                                 &mut ipc_service,
                                 &candidates,
@@ -4305,9 +4706,19 @@ impl TextServiceFactory {
                                 None,
                                 true,
                             )?;
-                        }
+                            true
+                        } else if candidates.is_empty_composition() {
+                            reset_after_empty_server_composition!(
+                                "shrink_text_raw returned empty composition"
+                            );
+                            false
+                        } else {
+                            true
+                        };
 
-                        transition = CompositionState::Composing;
+                        if recovered {
+                            transition = CompositionState::Composing;
+                        }
                     }
                     ClientAction::ShrinkTextDirect(text) => {
                         fixed_prefix.clear();
@@ -4324,22 +4735,62 @@ impl TextServiceFactory {
                             Self::current_raw_input_suffix(&raw_input, corresponding_count);
                         updated_raw_input.push_str(text);
 
-                        let shrunk_candidates = ipc_service.shrink_text(corresponding_count)?;
+                        let session_changed_before_shrink = ipc_service
+                            .take_server_reset_recovered()
+                            && Self::has_client_composition_state(
+                                &raw_input,
+                                &preview,
+                                &suffix,
+                                &fixed_prefix,
+                                &candidates,
+                            );
+                        let shrunk_candidates = if session_changed_before_shrink {
+                            Candidates::default()
+                        } else {
+                            ipc_service.shrink_text(corresponding_count)?
+                        };
+                        let mut fresh_append_after_server_reset = session_changed_before_shrink
+                            || shrunk_candidates.is_empty_composition();
+                        if fresh_append_after_server_reset {
+                            let reset_reason = if session_changed_before_shrink {
+                                "server session changed before shrink_text_direct"
+                            } else {
+                                "shrink_text_direct returned empty composition before append"
+                            };
+                            reset_stale_composition_before_fresh_append!(reset_reason);
+                            updated_raw_input.clear();
+                            updated_raw_input.push_str(text);
+                        }
                         candidates = ipc_service
                             .append_text_direct_with_context(text.clone(), &shrunk_candidates)?;
+                        if ipc_service.take_server_reset_recovered() {
+                            if !fresh_append_after_server_reset {
+                                reset_stale_composition_before_fresh_append!(
+                                    "shrink_text_direct append recovered after server reset"
+                                );
+                            }
+                            updated_raw_input.clear();
+                            updated_raw_input.push_str(text);
+                            fresh_append_after_server_reset = true;
+                        }
                         raw_input = updated_raw_input;
                         selection_index = 0;
 
-                        if let Some(selected) = Self::select_candidate(&candidates, selection_index)
+                        let recovered = if let Some(selected) =
+                            Self::select_candidate(&candidates, selection_index)
                         {
-                            self.shift_start(&preview, &selected.text)?;
-
+                            let previous_preview = preview.clone();
                             selection_index = selected.index;
                             corresponding_count = selected.corresponding_count;
                             preview = selected.text.clone();
                             suffix = selected.sub_text.clone();
                             raw_hiragana = selected.hiragana;
 
+                            if fresh_append_after_server_reset {
+                                self.set_text(&preview, &suffix)?;
+                            } else {
+                                self.shift_start(&previous_preview, &selected.text)?;
+                            }
                             self.sync_candidate_window_update(
                                 &mut ipc_service,
                                 &candidates,
@@ -4347,9 +4798,19 @@ impl TextServiceFactory {
                                 None,
                                 true,
                             )?;
-                        }
+                            true
+                        } else if candidates.is_empty_composition() {
+                            reset_after_empty_server_composition!(
+                                "shrink_text_direct returned empty composition"
+                            );
+                            false
+                        } else {
+                            true
+                        };
 
-                        transition = CompositionState::Composing;
+                        if recovered {
+                            transition = CompositionState::Composing;
+                        }
                     }
                     ClientAction::SetTemporaryLatin(is_temporary_latin) => {
                         temporary_latin = *is_temporary_latin;

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1347,13 +1347,15 @@ impl TextServiceFactory {
     fn clear_clause_snapshots(
         clause_snapshots: &mut Vec<ClauseSnapshot>,
         ipc_service: &mut IPCService,
+        candidates: &Candidates,
     ) -> Result<()> {
         if clause_snapshots.is_empty() {
             return Ok(());
         }
 
         clause_snapshots.clear();
-        let _ = ipc_service.move_cursor(Self::MOVE_CURSOR_CLEAR_CLAUSE_SNAPSHOTS)?;
+        let _ = ipc_service
+            .move_cursor_with_context(Self::MOVE_CURSOR_CLEAR_CLAUSE_SNAPSHOTS, candidates)?;
         Ok(())
     }
 
@@ -1367,9 +1369,10 @@ impl TextServiceFactory {
         clause_snapshots: &mut Vec<ClauseSnapshot>,
         future_clause_snapshots: &mut Vec<FutureClauseSnapshot>,
         ipc_service: &mut IPCService,
+        candidates: &Candidates,
     ) -> Result<()> {
         Self::clear_future_clause_snapshots(future_clause_snapshots);
-        Self::clear_clause_snapshots(clause_snapshots, ipc_service)
+        Self::clear_clause_snapshots(clause_snapshots, ipc_service, candidates)
     }
 
     #[cfg(test)]
@@ -2217,7 +2220,11 @@ impl TextServiceFactory {
         }
 
         for _ in 0..temp_clause_snapshots.len() {
-            let _ = backend.move_cursor(Self::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT)?;
+            let previous_candidates = temp_candidates.clone();
+            let _ = backend.move_cursor_with_context(
+                Self::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT,
+                &previous_candidates,
+            )?;
         }
 
         state.future_clause_snapshots.clear();
@@ -2372,10 +2379,11 @@ impl TextServiceFactory {
                 }
             }
 
-            let _ = backend.move_cursor(-1)?;
+            let previous_candidates = candidates.clone();
+            let _ = backend.move_cursor_with_context(-1, &previous_candidates)?;
             let next_candidates = backend.move_cursor(0)?;
             if next_candidates.texts.is_empty() {
-                let _ = backend.move_cursor(1)?;
+                let _ = backend.move_cursor_with_context(1, &next_candidates)?;
                 return Ok(());
             }
 
@@ -3685,6 +3693,7 @@ impl TextServiceFactory {
                             &mut clause_snapshots,
                             &mut future_clause_snapshots,
                             &mut ipc_service,
+                            &candidates,
                         )?;
                         let resolved_symbol_text = match mode {
                             InputMode::Kana => Self::resolve_symbol_input_text_with_lookup(
@@ -3759,6 +3768,7 @@ impl TextServiceFactory {
                             &mut clause_snapshots,
                             &mut future_clause_snapshots,
                             &mut ipc_service,
+                            &candidates,
                         )?;
                         current_clause_is_split_derived = false;
                         current_clause_is_direct_split_remainder = false;
@@ -3817,6 +3827,7 @@ impl TextServiceFactory {
                             &mut clause_snapshots,
                             &mut future_clause_snapshots,
                             &mut ipc_service,
+                            &candidates,
                         )?;
                         current_clause_is_split_derived = false;
                         current_clause_is_direct_split_remainder = false;
@@ -3880,6 +3891,7 @@ impl TextServiceFactory {
                             &mut clause_snapshots,
                             &mut future_clause_snapshots,
                             &mut ipc_service,
+                            &candidates,
                         )?;
                         current_clause_is_split_derived = false;
                         current_clause_is_direct_split_remainder = false;
@@ -3900,7 +3912,7 @@ impl TextServiceFactory {
                             continue;
                         }
                         raw_input.pop();
-                        candidates = ipc_service.remove_text()?;
+                        candidates = ipc_service.remove_text_with_context(&candidates)?;
                         if ipc_service.take_server_reset_recovered()
                             && Self::has_client_composition_state(
                                 &raw_input,
@@ -3987,7 +3999,7 @@ impl TextServiceFactory {
                             );
                             continue;
                         }
-                        candidates = ipc_service.move_cursor(*offset)?;
+                        candidates = ipc_service.move_cursor_with_context(*offset, &candidates)?;
                         if ipc_service.take_server_reset_recovered()
                             && Self::has_client_composition_state(
                                 &raw_input,
@@ -4526,6 +4538,7 @@ impl TextServiceFactory {
                             &mut clause_snapshots,
                             &mut future_clause_snapshots,
                             &mut ipc_service,
+                            &candidates,
                         )?;
                         current_clause_is_split_derived = false;
                         current_clause_is_direct_split_remainder = false;
@@ -4563,7 +4576,8 @@ impl TextServiceFactory {
                         let shrunk_candidates = if session_changed_before_shrink {
                             Candidates::default()
                         } else {
-                            ipc_service.shrink_text(corresponding_count)?
+                            ipc_service
+                                .shrink_text_with_context(corresponding_count, &candidates)?
                         };
                         let mut fresh_append_after_server_reset = session_changed_before_shrink
                             || shrunk_candidates.is_empty_composition();
@@ -4634,6 +4648,7 @@ impl TextServiceFactory {
                             &mut clause_snapshots,
                             &mut future_clause_snapshots,
                             &mut ipc_service,
+                            &candidates,
                         )?;
                         current_clause_is_split_derived = false;
                         current_clause_is_direct_split_remainder = false;
@@ -4655,7 +4670,8 @@ impl TextServiceFactory {
                         let shrunk_candidates = if session_changed_before_shrink {
                             Candidates::default()
                         } else {
-                            ipc_service.shrink_text(corresponding_count)?
+                            ipc_service
+                                .shrink_text_with_context(corresponding_count, &candidates)?
                         };
                         let mut fresh_append_after_server_reset = session_changed_before_shrink
                             || shrunk_candidates.is_empty_composition();
@@ -4726,6 +4742,7 @@ impl TextServiceFactory {
                             &mut clause_snapshots,
                             &mut future_clause_snapshots,
                             &mut ipc_service,
+                            &candidates,
                         )?;
                         current_clause_is_split_derived = false;
                         current_clause_is_direct_split_remainder = false;
@@ -4747,7 +4764,8 @@ impl TextServiceFactory {
                         let shrunk_candidates = if session_changed_before_shrink {
                             Candidates::default()
                         } else {
-                            ipc_service.shrink_text(corresponding_count)?
+                            ipc_service
+                                .shrink_text_with_context(corresponding_count, &candidates)?
                         };
                         let mut fresh_append_after_server_reset = session_changed_before_shrink
                             || shrunk_candidates.is_empty_composition();

--- a/crates/client/src/engine/composition/clause_state.rs
+++ b/crates/client/src/engine/composition/clause_state.rs
@@ -22,6 +22,22 @@ pub(crate) struct CandidateSelection {
 pub(crate) trait ClauseActionBackend {
     fn move_cursor(&mut self, offset: i32) -> Result<Candidates>;
     fn shrink_text(&mut self, offset: i32) -> Result<Candidates>;
+
+    fn move_cursor_with_context(
+        &mut self,
+        offset: i32,
+        _previous_candidates: &Candidates,
+    ) -> Result<Candidates> {
+        self.move_cursor(offset)
+    }
+
+    fn shrink_text_with_context(
+        &mut self,
+        offset: i32,
+        _previous_candidates: &Candidates,
+    ) -> Result<Candidates> {
+        self.shrink_text(offset)
+    }
 }
 
 impl ClauseActionBackend for IPCService {
@@ -31,6 +47,22 @@ impl ClauseActionBackend for IPCService {
 
     fn shrink_text(&mut self, offset: i32) -> Result<Candidates> {
         IPCService::shrink_text(self, offset)
+    }
+
+    fn move_cursor_with_context(
+        &mut self,
+        offset: i32,
+        previous_candidates: &Candidates,
+    ) -> Result<Candidates> {
+        IPCService::move_cursor_with_context(self, offset, previous_candidates)
+    }
+
+    fn shrink_text_with_context(
+        &mut self,
+        offset: i32,
+        previous_candidates: &Candidates,
+    ) -> Result<Candidates> {
+        IPCService::shrink_text_with_context(self, offset, previous_candidates)
     }
 }
 
@@ -428,11 +460,16 @@ impl ClauseState {
             let current_clause_preview =
                 TextServiceFactory::current_clause_preview(state.preview, state.fixed_prefix);
             let current_corresponding_count = *state.corresponding_count;
+            let previous_candidates = state.candidates.clone();
 
-            let _ = backend.move_cursor(TextServiceFactory::MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT)?;
+            let _ = backend.move_cursor_with_context(
+                TextServiceFactory::MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT,
+                &previous_candidates,
+            )?;
             state.clause_snapshots.push(snapshot);
 
-            *state.candidates = backend.shrink_text(current_corresponding_count)?;
+            *state.candidates = backend
+                .shrink_text_with_context(current_corresponding_count, &previous_candidates)?;
             if state.candidates.is_empty_composition() {
                 return Ok(ClauseActionEffect::server_reset());
             }
@@ -507,8 +544,11 @@ impl ClauseState {
                 let Some(selected) =
                     TextServiceFactory::select_candidate(state.candidates, *state.selection_index)
                 else {
-                    let _ =
-                        backend.move_cursor(TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT)?;
+                    let previous_candidates = state.candidates.clone();
+                    let _ = backend.move_cursor_with_context(
+                        TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT,
+                        &previous_candidates,
+                    )?;
                     if let Some(restored) = state.clause_snapshots.pop() {
                         *state.preview = restored.preview;
                         *state.suffix = restored.suffix;
@@ -568,7 +608,11 @@ impl ClauseState {
                     *state.current_clause_split_group_id,
                     state.candidates,
                 );
-                let _ = backend.move_cursor(TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT)?;
+                let previous_candidates = state.candidates.clone();
+                let _ = backend.move_cursor_with_context(
+                    TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT,
+                    &previous_candidates,
+                )?;
 
                 *state.preview = restored.preview;
                 *state.suffix = restored.suffix;
@@ -625,11 +669,12 @@ impl ClauseState {
             )?;
         }
 
-        let _ = backend.move_cursor(direction)?;
+        let previous_candidates = state.candidates.clone();
+        let _ = backend.move_cursor_with_context(direction, &previous_candidates)?;
         let boundary_candidates = backend.move_cursor(0)?;
         if boundary_candidates.texts.is_empty() {
             if direction < 0 {
-                let _ = backend.move_cursor(1)?;
+                let _ = backend.move_cursor_with_context(1, &boundary_candidates)?;
                 if let Some(selected) = ClauseState::select_split_left_candidate(
                     &fallback_candidates,
                     *state.corresponding_count,

--- a/crates/client/src/engine/composition/clause_state.rs
+++ b/crates/client/src/engine/composition/clause_state.rs
@@ -56,6 +56,7 @@ pub(crate) struct ClauseActionStateMut<'a> {
 pub(crate) struct ClauseActionEffect {
     pub(crate) applied: bool,
     pub(crate) update_pos: bool,
+    pub(crate) server_reset: bool,
 }
 
 impl ClauseActionEffect {
@@ -63,6 +64,7 @@ impl ClauseActionEffect {
         Self {
             applied: false,
             update_pos: false,
+            server_reset: false,
         }
     }
 
@@ -70,6 +72,15 @@ impl ClauseActionEffect {
         Self {
             applied: true,
             update_pos,
+            server_reset: false,
+        }
+    }
+
+    pub(crate) fn server_reset() -> Self {
+        Self {
+            applied: false,
+            update_pos: false,
+            server_reset: true,
         }
     }
 }
@@ -270,6 +281,9 @@ impl ClauseState {
             Some(candidates) => candidates,
             None => backend.move_cursor(0)?,
         };
+        if navigation_candidates.is_empty_composition() {
+            return Ok(ClauseActionEffect::server_reset());
+        }
         let Some(mut selected) =
             TextServiceFactory::select_navigation_candidate_for_current_preview(
                 &navigation_candidates,
@@ -369,6 +383,9 @@ impl ClauseState {
             loop {
                 let before = MoveClauseProgressMarker::from_state(state);
                 let effect = ClauseState::apply_move_clause(state, backend, 1)?;
+                if effect.server_reset {
+                    return Ok(effect);
+                }
                 if !effect.applied {
                     break;
                 }
@@ -416,6 +433,9 @@ impl ClauseState {
             state.clause_snapshots.push(snapshot);
 
             *state.candidates = backend.shrink_text(current_corresponding_count)?;
+            if state.candidates.is_empty_composition() {
+                return Ok(ClauseActionEffect::server_reset());
+            }
             *state.selection_index = 0;
             *state.raw_input = TextServiceFactory::current_raw_input_suffix(
                 state.raw_input,

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -83,6 +83,67 @@ fn reducer_plans_composition_start_without_tsf_or_ipc_state() {
 }
 
 #[test]
+fn append_result_indicates_server_reset_when_result_only_contains_appended_input() {
+    let previous_candidates = candidates(&["感じ"], &[""], "かんじ", &[5]);
+    let appended_candidates = candidates(&["k"], &[""], "k", &[1]);
+
+    assert!(TextServiceFactory::append_result_indicates_server_reset(
+        "kanji",
+        &previous_candidates,
+        "k",
+        &appended_candidates,
+    ));
+}
+
+#[test]
+fn append_result_does_not_indicate_server_reset_when_result_extends_previous_input() {
+    let previous_candidates = candidates(&["感じ"], &[""], "かんじ", &[5]);
+    let appended_candidates = candidates(&["感じk"], &[""], "かんじk", &[6]);
+
+    assert!(!TextServiceFactory::append_result_indicates_server_reset(
+        "kanji",
+        &previous_candidates,
+        "k",
+        &appended_candidates,
+    ));
+}
+
+#[test]
+fn append_result_does_not_indicate_server_reset_for_romaji_rewrite() {
+    let previous_candidates = candidates(&["n"], &[""], "n", &[1]);
+    let appended_candidates = candidates(&["な"], &[""], "な", &[2]);
+
+    assert!(!TextServiceFactory::append_result_indicates_server_reset(
+        "n",
+        &previous_candidates,
+        "a",
+        &appended_candidates,
+    ));
+}
+
+#[test]
+fn client_composition_state_is_empty_when_all_buffers_are_empty() {
+    assert!(!TextServiceFactory::has_client_composition_state(
+        "",
+        "",
+        "",
+        "",
+        &Candidates::default(),
+    ));
+}
+
+#[test]
+fn client_composition_state_is_present_when_candidates_remain() {
+    assert!(TextServiceFactory::has_client_composition_state(
+        "",
+        "",
+        "",
+        "",
+        &candidates(&["漢字"], &[""], "かんじ", &[5]),
+    ));
+}
+
+#[test]
 fn delayed_candidate_window_does_not_show_on_composition_start() {
     let mut app_config = AppConfig::default();
     app_config.general.show_candidate_window_after_space = true;

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -67,6 +67,29 @@ impl Candidates {
     }
 }
 
+#[derive(Debug)]
+enum NonIdempotentEditAttempt<T> {
+    Completed(T),
+    ReconnectAndRefresh(anyhow::Error),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NonIdempotentEditRecovery {
+    None,
+    RetriedAfterUnchangedRefresh,
+    RefreshedAfterReconnect,
+}
+
+impl NonIdempotentEditRecovery {
+    fn log_value(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::RetriedAfterUnchangedRefresh => "retry_after_unchanged_refresh",
+            Self::RefreshedAfterReconnect => "refresh_after_reconnect",
+        }
+    }
+}
+
 fn next_request_id() -> u64 {
     let counter = CLIENT_REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     (u64::from(std::process::id()) << 32) | (counter & 0xffff_ffff)
@@ -318,6 +341,99 @@ impl IPCService {
                             "{operation} retry failed after IPC reconnect: {retry_error:?}"
                         );
                         Err(retry_error)
+                    }
+                }
+            }
+        }
+    }
+
+    fn classify_non_idempotent_edit_attempt<T>(
+        operation: &str,
+        first_result: anyhow::Result<T>,
+    ) -> anyhow::Result<NonIdempotentEditAttempt<T>> {
+        match first_result {
+            Ok(value) => Ok(NonIdempotentEditAttempt::Completed(value)),
+            Err(first_error) => {
+                if !Self::should_reconnect_rpc_error(&first_error) {
+                    tracing::warn!(
+                        "{operation} failed with non-reconnectable error: {first_error:?}"
+                    );
+                    return Err(first_error);
+                }
+
+                tracing::warn!(
+                    "{operation} first attempt failed, reconnecting IPC once without replaying edit RPC: {first_error:?}"
+                );
+                Ok(NonIdempotentEditAttempt::ReconnectAndRefresh(first_error))
+            }
+        }
+    }
+
+    #[inline]
+    fn should_retry_non_idempotent_edit_after_refresh(
+        previous_candidates: Option<&Candidates>,
+        refreshed_candidates: &Candidates,
+    ) -> bool {
+        previous_candidates.is_some_and(|previous| {
+            previous == refreshed_candidates && !refreshed_candidates.is_empty_composition()
+        })
+    }
+
+    fn run_non_idempotent_edit_with_reconnect(
+        &mut self,
+        operation: &str,
+        request_id: u64,
+        previous_candidates: Option<&Candidates>,
+        mut send: impl FnMut(&mut Self) -> anyhow::Result<Candidates>,
+    ) -> anyhow::Result<(Candidates, NonIdempotentEditRecovery)> {
+        match Self::classify_non_idempotent_edit_attempt(operation, send(self))? {
+            NonIdempotentEditAttempt::Completed(candidates) => {
+                Ok((candidates, NonIdempotentEditRecovery::None))
+            }
+            NonIdempotentEditAttempt::ReconnectAndRefresh(first_error) => {
+                match self.reconnect() {
+                    Ok(()) => {
+                        tracing::info!(
+                            "{operation} IPC reconnect succeeded, refreshing server composition without replaying edit RPC"
+                        );
+                    }
+                    Err(reconnect_error) => {
+                        tracing::error!(
+                            "{operation} IPC reconnect failed after first error {first_error:?}: {reconnect_error:?}"
+                        );
+                        return Err(reconnect_error);
+                    }
+                }
+
+                // remove_text, shrink_text, and non-zero move_cursor may have already
+                // changed server state before the transport broke. Refresh first, and
+                // only replay the edit if the server state is still the previous one.
+                match self.send_move_cursor(0, request_id) {
+                    Ok(refreshed_candidates) => {
+                        if Self::should_retry_non_idempotent_edit_after_refresh(
+                            previous_candidates,
+                            &refreshed_candidates,
+                        ) {
+                            tracing::warn!(
+                                "{operation} refreshed unchanged composition after reconnect, retrying edit RPC once"
+                            );
+                            let candidates = send(self)?;
+                            return Ok((
+                                candidates,
+                                NonIdempotentEditRecovery::RetriedAfterUnchangedRefresh,
+                            ));
+                        }
+
+                        Ok((
+                            refreshed_candidates,
+                            NonIdempotentEditRecovery::RefreshedAfterReconnect,
+                        ))
+                    }
+                    Err(refresh_error) => {
+                        tracing::error!(
+                            "{operation} refresh failed after IPC reconnect: {refresh_error:?}"
+                        );
+                        Err(refresh_error)
                     }
                 }
             }
@@ -670,17 +786,36 @@ impl IPCService {
 
     #[tracing::instrument]
     pub fn remove_text(&mut self) -> anyhow::Result<Candidates> {
+        self.remove_text_inner(None)
+    }
+
+    #[tracing::instrument(skip(self, previous_candidates))]
+    pub fn remove_text_with_context(
+        &mut self,
+        previous_candidates: &Candidates,
+    ) -> anyhow::Result<Candidates> {
+        self.remove_text_inner(Some(previous_candidates))
+    }
+
+    fn remove_text_inner(
+        &mut self,
+        previous_candidates: Option<&Candidates>,
+    ) -> anyhow::Result<Candidates> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
-        let result =
-            self.run_rpc_with_reconnect("remove_text", |this| this.send_remove_text(request_id));
+        let result = self.run_non_idempotent_edit_with_reconnect(
+            "remove_text",
+            request_id,
+            previous_candidates,
+            |this| this.send_remove_text(request_id),
+        );
         self.log_client_performance_from_start(
             performance_start,
             request_id,
             "remove_text",
             "rpc_total",
             || match &result {
-                Ok((_, retried)) => format!("status=success;retry={retried}"),
+                Ok((_, recovery)) => format!("status=success;recovery={}", recovery.log_value()),
                 Err(error) => format!("status=error;error={error:?}"),
             },
         );
@@ -709,18 +844,41 @@ impl IPCService {
 
     #[tracing::instrument]
     pub fn shrink_text(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        self.shrink_text_inner(offset, None)
+    }
+
+    #[tracing::instrument(skip(self, previous_candidates))]
+    pub fn shrink_text_with_context(
+        &mut self,
+        offset: i32,
+        previous_candidates: &Candidates,
+    ) -> anyhow::Result<Candidates> {
+        self.shrink_text_inner(offset, Some(previous_candidates))
+    }
+
+    fn shrink_text_inner(
+        &mut self,
+        offset: i32,
+        previous_candidates: Option<&Candidates>,
+    ) -> anyhow::Result<Candidates> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
-        let result = self.run_rpc_with_reconnect("shrink_text", |this| {
-            this.send_shrink_text(offset, request_id)
-        });
+        let result = self.run_non_idempotent_edit_with_reconnect(
+            "shrink_text",
+            request_id,
+            previous_candidates,
+            |this| this.send_shrink_text(offset, request_id),
+        );
         self.log_client_performance_from_start(
             performance_start,
             request_id,
             "shrink_text",
             "rpc_total",
             || match &result {
-                Ok((_, retried)) => format!("status=success;retry={retried};offset={offset}"),
+                Ok((_, recovery)) => format!(
+                    "status=success;recovery={};offset={offset}",
+                    recovery.log_value()
+                ),
                 Err(error) => format!("status=error;offset={offset};error={error:?}"),
             },
         );
@@ -730,18 +888,41 @@ impl IPCService {
 
     #[tracing::instrument]
     pub fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
+        self.move_cursor_inner(offset, None)
+    }
+
+    #[tracing::instrument(skip(self, previous_candidates))]
+    pub fn move_cursor_with_context(
+        &mut self,
+        offset: i32,
+        previous_candidates: &Candidates,
+    ) -> anyhow::Result<Candidates> {
+        self.move_cursor_inner(offset, Some(previous_candidates))
+    }
+
+    fn move_cursor_inner(
+        &mut self,
+        offset: i32,
+        previous_candidates: Option<&Candidates>,
+    ) -> anyhow::Result<Candidates> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
-        let result = self.run_rpc_with_reconnect("move_cursor", |this| {
-            this.send_move_cursor(offset, request_id)
-        });
+        let result = self.run_non_idempotent_edit_with_reconnect(
+            "move_cursor",
+            request_id,
+            previous_candidates,
+            |this| this.send_move_cursor(offset, request_id),
+        );
         self.log_client_performance_from_start(
             performance_start,
             request_id,
             "move_cursor",
             "rpc_total",
             || match &result {
-                Ok((_, retried)) => format!("status=success;retry={retried};offset={offset}"),
+                Ok((_, recovery)) => format!(
+                    "status=success;recovery={};offset={offset}",
+                    recovery.log_value()
+                ),
                 Err(error) => format!("status=error;offset={offset};error={error:?}"),
             },
         );
@@ -1009,7 +1190,7 @@ impl IPCService {
 
 #[cfg(test)]
 mod tests {
-    use super::{Candidates, IPCService};
+    use super::{Candidates, IPCService, NonIdempotentEditAttempt};
 
     #[test]
     fn append_retry_is_enabled_when_server_state_is_unchanged() {
@@ -1092,6 +1273,57 @@ mod tests {
     }
 
     #[test]
+    fn non_idempotent_edit_retry_is_enabled_when_refreshed_state_is_unchanged() {
+        let previous = Candidates {
+            texts: vec!["か".to_string()],
+            sub_texts: vec![String::new()],
+            hiragana: "か".to_string(),
+            corresponding_count: vec![1],
+        };
+
+        assert!(IPCService::should_retry_non_idempotent_edit_after_refresh(
+            Some(&previous),
+            &previous
+        ));
+    }
+
+    #[test]
+    fn non_idempotent_edit_retry_is_disabled_when_refreshed_state_changed() {
+        let previous = Candidates {
+            texts: vec!["か".to_string()],
+            sub_texts: vec![String::new()],
+            hiragana: "か".to_string(),
+            corresponding_count: vec![1],
+        };
+        let refreshed = Candidates {
+            texts: vec!["".to_string()],
+            sub_texts: vec![String::new()],
+            hiragana: String::new(),
+            corresponding_count: vec![0],
+        };
+
+        assert!(!IPCService::should_retry_non_idempotent_edit_after_refresh(
+            Some(&previous),
+            &refreshed
+        ));
+    }
+
+    #[test]
+    fn non_idempotent_edit_retry_is_disabled_for_empty_refreshed_state() {
+        let previous = Candidates {
+            texts: vec!["か".to_string()],
+            sub_texts: vec![String::new()],
+            hiragana: "か".to_string(),
+            corresponding_count: vec![1],
+        };
+
+        assert!(!IPCService::should_retry_non_idempotent_edit_after_refresh(
+            Some(&previous),
+            &Candidates::default()
+        ));
+    }
+
+    #[test]
     fn server_session_change_ignores_initial_observation() {
         assert!(!IPCService::server_session_changed(None, 42));
     }
@@ -1130,5 +1362,54 @@ mod tests {
         let error = anyhow::anyhow!("named pipe disconnected");
 
         assert!(IPCService::should_reconnect_rpc_error(&error));
+    }
+
+    #[test]
+    fn non_idempotent_edit_attempt_completes_without_recovery_on_success() {
+        let candidates = Candidates {
+            texts: vec!["か".to_string()],
+            sub_texts: vec![String::new()],
+            hiragana: "か".to_string(),
+            corresponding_count: vec![1],
+        };
+
+        let attempt =
+            IPCService::classify_non_idempotent_edit_attempt("remove_text", Ok(candidates.clone()))
+                .expect("successful edit should not require recovery");
+
+        match attempt {
+            NonIdempotentEditAttempt::Completed(value) => assert_eq!(value, candidates),
+            NonIdempotentEditAttempt::ReconnectAndRefresh(_) => {
+                panic!("successful edit must not be classified as reconnect recovery")
+            }
+        }
+    }
+
+    #[test]
+    fn non_idempotent_edit_attempt_refreshes_after_reconnectable_error() {
+        let error = anyhow::Error::new(tonic::Status::unavailable("pipe closed"));
+
+        let attempt = IPCService::classify_non_idempotent_edit_attempt::<Candidates>(
+            "remove_text",
+            Err(error),
+        )
+        .expect("reconnectable edit error should recover by refreshing");
+
+        assert!(matches!(
+            attempt,
+            NonIdempotentEditAttempt::ReconnectAndRefresh(_)
+        ));
+    }
+
+    #[test]
+    fn non_idempotent_edit_attempt_returns_non_reconnectable_error() {
+        let error = anyhow::Error::new(tonic::Status::invalid_argument("offset out of range"));
+
+        let attempt = IPCService::classify_non_idempotent_edit_attempt::<Candidates>(
+            "move_cursor",
+            Err(error),
+        );
+
+        assert!(attempt.is_err());
     }
 }

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -46,6 +46,8 @@ pub struct IPCService {
     window_client: WindowServiceClient<tonic::transport::channel::Channel>,
     runtime: Arc<tokio::runtime::Runtime>,
     performance_log_tx: tokio::sync::mpsc::UnboundedSender<PerformanceLogRequest>,
+    server_session_id: Option<u64>,
+    server_reset_recovered: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -54,6 +56,15 @@ pub struct Candidates {
     pub sub_texts: Vec<String>,
     pub hiragana: String,
     pub corresponding_count: Vec<i32>,
+}
+
+impl Candidates {
+    pub(crate) fn is_empty_composition(&self) -> bool {
+        self.texts.is_empty()
+            && self.sub_texts.is_empty()
+            && self.hiragana.is_empty()
+            && self.corresponding_count.is_empty()
+    }
 }
 
 fn next_request_id() -> u64 {
@@ -195,6 +206,8 @@ impl IPCService {
             window_client,
             runtime,
             performance_log_tx,
+            server_session_id: None,
+            server_reset_recovered: false,
         })
     }
 }
@@ -234,6 +247,176 @@ impl IPCService {
         self.window_client = refreshed.window_client;
         self.runtime = refreshed.runtime;
         self.performance_log_tx = refreshed.performance_log_tx;
+        Ok(())
+    }
+
+    fn observe_server_session(&mut self, operation: &str, server_session_id: u64) {
+        if server_session_id == 0 {
+            return;
+        }
+
+        if Self::server_session_changed(self.server_session_id, server_session_id) {
+            if let Some(previous_session_id) = self.server_session_id {
+                self.server_reset_recovered = true;
+                tracing::warn!(
+                    operation = operation,
+                    previous_session_id = previous_session_id,
+                    server_session_id = server_session_id,
+                    "Detected azookey server session change"
+                );
+            }
+        }
+
+        self.server_session_id = Some(server_session_id);
+    }
+
+    #[inline]
+    fn server_session_changed(previous_session_id: Option<u64>, server_session_id: u64) -> bool {
+        server_session_id != 0
+            && previous_session_id.is_some_and(|previous| previous != server_session_id)
+    }
+
+    pub(crate) fn take_server_reset_recovered(&mut self) -> bool {
+        let recovered = self.server_reset_recovered;
+        self.server_reset_recovered = false;
+        recovered
+    }
+
+    fn run_rpc_with_reconnect<T>(
+        &mut self,
+        operation: &str,
+        mut send: impl FnMut(&mut Self) -> anyhow::Result<T>,
+    ) -> anyhow::Result<(T, bool)> {
+        match send(self) {
+            Ok(value) => Ok((value, false)),
+            Err(first_error) => {
+                if !Self::should_reconnect_rpc_error(&first_error) {
+                    tracing::warn!(
+                        "{operation} failed with non-reconnectable error: {first_error:?}"
+                    );
+                    return Err(first_error);
+                }
+
+                tracing::warn!(
+                    "{operation} first attempt failed, reconnecting IPC once: {first_error:?}"
+                );
+
+                match self.reconnect() {
+                    Ok(()) => {
+                        tracing::info!("{operation} IPC reconnect succeeded, retrying request");
+                    }
+                    Err(reconnect_error) => {
+                        tracing::error!("{operation} IPC reconnect failed: {reconnect_error:?}");
+                        return Err(reconnect_error);
+                    }
+                }
+
+                match send(self) {
+                    Ok(value) => Ok((value, true)),
+                    Err(retry_error) => {
+                        tracing::error!(
+                            "{operation} retry failed after IPC reconnect: {retry_error:?}"
+                        );
+                        Err(retry_error)
+                    }
+                }
+            }
+        }
+    }
+
+    fn should_reconnect_rpc_error(error: &anyhow::Error) -> bool {
+        let Some(status) = error.downcast_ref::<tonic::Status>() else {
+            return true;
+        };
+
+        matches!(
+            status.code(),
+            tonic::Code::Aborted
+                | tonic::Code::Cancelled
+                | tonic::Code::DataLoss
+                | tonic::Code::DeadlineExceeded
+                | tonic::Code::Internal
+                | tonic::Code::Unavailable
+                | tonic::Code::Unknown
+        )
+    }
+
+    fn send_append_text(
+        &mut self,
+        text: &str,
+        input_style: i32,
+        request_id: u64,
+    ) -> anyhow::Result<shared::proto::AppendTextResponse> {
+        let request = tonic::Request::new(shared::proto::AppendTextRequest {
+            text_to_append: text.to_string(),
+            input_style,
+            request_id,
+        });
+
+        let response = self
+            .runtime
+            .clone()
+            .block_on(self.azookey_client.append_text(request))?;
+        let response = response.into_inner();
+        self.observe_server_session("append_text", response.server_session_id);
+        Ok(response)
+    }
+
+    fn send_remove_text(&mut self, request_id: u64) -> anyhow::Result<Candidates> {
+        let request = tonic::Request::new(shared::proto::RemoveTextRequest { request_id });
+        let response = self
+            .runtime
+            .clone()
+            .block_on(self.azookey_client.remove_text(request))?;
+        let response = response.into_inner();
+        self.observe_server_session("remove_text", response.server_session_id);
+        Self::candidates_from_composing_text(response.composing_text)
+    }
+
+    fn send_clear_text(&mut self, request_id: u64) -> anyhow::Result<()> {
+        let request = tonic::Request::new(shared::proto::ClearTextRequest { request_id });
+        let response = self
+            .runtime
+            .clone()
+            .block_on(self.azookey_client.clear_text(request))?;
+        let response = response.into_inner();
+        self.observe_server_session("clear_text", response.server_session_id);
+        Ok(())
+    }
+
+    fn send_shrink_text(&mut self, offset: i32, request_id: u64) -> anyhow::Result<Candidates> {
+        let request = tonic::Request::new(shared::proto::ShrinkTextRequest { offset, request_id });
+        let response = self
+            .runtime
+            .clone()
+            .block_on(self.azookey_client.shrink_text(request))?;
+        let response = response.into_inner();
+        self.observe_server_session("shrink_text", response.server_session_id);
+        Self::candidates_from_composing_text(response.composing_text)
+    }
+
+    fn send_move_cursor(&mut self, offset: i32, request_id: u64) -> anyhow::Result<Candidates> {
+        let request = tonic::Request::new(shared::proto::MoveCursorRequest { offset, request_id });
+        let response = self
+            .runtime
+            .clone()
+            .block_on(self.azookey_client.move_cursor(request))?;
+        let response = response.into_inner();
+        self.observe_server_session("move_cursor", response.server_session_id);
+        Self::candidates_from_composing_text(response.composing_text)
+    }
+
+    fn send_set_context(&mut self, context: &str, request_id: u64) -> anyhow::Result<()> {
+        let request = tonic::Request::new(shared::proto::SetContextRequest {
+            context: context.to_string(),
+            request_id,
+        });
+        let response = self
+            .runtime
+            .clone()
+            .block_on(self.azookey_client.set_context(request))?;
+        let response = response.into_inner();
+        self.observe_server_session("set_context", response.server_session_id);
         Ok(())
     }
 
@@ -339,7 +522,17 @@ impl IPCService {
         previous_candidates: Option<&Candidates>,
         refreshed_candidates: &Candidates,
     ) -> bool {
-        previous_candidates.is_some_and(|previous| previous == refreshed_candidates)
+        previous_candidates.is_some_and(|previous| {
+            previous == refreshed_candidates || refreshed_candidates.is_empty_composition()
+        })
+    }
+
+    #[inline]
+    fn should_reset_client_composition_after_append_refresh(
+        previous_candidates: Option<&Candidates>,
+        refreshed_candidates: &Candidates,
+    ) -> bool {
+        previous_candidates.is_some() && refreshed_candidates.is_empty_composition()
     }
 
     #[tracing::instrument]
@@ -352,21 +545,7 @@ impl IPCService {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
         let input_len = performance_start.map(|_| text.chars().count());
-        let send = |this: &mut Self| -> anyhow::Result<
-            tonic::Response<shared::proto::AppendTextResponse>,
-        > {
-            let request = tonic::Request::new(shared::proto::AppendTextRequest {
-                text_to_append: text.clone(),
-                input_style,
-                request_id,
-            });
-
-            let response = this
-                .runtime
-                .clone()
-                .block_on(this.azookey_client.append_text(request))?;
-            Ok(response)
-        };
+        let send = |this: &mut Self| this.send_append_text(&text, input_style, request_id);
 
         let response = match send(self) {
             Ok(response) => response,
@@ -402,16 +581,25 @@ impl IPCService {
                     }
                 }
 
-                match self.move_cursor(0) {
+                match self.send_move_cursor(0, request_id) {
                     Ok(candidates) => {
                         if Self::should_retry_append_after_refresh(previous_candidates, &candidates)
                         {
+                            if Self::should_reset_client_composition_after_append_refresh(
+                                previous_candidates,
+                                &candidates,
+                            ) {
+                                self.server_reset_recovered = true;
+                                tracing::warn!(
+                                    "append_text recovered empty composition after reconnect (style={input_style}); client composition reset required"
+                                );
+                            }
                             tracing::warn!(
                                 "append_text recovered unchanged composition after reconnect (style={input_style}), retrying original input"
                             );
                             let retry_response = send(self)?;
                             let candidates = Self::candidates_from_composing_text(
-                                retry_response.into_inner().composing_text,
+                                retry_response.composing_text,
                             )?;
                             self.log_client_performance_from_start(
                                 performance_start,
@@ -466,8 +654,7 @@ impl IPCService {
                 }
             }
         };
-        let candidates =
-            Self::candidates_from_composing_text(response.into_inner().composing_text)?;
+        let candidates = Self::candidates_from_composing_text(response.composing_text)?;
         self.log_client_performance_from_start(
             performance_start,
             request_id,
@@ -485,20 +672,19 @@ impl IPCService {
     pub fn remove_text(&mut self) -> anyhow::Result<Candidates> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
-        let request = tonic::Request::new(shared::proto::RemoveTextRequest { request_id });
-        let response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.remove_text(request))?;
-        let candidates =
-            Self::candidates_from_composing_text(response.into_inner().composing_text)?;
+        let result =
+            self.run_rpc_with_reconnect("remove_text", |this| this.send_remove_text(request_id));
         self.log_client_performance_from_start(
             performance_start,
             request_id,
             "remove_text",
             "rpc_total",
-            || "status=success".to_string(),
+            || match &result {
+                Ok((_, retried)) => format!("status=success;retry={retried}"),
+                Err(error) => format!("status=error;error={error:?}"),
+            },
         );
+        let (candidates, _) = result?;
         Ok(candidates)
     }
 
@@ -506,40 +692,39 @@ impl IPCService {
     pub fn clear_text(&mut self) -> anyhow::Result<()> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
-        let request = tonic::Request::new(shared::proto::ClearTextRequest { request_id });
-        let _response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.clear_text(request))?;
+        let result =
+            self.run_rpc_with_reconnect("clear_text", |this| this.send_clear_text(request_id));
         self.log_client_performance_from_start(
             performance_start,
             request_id,
             "clear_text",
             "rpc_total",
-            || "status=success".to_string(),
+            || match &result {
+                Ok(((), retried)) => format!("status=success;retry={retried}"),
+                Err(error) => format!("status=error;error={error:?}"),
+            },
         );
-
-        Ok(())
+        result.map(|((), _)| ())
     }
 
     #[tracing::instrument]
     pub fn shrink_text(&mut self, offset: i32) -> anyhow::Result<Candidates> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
-        let request = tonic::Request::new(shared::proto::ShrinkTextRequest { offset, request_id });
-        let response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.shrink_text(request))?;
-        let candidates =
-            Self::candidates_from_composing_text(response.into_inner().composing_text)?;
+        let result = self.run_rpc_with_reconnect("shrink_text", |this| {
+            this.send_shrink_text(offset, request_id)
+        });
         self.log_client_performance_from_start(
             performance_start,
             request_id,
             "shrink_text",
             "rpc_total",
-            || format!("status=success;offset={offset}"),
+            || match &result {
+                Ok((_, retried)) => format!("status=success;retry={retried};offset={offset}"),
+                Err(error) => format!("status=error;offset={offset};error={error:?}"),
+            },
         );
+        let (candidates, _) = result?;
         Ok(candidates)
     }
 
@@ -547,20 +732,20 @@ impl IPCService {
     pub fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
-        let request = tonic::Request::new(shared::proto::MoveCursorRequest { offset, request_id });
-        let response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.move_cursor(request))?;
-        let candidates =
-            Self::candidates_from_composing_text(response.into_inner().composing_text)?;
+        let result = self.run_rpc_with_reconnect("move_cursor", |this| {
+            this.send_move_cursor(offset, request_id)
+        });
         self.log_client_performance_from_start(
             performance_start,
             request_id,
             "move_cursor",
             "rpc_total",
-            || format!("status=success;offset={offset}"),
+            || match &result {
+                Ok((_, retried)) => format!("status=success;retry={retried};offset={offset}"),
+                Err(error) => format!("status=error;offset={offset};error={error:?}"),
+            },
         );
+        let (candidates, _) = result?;
         Ok(candidates)
     }
 
@@ -568,14 +753,9 @@ impl IPCService {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
         let context_len = performance_start.map(|_| context.chars().count());
-        let request = tonic::Request::new(shared::proto::SetContextRequest {
-            context,
-            request_id,
+        let result = self.run_rpc_with_reconnect("set_context", |this| {
+            this.send_set_context(&context, request_id)
         });
-        let _response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.set_context(request))?;
         self.log_client_performance_from_start(
             performance_start,
             request_id,
@@ -583,11 +763,18 @@ impl IPCService {
             "rpc_total",
             || {
                 let context_len = context_len.unwrap_or_default();
-                format!("status=success;context_len={context_len}")
+                match &result {
+                    Ok(((), retried)) => {
+                        format!("status=success;retry={retried};context_len={context_len}")
+                    }
+                    Err(error) => {
+                        format!("status=error;context_len={context_len};error={error:?}")
+                    }
+                }
             },
         );
 
-        Ok(())
+        result.map(|((), _)| ())
     }
 }
 
@@ -853,5 +1040,95 @@ mod tests {
             Some(&previous),
             &refreshed
         ));
+    }
+
+    #[test]
+    fn append_retry_is_enabled_when_server_state_was_reset() {
+        let previous = Candidates {
+            texts: vec!["感じ".to_string()],
+            sub_texts: vec![String::new()],
+            hiragana: "かんじ".to_string(),
+            corresponding_count: vec![5],
+        };
+
+        assert!(IPCService::should_retry_append_after_refresh(
+            Some(&previous),
+            &Candidates::default()
+        ));
+    }
+
+    #[test]
+    fn append_recovery_requires_client_reset_when_server_state_was_reset() {
+        let previous = Candidates {
+            texts: vec!["漢字".to_string()],
+            sub_texts: vec![String::new()],
+            hiragana: "かんじ".to_string(),
+            corresponding_count: vec![5],
+        };
+
+        assert!(
+            IPCService::should_reset_client_composition_after_append_refresh(
+                Some(&previous),
+                &Candidates::default()
+            )
+        );
+    }
+
+    #[test]
+    fn append_recovery_does_not_reset_client_when_server_state_is_unchanged() {
+        let previous = Candidates {
+            texts: vec!["か".to_string()],
+            sub_texts: vec![String::new()],
+            hiragana: "か".to_string(),
+            corresponding_count: vec![1],
+        };
+
+        assert!(
+            !IPCService::should_reset_client_composition_after_append_refresh(
+                Some(&previous),
+                &previous
+            )
+        );
+    }
+
+    #[test]
+    fn server_session_change_ignores_initial_observation() {
+        assert!(!IPCService::server_session_changed(None, 42));
+    }
+
+    #[test]
+    fn server_session_change_detects_known_session_change() {
+        assert!(IPCService::server_session_changed(Some(42), 43));
+    }
+
+    #[test]
+    fn server_session_change_ignores_zero_session_id() {
+        assert!(!IPCService::server_session_changed(Some(42), 0));
+    }
+
+    #[test]
+    fn server_session_change_ignores_same_session() {
+        assert!(!IPCService::server_session_changed(Some(42), 42));
+    }
+
+    #[test]
+    fn reconnect_retry_is_enabled_for_transport_like_status() {
+        let error = anyhow::Error::new(tonic::Status::unavailable("pipe closed"));
+
+        assert!(IPCService::should_reconnect_rpc_error(&error));
+    }
+
+    #[test]
+    fn reconnect_retry_is_disabled_for_invalid_request_status() {
+        let error = anyhow::Error::new(tonic::Status::invalid_argument("offset out of range"));
+
+        assert!(!IPCService::should_reconnect_rpc_error(&error));
+    }
+
+    #[test]
+    fn reconnect_retry_is_enabled_for_non_status_error() {
+        let error = anyhow::anyhow!("named pipe disconnected");
+
+        assert!(IPCService::should_reconnect_rpc_error(&error));
     }
 }

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -189,6 +189,12 @@ impl TextServiceFactory {
     }
 
     #[tracing::instrument]
+    pub fn discard_composition_text(&self) -> Result<()> {
+        tracing::debug!("discard_composition_text");
+        self.close_composition(true)
+    }
+
+    #[tracing::instrument]
     pub fn set_text(&self, text: &str, subtext: &str) -> Result<()> {
         let text_service = self.borrow()?;
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -48,6 +48,7 @@ static SERVER_LOG_LEVEL: AtomicU8 = AtomicU8::new(ServerLogLevel::Warn as u8);
 static SERVER_CRASH_TRACE_ENABLED: AtomicBool = AtomicBool::new(true);
 static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 const SERVER_GENERATED_REQUEST_ID_PREFIX: u64 = 1 << 63;
+static SERVER_SESSION_ID: OnceLock<u64> = OnceLock::new();
 static HAS_ACTIVE_COMPOSITION: AtomicBool = AtomicBool::new(false);
 static SERVER_REQUESTS_IN_FLIGHT: AtomicU64 = AtomicU64::new(0);
 static LAST_INPUT_REQUEST_FINISHED_MS: AtomicU64 = AtomicU64::new(0);
@@ -532,6 +533,13 @@ fn request_id_or_next(request_id: u64) -> u64 {
     } else {
         request_id
     }
+}
+
+fn server_session_id() -> u64 {
+    *SERVER_SESSION_ID.get_or_init(|| {
+        let session_id = (u64::from(std::process::id()) << 32) ^ (now_timestamp_millis() as u64);
+        session_id.max(1)
+    })
 }
 
 fn set_request_id(request_id: u64) {
@@ -1392,6 +1400,7 @@ impl AzookeyService for MyAzookeyService {
                 hiragana: composed_text.hiragana.unwrap_or(composing_text.text),
                 suggestions: composed_text.suggestions,
             }),
+            server_session_id: server_session_id(),
         }))
     }
 
@@ -1444,6 +1453,7 @@ impl AzookeyService for MyAzookeyService {
                 hiragana: composed_text.hiragana.unwrap_or(composing_text.text),
                 suggestions: composed_text.suggestions,
             }),
+            server_session_id: server_session_id(),
         }))
     }
 
@@ -1499,6 +1509,7 @@ impl AzookeyService for MyAzookeyService {
                 hiragana: composed_text.hiragana.unwrap_or(composing_text.text),
                 suggestions: composed_text.suggestions,
             }),
+            server_session_id: server_session_id(),
         }))
     }
 
@@ -1528,7 +1539,9 @@ impl AzookeyService for MyAzookeyService {
             "status=success"
         );
         HAS_ACTIVE_COMPOSITION.store(false, Ordering::Relaxed);
-        Ok(Response::new(ClearTextResponse {}))
+        Ok(Response::new(ClearTextResponse {
+            server_session_id: server_session_id(),
+        }))
     }
 
     async fn shrink_text(
@@ -1581,6 +1594,7 @@ impl AzookeyService for MyAzookeyService {
                 hiragana: composed_text.hiragana.unwrap_or(composing_text.text),
                 suggestions: composed_text.suggestions,
             }),
+            server_session_id: server_session_id(),
         }))
     }
 
@@ -1621,7 +1635,9 @@ impl AzookeyService for MyAzookeyService {
             elapsed_ms(handler_start),
             "status=success"
         );
-        Ok(Response::new(shared::proto::SetContextResponse {}))
+        Ok(Response::new(shared::proto::SetContextResponse {
+            server_session_id: server_session_id(),
+        }))
     }
 
     async fn update_config(
@@ -1652,7 +1668,9 @@ impl AzookeyService for MyAzookeyService {
             elapsed_ms(handler_start),
             "status=success;active_composition={has_active_composition}"
         );
-        Ok(Response::new(shared::proto::UpdateConfigResponse {}))
+        Ok(Response::new(shared::proto::UpdateConfigResponse {
+            server_session_id: server_session_id(),
+        }))
     }
 
     async fn log_performance(

--- a/crates/shared/service.proto
+++ b/crates/shared/service.proto
@@ -29,6 +29,7 @@ message AppendTextRequest {
 // Response message for AppendText.
 message AppendTextResponse {
   ComposingText composing_text = 1; // The resulting text and suggestions.
+  uint64 server_session_id = 2; // Identifies the current server process session.
 }
 
 // Request message for RemoveText.
@@ -39,6 +40,7 @@ message RemoveTextRequest {
 // Response message for RemoveText.
 message RemoveTextResponse {
   ComposingText composing_text = 1; // The resulting text and suggestions.
+  uint64 server_session_id = 2; // Identifies the current server process session.
 }
 
 // Request message for MoveCursor.
@@ -54,12 +56,14 @@ message ShrinkTextRequest {
 }
 
 message ShrinkTextResponse {
-    ComposingText composing_text = 1; // The resulting text and suggestions.
+  ComposingText composing_text = 1; // The resulting text and suggestions.
+  uint64 server_session_id = 2; // Identifies the current server process session.
 }
 
 // Response message for MoveCursor.
 message MoveCursorResponse {
   ComposingText composing_text = 1; // The resulting text and suggestions.
+  uint64 server_session_id = 2; // Identifies the current server process session.
 }
 
 // Request message for ClearText.
@@ -68,19 +72,25 @@ message ClearTextRequest {
 }
 
 // Response message for ClearText.
-message ClearTextResponse {}
+message ClearTextResponse {
+  uint64 server_session_id = 1; // Identifies the current server process session.
+}
 
 message SetContextRequest {
   string context = 1;
   uint64 request_id = 2;
 }
 
-message SetContextResponse {}
+message SetContextResponse {
+  uint64 server_session_id = 1; // Identifies the current server process session.
+}
 
 message UpdateConfigRequest {
   uint64 request_id = 1;
 }
-message UpdateConfigResponse {}
+message UpdateConfigResponse {
+  uint64 server_session_id = 1; // Identifies the current server process session.
+}
 
 message PerformanceLogRequest {
   uint64 request_id = 1;


### PR DESCRIPTION
## Summary
- client IPC の reconnect / retry を共通化し、append 以外の remove / move / shrink / set_context でも reconnectable error を扱えるようにしました。
- remove / move / shrink などの非冪等な edit RPC は reconnect 後に server composition を refresh し、server 状態が未変更のときだけ retry するようにしました。
- server response に `server_session_id` を追加し、watchdog / manual restart をまたいだ server process session 変更を client 側で検知できるようにしました。
- reconnect 後に server 側 composition が空になっていた場合、client 側の stale composition / candidate window / clause snapshots を破棄して、次の入力で日本語入力へ復帰できるようにしました。

Closes #90

## Background
- Related: #81, #83
- #83 で launcher watchdog による `azookey-server.exe` の自動再起動が入った一方、client 側の reconnect / retry は append 系に寄っていました。
- server restart をまたいだ remove / move / shrink / set_context で stale state が残ると、候補 UI が古いままになったり、以後の入力復帰が難しくなる可能性がありました。
- review で、remove / move / shrink を blind retry すると response lost 時に削除・移動・短縮が二重適用され得る点が指摘されました。

## Changes
- IPC reconnect helper
  - reconnectable な tonic status / transport-like error を分類し、対象 RPC を reconnect 後に扱う helper へ整理
  - append / remove / move / shrink / clear / set_context の送信処理を session id 観測付き helper に整理
- non-idempotent edit recovery
  - remove / move / shrink は reconnect 後に `MoveCursor(0)` で server composition を refresh
  - refresh 後の候補が直前の client 候補と一致し、かつ空でない場合だけ元の edit RPC を retry
  - refresh 後に server 側状態が変化している場合は retry せず、refresh 結果を採用して二重適用を回避
- server session tracking
  - server process ごとに `server_session_id` を生成
  - `AppendText` / `RemoveText` / `MoveCursor` / `ShrinkText` / `ClearText` / `SetContext` / `UpdateConfig` response に session id を追加
  - client が既知 session からの変化を検知した場合、server reset recovery として扱う
- client composition recovery
  - reconnect 後に server composition が空、または append 結果が fresh input 相当になった場合、stale client composition を破棄
  - candidate window を非表示・空候補へ更新し、clause snapshots / future snapshots / temporary latin state をリセット
  - clause navigation / boundary adjustment 中に server reset を検知した場合、古い UI sync を抑制
- CI
  - `arduino/setup-protoc@v3` に `GITHUB_TOKEN` を渡し、GitHub API rate limit で protoc setup が落ちる問題を回避
- tests
  - append retry / client reset 判定の unit test を追加
  - reconnectable status 判定の unit test を追加
  - server session change detection の unit test を追加
  - non-idempotent edit recovery の unit test を追加

## Verification
- [x] Codex review
  - review 指摘「non-idempotent edit RPC の blind replay」を対応済み
- [x] 差分チェック
  - `git diff --check`
- [x] ローカル Windows VM targeted IPC tests
  - `.local/vm_test_client_composition.sh feature/90-ipc-reconnect-recovery ipc_service skip`
  - result: 18 tests passed
  - log: `.local/logs/vm-client-test-20260612-182851.log`
- [x] ローカル Windows VM composition test
  - `.local/vm_test_client_composition.sh feature/90-ipc-reconnect-recovery composition skip`
  - result: 104 tests passed
  - log: `.local/logs/vm-client-test-20260612-183406.log`
- [x] ローカル Windows VM build / install / restart smoke
  - artifact: `.local/artifacts/azookey-setup-feature_90-ipc-reconnect-recovery-20260611-180403.exe`
  - install log: `.local/logs/win11-install-20260611-184951.log`
  - TextBox smoke で server PID 変更後も入力復帰を確認
  - evidence screenshots: `.local/vm-debug/issue90-finalbuild-*`
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/27407713904

## Notes
- Notepad AppX が VM 側で起動できない状態だったため、入力 smoke は WinForms TextBox host で確認しました。
- protocol response に `server_session_id` field を追加しています。proto3 の追加 field なので wire compatibility は保たれますが、client/server は同一 installer で更新される前提です。
