### PR TITLE
perf(client): cache AppConfig for key handling

### DIFF
--- a/crates/client/src/engine.rs
+++ b/crates/client/src/engine.rs
@@ -3,6 +3,7 @@ pub(super) mod composition;
 pub(super) mod full_width;
 pub(super) mod input_mode;
 pub(super) mod ipc_service;
+pub(super) mod romaji_lookup;
 pub(super) mod state;
 pub(super) mod text_util;
 pub(super) mod theme;

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use crate::{
     engine::user_action::UserAction,
@@ -18,13 +15,14 @@ use super::{
         client_performance_log_enabled, current_input_trace_request_id, Candidates,
         ClientInputTraceGuard, IPCService,
     },
-    state::{keyboard_disabled_from_context, IMEState},
+    romaji_lookup::RomajiLookup,
+    state::{keyboard_disabled_from_context, AppConfigSnapshot, IMEState},
     text_util::{to_half_katakana, to_katakana},
     user_action::{Function, Navigation},
 };
-use shared::{
-    zenzai_cpu_backend_supported, AppConfig, NumpadInputMode, RomajiRule, SpaceInputMode,
-};
+#[cfg(test)]
+use shared::RomajiRule;
+use shared::{zenzai_cpu_backend_supported, AppConfig, NumpadInputMode, SpaceInputMode};
 use windows::Win32::{
     Foundation::{LPARAM, WPARAM},
     UI::{
@@ -69,124 +67,6 @@ impl CompositionReducer {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-struct RomajiLookup {
-    max_input_len: usize,
-    max_multi_char_input_len: usize,
-    prefix_set: HashSet<String>,
-    multi_char_prefix_set: HashSet<String>,
-    single_symbol_outputs: HashMap<char, String>,
-    single_symbol_output_order: HashMap<char, usize>,
-}
-
-impl RomajiLookup {
-    fn from_rows(rows: &[RomajiRule]) -> Self {
-        let mut lookup = Self::default();
-
-        for (row_index, row) in rows.iter().enumerate() {
-            let input = row.input.trim();
-            if input.is_empty() {
-                continue;
-            }
-
-            let input_len = input.chars().count();
-            lookup.max_input_len = lookup.max_input_len.max(input_len);
-            Self::insert_prefixes(input, &mut lookup.prefix_set);
-
-            if input_len > 1 {
-                lookup.max_multi_char_input_len = lookup.max_multi_char_input_len.max(input_len);
-                Self::insert_prefixes(input, &mut lookup.multi_char_prefix_set);
-            } else if row.next_input.trim().is_empty() && !row.output.is_empty() {
-                if let Some(symbol) = Self::single_char(input) {
-                    lookup
-                        .single_symbol_outputs
-                        .entry(symbol)
-                        .or_insert_with(|| row.output.clone());
-                    lookup
-                        .single_symbol_output_order
-                        .entry(symbol)
-                        .or_insert(row_index);
-                }
-            }
-        }
-
-        lookup
-    }
-
-    fn insert_prefixes(input: &str, prefixes: &mut HashSet<String>) {
-        let mut end = 0;
-        for ch in input.chars() {
-            end += ch.len_utf8();
-            prefixes.insert(input[..end].to_string());
-        }
-    }
-
-    fn single_char(input: &str) -> Option<char> {
-        let mut chars = input.chars();
-        let ch = chars.next()?;
-        chars.next().is_none().then_some(ch)
-    }
-
-    fn has_romaji_table_context(&self, raw_input_before: &str, symbol: char) -> bool {
-        self.has_context(
-            raw_input_before,
-            symbol,
-            self.max_input_len,
-            &self.prefix_set,
-        )
-    }
-
-    fn has_multi_character_romaji_context(&self, raw_input_before: &str, symbol: char) -> bool {
-        self.has_context(
-            raw_input_before,
-            symbol,
-            self.max_multi_char_input_len,
-            &self.multi_char_prefix_set,
-        )
-    }
-
-    fn has_context(
-        &self,
-        raw_input_before: &str,
-        symbol: char,
-        max_input_len: usize,
-        prefixes: &HashSet<String>,
-    ) -> bool {
-        if max_input_len == 0 || prefixes.is_empty() {
-            return false;
-        }
-
-        let mut tail: Vec<char> = raw_input_before
-            .chars()
-            .rev()
-            .take(max_input_len.saturating_sub(1))
-            .collect();
-        tail.reverse();
-
-        let mut combined = String::with_capacity(raw_input_before.len() + symbol.len_utf8());
-        for ch in tail {
-            combined.push(ch);
-        }
-        combined.push(symbol);
-
-        combined
-            .char_indices()
-            .any(|(suffix_start, _)| prefixes.contains(&combined[suffix_start..]))
-    }
-
-    fn single_symbol_output(&self, symbols: &[char]) -> Option<String> {
-        symbols
-            .iter()
-            .filter_map(|symbol| {
-                let order = self.single_symbol_output_order.get(symbol)?;
-                let output = self.single_symbol_outputs.get(symbol)?;
-                Some((*order, output))
-            })
-            .min_by_key(|(order, _)| *order)
-            .map(|(_, output)| output.clone())
-    }
-}
-
 #[derive(Default, Clone, PartialEq, Debug)]
 pub enum CompositionState {
     #[default]
@@ -195,6 +75,8 @@ pub enum CompositionState {
     Previewing,
     Selecting,
 }
+
+pub(crate) type ProcessKeyResult = Option<(Vec<ClientAction>, CompositionState, AppConfigSnapshot)>;
 
 #[derive(Default, Clone, Debug)]
 pub struct Composition {
@@ -284,13 +166,6 @@ impl TextServiceFactory {
     const MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT: i32 = 126;
     const MOVE_CURSOR_POP_CLAUSE_SNAPSHOT: i32 = 127;
     const MOVE_CLAUSE_TO_LAST: i32 = i32::MAX;
-
-    fn load_app_config_or_default() -> AppConfig {
-        AppConfig::read().unwrap_or_else(|error| {
-            tracing::error!("Failed to load settings; using defaults: {error}");
-            AppConfig::default()
-        })
-    }
 
     fn log_client_performance(
         request_id: u64,
@@ -3108,7 +2983,7 @@ impl TextServiceFactory {
         context: Option<&ITfContext>,
         wparam: WPARAM,
         lparam: LPARAM,
-    ) -> Result<Option<(Vec<ClientAction>, CompositionState)>> {
+    ) -> Result<ProcessKeyResult> {
         let standalone_trace = (current_input_trace_request_id().is_none()
             && client_performance_log_enabled())
         .then(ClientInputTraceGuard::begin);
@@ -3118,7 +2993,7 @@ impl TextServiceFactory {
                 .map(ClientInputTraceGuard::request_id)
         });
         let total_start = trace_request_id.map(|_| Instant::now());
-        let result: Result<Option<(Vec<ClientAction>, CompositionState)>> = (|| {
+        let result: Result<ProcessKeyResult> = (|| {
             let Some(context) = context else {
                 self.set_keyboard_disabled_state(true)?;
                 return Ok(None);
@@ -3142,18 +3017,23 @@ impl TextServiceFactory {
             let is_shift_right = is_shift_pressed && wparam.0 == 0x27;
             let is_shift_key = Self::is_shift_key(wparam);
             let is_alt_backquote = Self::is_alt_backquote(wparam, lparam);
-            let app_config_start = trace_request_id.map(|_| Instant::now());
-            let app_config = Self::load_app_config_or_default();
-            if let (Some(request_id), Some(app_config_start)) = (trace_request_id, app_config_start)
+            let config_snapshot_start = trace_request_id.map(|_| Instant::now());
+            let config_snapshot = IMEState::app_config_snapshot()?;
+            let app_config = config_snapshot.app_config();
+            let romaji_lookup = config_snapshot.romaji_lookup();
+            if let (Some(request_id), Some(config_snapshot_start)) =
+                (trace_request_id, config_snapshot_start)
             {
                 Self::log_client_performance(
                     request_id,
                     "process_key",
-                    "app_config_read",
-                    app_config_start.elapsed(),
+                    "config_snapshot",
+                    config_snapshot_start.elapsed(),
                     format!(
-                        "romaji_rows={};wparam={}",
+                        "romaji_rows={};max_input_len={};max_multi_char_input_len={};wparam={}",
                         app_config.romaji_table.rows.len(),
+                        romaji_lookup.max_input_len,
+                        romaji_lookup.max_multi_char_input_len,
                         wparam.0
                     ),
                 );
@@ -3204,6 +3084,7 @@ impl TextServiceFactory {
                 return Ok(Some((
                     vec![ClientAction::SetTemporaryLatinShiftPending(true)],
                     composition.state.clone(),
+                    config_snapshot,
                 )));
             }
 
@@ -3226,32 +3107,13 @@ impl TextServiceFactory {
                 UserAction::try_from(wparam.0)?
             };
 
-            let romaji_lookup_start = trace_request_id.map(|_| Instant::now());
-            let romaji_lookup = RomajiLookup::from_rows(&app_config.romaji_table.rows);
-            if let (Some(request_id), Some(romaji_lookup_start)) =
-                (trace_request_id, romaji_lookup_start)
-            {
-                Self::log_client_performance(
-                    request_id,
-                    "process_key",
-                    "romaji_lookup_build",
-                    romaji_lookup_start.elapsed(),
-                    format!(
-                        "rows={};max_input_len={};max_multi_char_input_len={}",
-                        app_config.romaji_table.rows.len(),
-                        romaji_lookup.max_input_len,
-                        romaji_lookup.max_multi_char_input_len
-                    ),
-                );
-            }
-
             let Some((transition, mut actions)) = Self::plan_actions_for_user_action_with_lookup(
                 &composition,
                 &action,
                 &mode,
                 is_shift_pressed,
-                &app_config,
-                &romaji_lookup,
+                app_config,
+                romaji_lookup,
                 start_temporary_latin,
             ) else {
                 self.clear_temporary_latin_shift_pending_if_needed(should_clear_shift_pending)?;
@@ -3293,12 +3155,12 @@ impl TextServiceFactory {
                 actions.insert(0, ClientAction::SetTemporaryLatinShiftPending(false));
             }
 
-            Ok(Some((actions, transition)))
+            Ok(Some((actions, transition, config_snapshot)))
         })();
 
         if let (Some(request_id), Some(total_start)) = (trace_request_id, total_start) {
             let details = match &result {
-                Ok(Some((actions, transition))) => format!(
+                Ok(Some((actions, transition, _))) => format!(
                     "status=success;handled=true;actions={};transition={transition:?};wparam={}",
                     actions.len(),
                     wparam.0
@@ -3374,8 +3236,10 @@ impl TextServiceFactory {
                 return Ok(false);
             };
 
-            if let Some((actions, transition)) = self.process_key(context, wparam, lparam)? {
-                self.handle_action(&actions, transition)?;
+            if let Some((actions, transition, config_snapshot)) =
+                self.process_key(context, wparam, lparam)?
+            {
+                self.handle_action_with_config_snapshot(&actions, transition, config_snapshot)?;
                 Ok(true)
             } else {
                 Ok(false)
@@ -3500,6 +3364,38 @@ impl TextServiceFactory {
         transition: CompositionState,
     ) -> Result<()> {
         let trace_request_id = current_input_trace_request_id();
+        let config_snapshot_start = trace_request_id.map(|_| Instant::now());
+        let config_snapshot = IMEState::app_config_snapshot()?;
+        if let (Some(request_id), Some(config_snapshot_start)) =
+            (trace_request_id, config_snapshot_start)
+        {
+            let app_config = config_snapshot.app_config();
+            let romaji_lookup = config_snapshot.romaji_lookup();
+            Self::log_client_performance(
+                request_id,
+                "handle_action",
+                "config_snapshot",
+                config_snapshot_start.elapsed(),
+                format!(
+                    "actions={};romaji_rows={};max_input_len={};max_multi_char_input_len={}",
+                    actions.len(),
+                    app_config.romaji_table.rows.len(),
+                    romaji_lookup.max_input_len,
+                    romaji_lookup.max_multi_char_input_len
+                ),
+            );
+        }
+
+        self.handle_action_with_config_snapshot(actions, transition, config_snapshot)
+    }
+
+    fn handle_action_with_config_snapshot(
+        &self,
+        actions: &[ClientAction],
+        transition: CompositionState,
+        config_snapshot: AppConfigSnapshot,
+    ) -> Result<()> {
+        let trace_request_id = current_input_trace_request_id();
         let total_start = trace_request_id.map(|_| Instant::now());
         let requested_transition = transition.clone();
         let result: Result<()> = (|| {
@@ -3510,40 +3406,8 @@ impl TextServiceFactory {
                 let mode = IMEState::input_mode()?;
                 (composition, mode)
             };
-            let app_config_start = trace_request_id.map(|_| Instant::now());
-            let app_config = Self::load_app_config_or_default();
-            if let (Some(request_id), Some(app_config_start)) = (trace_request_id, app_config_start)
-            {
-                Self::log_client_performance(
-                    request_id,
-                    "handle_action",
-                    "app_config_read",
-                    app_config_start.elapsed(),
-                    format!(
-                        "actions={};romaji_rows={}",
-                        actions.len(),
-                        app_config.romaji_table.rows.len()
-                    ),
-                );
-            }
-            let romaji_lookup_start = trace_request_id.map(|_| Instant::now());
-            let romaji_lookup = RomajiLookup::from_rows(&app_config.romaji_table.rows);
-            if let (Some(request_id), Some(romaji_lookup_start)) =
-                (trace_request_id, romaji_lookup_start)
-            {
-                Self::log_client_performance(
-                    request_id,
-                    "handle_action",
-                    "romaji_lookup_build",
-                    romaji_lookup_start.elapsed(),
-                    format!(
-                        "rows={};max_input_len={};max_multi_char_input_len={}",
-                        app_config.romaji_table.rows.len(),
-                        romaji_lookup.max_input_len,
-                        romaji_lookup.max_multi_char_input_len
-                    ),
-                );
-            }
+            let app_config = config_snapshot.app_config();
+            let romaji_lookup = config_snapshot.romaji_lookup();
 
             let mut preview = composition.preview.clone();
             let mut suffix = composition.suffix.clone();
@@ -3699,8 +3563,8 @@ impl TextServiceFactory {
                             InputMode::Kana => Self::resolve_symbol_input_text_with_lookup(
                                 &raw_input,
                                 text,
-                                &app_config,
-                                &romaji_lookup,
+                                app_config,
+                                romaji_lookup,
                             ),
                             InputMode::Latin => None,
                         };
@@ -3754,7 +3618,7 @@ impl TextServiceFactory {
                                 &mut ipc_service,
                                 &candidates,
                                 selection_index,
-                                &app_config,
+                                app_config,
                                 &transition,
                             )?;
                         } else if candidates.is_empty_composition() {
@@ -3813,7 +3677,7 @@ impl TextServiceFactory {
                                 &mut ipc_service,
                                 &candidates,
                                 selection_index,
-                                &app_config,
+                                app_config,
                                 &transition,
                             )?;
                         } else if candidates.is_empty_composition() {
@@ -3872,7 +3736,7 @@ impl TextServiceFactory {
                                 &mut ipc_service,
                                 &candidates,
                                 selection_index,
-                                &app_config,
+                                app_config,
                                 &transition,
                             )?;
                         } else if candidates.is_empty_composition() {
@@ -4550,8 +4414,8 @@ impl TextServiceFactory {
                             InputMode::Kana => Self::resolve_symbol_input_text_with_lookup(
                                 &shrunk_raw_input,
                                 text,
-                                &app_config,
-                                &romaji_lookup,
+                                app_config,
+                                romaji_lookup,
                             ),
                             InputMode::Latin => None,
                         };

--- a/crates/client/src/engine/romaji_lookup.rs
+++ b/crates/client/src/engine/romaji_lookup.rs
@@ -1,0 +1,125 @@
+use std::collections::{HashMap, HashSet};
+
+use shared::RomajiRule;
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct RomajiLookup {
+    pub(super) max_input_len: usize,
+    pub(super) max_multi_char_input_len: usize,
+    prefix_set: HashSet<String>,
+    multi_char_prefix_set: HashSet<String>,
+    single_symbol_outputs: HashMap<char, String>,
+    single_symbol_output_order: HashMap<char, usize>,
+}
+
+impl RomajiLookup {
+    pub(super) fn from_rows(rows: &[RomajiRule]) -> Self {
+        let mut lookup = Self::default();
+
+        for (row_index, row) in rows.iter().enumerate() {
+            let input = row.input.trim();
+            if input.is_empty() {
+                continue;
+            }
+
+            let input_len = input.chars().count();
+            lookup.max_input_len = lookup.max_input_len.max(input_len);
+            Self::insert_prefixes(input, &mut lookup.prefix_set);
+
+            if input_len > 1 {
+                lookup.max_multi_char_input_len = lookup.max_multi_char_input_len.max(input_len);
+                Self::insert_prefixes(input, &mut lookup.multi_char_prefix_set);
+            } else if row.next_input.trim().is_empty() && !row.output.is_empty() {
+                if let Some(symbol) = Self::single_char(input) {
+                    lookup
+                        .single_symbol_outputs
+                        .entry(symbol)
+                        .or_insert_with(|| row.output.clone());
+                    lookup
+                        .single_symbol_output_order
+                        .entry(symbol)
+                        .or_insert(row_index);
+                }
+            }
+        }
+
+        lookup
+    }
+
+    fn insert_prefixes(input: &str, prefixes: &mut HashSet<String>) {
+        let mut end = 0;
+        for ch in input.chars() {
+            end += ch.len_utf8();
+            prefixes.insert(input[..end].to_string());
+        }
+    }
+
+    fn single_char(input: &str) -> Option<char> {
+        let mut chars = input.chars();
+        let ch = chars.next()?;
+        chars.next().is_none().then_some(ch)
+    }
+
+    pub(super) fn has_romaji_table_context(&self, raw_input_before: &str, symbol: char) -> bool {
+        self.has_context(
+            raw_input_before,
+            symbol,
+            self.max_input_len,
+            &self.prefix_set,
+        )
+    }
+
+    pub(super) fn has_multi_character_romaji_context(
+        &self,
+        raw_input_before: &str,
+        symbol: char,
+    ) -> bool {
+        self.has_context(
+            raw_input_before,
+            symbol,
+            self.max_multi_char_input_len,
+            &self.multi_char_prefix_set,
+        )
+    }
+
+    fn has_context(
+        &self,
+        raw_input_before: &str,
+        symbol: char,
+        max_input_len: usize,
+        prefixes: &HashSet<String>,
+    ) -> bool {
+        if max_input_len == 0 || prefixes.is_empty() {
+            return false;
+        }
+
+        let mut tail: Vec<char> = raw_input_before
+            .chars()
+            .rev()
+            .take(max_input_len.saturating_sub(1))
+            .collect();
+        tail.reverse();
+
+        let mut combined = String::with_capacity(raw_input_before.len() + symbol.len_utf8());
+        for ch in tail {
+            combined.push(ch);
+        }
+        combined.push(symbol);
+
+        combined
+            .char_indices()
+            .any(|(suffix_start, _)| prefixes.contains(&combined[suffix_start..]))
+    }
+
+    pub(super) fn single_symbol_output(&self, symbols: &[char]) -> Option<String> {
+        symbols
+            .iter()
+            .filter_map(|symbol| {
+                let order = self.single_symbol_output_order.get(symbol)?;
+                let output = self.single_symbol_outputs.get(symbol)?;
+                Some((*order, output))
+            })
+            .min_by_key(|(order, _)| *order)
+            .map(|(_, output)| output.clone())
+    }
+}

--- a/crates/client/src/engine/state.rs
+++ b/crates/client/src/engine/state.rs
@@ -1,17 +1,133 @@
-use std::sync::{LazyLock, Mutex, MutexGuard};
+use std::{
+    fs, io,
+    path::PathBuf,
+    sync::{Arc, LazyLock, Mutex, MutexGuard},
+    time::SystemTime,
+};
 
+use shared::AppConfig;
 use windows::{
     core::Interface as _,
     Win32::UI::TextServices::{ITfCompartmentMgr, ITfContext, GUID_COMPARTMENT_KEYBOARD_DISABLED},
 };
 
-use super::{input_mode::InputMode, ipc_service::IPCService};
+use super::{input_mode::InputMode, ipc_service::IPCService, romaji_lookup::RomajiLookup};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum AppConfigCacheKey {
+    File {
+        path: PathBuf,
+        len: u64,
+        modified: Option<SystemTime>,
+    },
+    Missing {
+        path: PathBuf,
+    },
+    Unavailable {
+        reason: String,
+    },
+}
+
+impl AppConfigCacheKey {
+    fn current() -> Result<Self, shared::ConfigError> {
+        Self::for_path(AppConfig::settings_path()?)
+    }
+
+    fn for_path(path: PathBuf) -> Result<Self, shared::ConfigError> {
+        match fs::metadata(&path) {
+            Ok(metadata) => Ok(Self::File {
+                path,
+                len: metadata.len(),
+                modified: metadata.modified().ok(),
+            }),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(Self::Missing { path }),
+            Err(source) => Err(shared::ConfigError::Read { path, source }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::AppConfigCacheKey;
+
+    fn unique_test_dir(test_name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after UNIX_EPOCH")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "azookey-windows-{test_name}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn app_config_cache_key_uses_missing_variant_for_absent_settings_file() {
+        let root = unique_test_dir("missing-config");
+        fs::create_dir_all(&root).expect("temp config dir should be created");
+        let path = root.join("settings.json");
+
+        let cache_key = AppConfigCacheKey::for_path(path.clone()).unwrap();
+
+        assert_eq!(cache_key, AppConfigCacheKey::Missing { path });
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn app_config_cache_key_changes_when_settings_file_changes_size() {
+        let root = unique_test_dir("changed-config");
+        fs::create_dir_all(&root).expect("temp config dir should be created");
+        let path = root.join("settings.json");
+        fs::write(&path, "a").expect("initial settings should be written");
+        let initial = AppConfigCacheKey::for_path(path.clone()).unwrap();
+
+        fs::write(&path, "abcd").expect("updated settings should be written");
+        let updated = AppConfigCacheKey::for_path(path).unwrap();
+
+        assert_ne!(initial, updated);
+        assert!(matches!(updated, AppConfigCacheKey::File { len: 4, .. }));
+        fs::remove_dir_all(root).ok();
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct AppConfigSnapshot {
+    app_config: Arc<AppConfig>,
+    romaji_lookup: Arc<RomajiLookup>,
+    cache_key: AppConfigCacheKey,
+}
+
+impl AppConfigSnapshot {
+    fn new(app_config: AppConfig, cache_key: AppConfigCacheKey) -> Self {
+        let romaji_lookup = RomajiLookup::from_rows(&app_config.romaji_table.rows);
+        Self {
+            app_config: Arc::new(app_config),
+            romaji_lookup: Arc::new(romaji_lookup),
+            cache_key,
+        }
+    }
+
+    pub(super) fn app_config(&self) -> &AppConfig {
+        self.app_config.as_ref()
+    }
+
+    pub(super) fn romaji_lookup(&self) -> &RomajiLookup {
+        self.romaji_lookup.as_ref()
+    }
+}
 
 #[derive(Debug)]
 pub struct IMEState {
     pub ipc_service: Option<IPCService>,
     pub input_mode: InputMode,
     pub keyboard_disabled: bool,
+    app_config_snapshot: Option<AppConfigSnapshot>,
 }
 
 pub static IME_STATE: LazyLock<Mutex<IMEState>> = LazyLock::new(|| {
@@ -20,6 +136,7 @@ pub static IME_STATE: LazyLock<Mutex<IMEState>> = LazyLock::new(|| {
         ipc_service: None,
         input_mode: InputMode::default(),
         keyboard_disabled: false,
+        app_config_snapshot: None,
     })
 });
 
@@ -66,6 +183,40 @@ impl IMEState {
         };
 
         Ok((changed, ipc_service))
+    }
+
+    pub(super) fn app_config_snapshot() -> anyhow::Result<AppConfigSnapshot> {
+        let (cache_key, inspect_error) = match AppConfigCacheKey::current() {
+            Ok(cache_key) => (cache_key, None),
+            Err(error) => {
+                let reason = error.to_string();
+                (
+                    AppConfigCacheKey::Unavailable {
+                        reason: reason.clone(),
+                    },
+                    Some(reason),
+                )
+            }
+        };
+
+        let mut state = Self::get()?;
+        if let Some(snapshot) = &state.app_config_snapshot {
+            if snapshot.cache_key == cache_key {
+                return Ok(snapshot.clone());
+            }
+        }
+        state.app_config_snapshot = None;
+
+        if let Some(error) = inspect_error {
+            tracing::error!("Failed to inspect settings; using cached/default config: {error}");
+        }
+        let app_config = AppConfig::read().unwrap_or_else(|error| {
+            tracing::error!("Failed to load settings; using defaults: {error}");
+            AppConfig::default()
+        });
+        let snapshot = AppConfigSnapshot::new(app_config, cache_key);
+        state.app_config_snapshot = Some(snapshot.clone());
+        Ok(snapshot)
     }
 }
 

--- a/crates/client/src/engine/state.rs
+++ b/crates/client/src/engine/state.rs
@@ -49,12 +49,50 @@ impl AppConfigCacheKey {
 #[cfg(test)]
 mod tests {
     use std::{
+        env,
+        ffi::OsString,
         fs,
         path::PathBuf,
+        sync::{Mutex, MutexGuard, OnceLock},
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use super::AppConfigCacheKey;
+    use super::{AppConfigCacheKey, IMEState};
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    struct AppDataGuard {
+        _guard: MutexGuard<'static, ()>,
+        previous: Option<OsString>,
+    }
+
+    impl AppDataGuard {
+        fn set(path: &PathBuf) -> Self {
+            let guard = env_lock();
+            let previous = env::var_os("APPDATA");
+            unsafe {
+                env::set_var("APPDATA", path);
+            }
+            Self {
+                _guard: guard,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for AppDataGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => env::set_var("APPDATA", value),
+                    None => env::remove_var("APPDATA"),
+                }
+            }
+        }
+    }
 
     fn unique_test_dir(test_name: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -92,6 +130,59 @@ mod tests {
 
         assert_ne!(initial, updated);
         assert!(matches!(updated, AppConfigCacheKey::File { len: 4, .. }));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn app_config_snapshot_does_not_cache_default_after_read_error() {
+        let root = unique_test_dir("config-read-error");
+        let config_root = root.join("Azookey");
+        fs::create_dir_all(&config_root).expect("temp config dir should be created");
+        fs::create_dir(config_root.join("settings.json"))
+            .expect("settings path directory should cause read_to_string to fail");
+        let _appdata = AppDataGuard::set(&root);
+
+        IMEState::get().unwrap().app_config_snapshot = None;
+
+        let snapshot = IMEState::app_config_snapshot().unwrap();
+        assert!(matches!(
+            &snapshot.cache_key,
+            AppConfigCacheKey::Unavailable { .. }
+        ));
+        assert!(IMEState::get().unwrap().app_config_snapshot.is_none());
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn app_config_snapshot_keeps_previous_cache_after_read_error() {
+        let root = unique_test_dir("config-read-error-keeps-cache");
+        let config_root = root.join("Azookey");
+        fs::create_dir_all(&config_root).expect("temp config dir should be created");
+        let _appdata = AppDataGuard::set(&root);
+
+        IMEState::get().unwrap().app_config_snapshot = None;
+        let initial = IMEState::app_config_snapshot().unwrap();
+        assert!(matches!(
+            &initial.cache_key,
+            AppConfigCacheKey::Missing { .. }
+        ));
+
+        fs::create_dir(config_root.join("settings.json"))
+            .expect("settings path directory should cause read_to_string to fail");
+        let after_error = IMEState::app_config_snapshot().unwrap();
+        assert_eq!(&after_error.cache_key, &initial.cache_key);
+        assert_eq!(
+            &IMEState::get()
+                .unwrap()
+                .app_config_snapshot
+                .as_ref()
+                .unwrap()
+                .cache_key,
+            &initial.cache_key
+        );
+
+        IMEState::get().unwrap().app_config_snapshot = None;
         fs::remove_dir_all(root).ok();
     }
 }
@@ -205,18 +296,39 @@ impl IMEState {
                 return Ok(snapshot.clone());
             }
         }
-        state.app_config_snapshot = None;
-
         if let Some(error) = inspect_error {
             tracing::error!("Failed to inspect settings; using cached/default config: {error}");
         }
-        let app_config = AppConfig::read().unwrap_or_else(|error| {
-            tracing::error!("Failed to load settings; using defaults: {error}");
-            AppConfig::default()
-        });
-        let snapshot = AppConfigSnapshot::new(app_config, cache_key);
-        state.app_config_snapshot = Some(snapshot.clone());
-        Ok(snapshot)
+        match AppConfig::read() {
+            Ok(app_config) => {
+                let snapshot = AppConfigSnapshot::new(app_config, cache_key);
+                state.app_config_snapshot = Some(snapshot.clone());
+                Ok(snapshot)
+            }
+            Err(shared::ConfigError::Read { path, source }) => {
+                tracing::error!(
+                    "Failed to load settings; using cached/default config without updating cache: failed to read config {}: {}",
+                    path.display(),
+                    source
+                );
+                if let Some(snapshot) = &state.app_config_snapshot {
+                    return Ok(snapshot.clone());
+                }
+
+                Ok(AppConfigSnapshot::new(
+                    AppConfig::default(),
+                    AppConfigCacheKey::Unavailable {
+                        reason: format!("read failed: {}: {}", path.display(), source),
+                    },
+                ))
+            }
+            Err(error) => {
+                tracing::error!("Failed to load settings; using defaults: {error}");
+                let snapshot = AppConfigSnapshot::new(AppConfig::default(), cache_key);
+                state.app_config_snapshot = Some(snapshot.clone());
+                Ok(snapshot)
+            }
+        }
     }
 }
 

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -894,6 +894,10 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
+    pub fn settings_path() -> Result<PathBuf, ConfigError> {
+        Ok(get_config_root()?.join(SETTINGS_FILENAME))
+    }
+
     pub fn write(&self) -> Result<(), ConfigError> {
         let config_root = get_config_root()?;
         ensure_config_dir(&config_root)?;


### PR DESCRIPTION
## Summary
- IME 側に `AppConfigSnapshot` を追加し、`AppConfig` と派生した `RomajiLookup` を cache するようにしました。
- `process_key` と `handle_action` が同じ設定 snapshot を使うようにして、1 打鍵内で設定読み込みと lookup 構築が重複しないようにしました。
- `settings.json` の metadata を cache key として見て、設定ファイル変更時には次回入力で snapshot を再読み込みします。
- config read error 時は成功 metadata key で default snapshot を保存せず、次回も再読込を試すようにしました。

Closes #86

## Background
- Related: #81
- 現状の入力 hot path では、`process_key` / `handle_action` の両方で `AppConfig::read()` が走り、さらに `RomajiLookup::from_rows(...)` が打鍵ごとに構築されていました。
- `settings.json` の読み込み・JSON parse・migration 判定・romaji table lookup 構築は通常入力の固定費になっていたため、設定 snapshot と派生 lookup を IME state に保持します。
- review で、metadata 取得成功後の一時的な read error を default snapshot として cache すると、同じ metadata のまま読み込み可能に戻った場合に設定が再読込されない点が指摘されました。

## Changes
- config snapshot cache
  - `IMEState` に `AppConfigSnapshot` を保持
  - `AppConfigCacheKey` で settings file の存在、更新時刻、file size を比較
  - cache key が変わらない場合は既存 snapshot を再利用
  - settings file の inspection / read に失敗した場合は log しつつ default config へ fallback
- read error recovery
  - `AppConfig::read()` の read error 時は成功 metadata key で default snapshot を cache しない
  - 既存 snapshot がある場合はそれを返し、次回入力でも再読込を試す
  - 既存 snapshot がない場合は入力を止めないため一時 default snapshot を返すが、cache には保存しない
- RomajiLookup cache
  - `RomajiLookup` を `composition.rs` から `engine/romaji_lookup.rs` に分離
  - `AppConfigSnapshot` 作成時に romaji rows から lookup を 1 回だけ構築
  - symbol / width / punctuation path で cached lookup を参照
- process_key / handle_action alignment
  - `process_key` の戻り値に `AppConfigSnapshot` を含める
  - 通常の key handling では `process_key` と `handle_action` が同じ snapshot を共有
  - direct `handle_action` path では必要時に snapshot を取得
- shared config access
  - client 側 cache key 判定のため、`AppConfig::settings_path()` を公開

## Verification
- [x] Codex review
  - review 指摘「read error 時に default snapshot が成功 metadata key で cache される」を対応済み
- [x] format / 差分チェック
  - `cargo fmt`
  - `git diff --check`
- [x] ローカル Windows VM targeted config cache tests
  - `.local/vm_test_client_composition.sh feature/86-config-cache app_config_snapshot skip`
  - result: 2 tests passed
  - log: `.local/logs/vm-client-test-20260612-222814.log`
- [x] ローカル Windows VM composition test
  - `.local/vm_test_client_composition.sh feature/86-config-cache composition skip`
  - result: 104 tests passed
  - log: `.local/logs/vm-client-test-20260612-223504.log`
- [x] GitHub Actions build
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/27419544334
- [ ] VM build / install smoke

## Notes
- GitHub Actions build pass 後、Ready for review の状態を維持しています。
