### PR TITLE
perf(client): reduce context and position updates

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1341,7 +1341,8 @@ impl TextServiceFactory {
         let trace_request_id = current_input_trace_request_id();
         let total_start = trace_request_id.map(|_| Instant::now());
         let result: Result<()> = (|| {
-            let should_update_pos = update_pos && visible != Some(false);
+            let should_update_pos =
+                self.should_update_candidate_window_position(update_pos, visible);
             let position = if should_update_pos {
                 let position_start = trace_request_id.map(|_| Instant::now());
                 let position = self.candidate_window_position_for_update()?;
@@ -1375,6 +1376,7 @@ impl TextServiceFactory {
                 Some(selection_index),
                 None,
             )?;
+            self.remember_candidate_window_visibility(visible);
             Ok(())
         })();
 
@@ -1402,6 +1404,43 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn should_update_candidate_window_position(
+        &self,
+        update_pos: bool,
+        visible: Option<bool>,
+    ) -> bool {
+        match self.borrow() {
+            Ok(text_service) => text_service
+                .candidate_window_visibility_state
+                .should_update_position(update_pos, visible),
+            Err(error) => {
+                tracing::warn!(
+                    "Assume candidate window position should update after visibility state borrow failed: {error:?}"
+                );
+                update_pos && visible != Some(false)
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn remember_candidate_window_visibility(&self, visible: Option<bool>) {
+        if visible.is_none() {
+            return;
+        }
+
+        match self.borrow_mut() {
+            Ok(mut text_service) => {
+                text_service
+                    .candidate_window_visibility_state
+                    .apply_visibility_update(visible);
+            }
+            Err(error) => {
+                tracing::warn!("Failed to remember candidate window visibility state: {error:?}");
+            }
+        }
+    }
+
+    #[inline]
     fn sync_candidate_window_after_text_update(
         &self,
         ipc_service: &mut IPCService,
@@ -1417,7 +1456,7 @@ impl TextServiceFactory {
         } else {
             None
         };
-        let update_pos = visible == Some(true);
+        let update_pos = *transition != CompositionState::None;
         self.sync_candidate_window_update(
             ipc_service,
             candidates,
@@ -3377,8 +3416,12 @@ impl TextServiceFactory {
         let ipc_service = IMEState::ipc_service().ok().flatten();
 
         if let Some(mut ipc_service) = ipc_service {
-            let _ =
+            let update_result =
                 ipc_service.update_candidate_window(Some(false), None, Some(vec![]), Some(0), None);
+            if update_result.is_ok() {
+                self.remember_candidate_window_visibility(Some(false));
+            }
+            let _ = update_result;
             let _ = ipc_service.clear_text();
 
             let _ = IMEState::set_ipc_service(ipc_service);
@@ -3494,6 +3537,7 @@ impl TextServiceFactory {
                         Some(0),
                         None,
                     )?;
+                    self.remember_candidate_window_visibility(Some(false));
                     ipc_service.clear_text()?;
                 }};
             }
@@ -3544,6 +3588,7 @@ impl TextServiceFactory {
                                 None,
                                 None,
                             )?;
+                            self.remember_candidate_window_visibility(Some(false));
                         }
                     }
                     ClientAction::ShowCandidateWindow => {
@@ -3555,6 +3600,7 @@ impl TextServiceFactory {
                             None,
                             None,
                         )?;
+                        self.remember_candidate_window_visibility(Some(true));
                     }
                     ClientAction::EndComposition => {
                         self.end_composition()?;
@@ -3581,6 +3627,7 @@ impl TextServiceFactory {
                             Some(0),
                             None,
                         )?;
+                        self.remember_candidate_window_visibility(Some(false));
                         ipc_service.clear_text()?;
                     }
                     ClientAction::AppendText(text) => {
@@ -3873,6 +3920,7 @@ impl TextServiceFactory {
                                 Some(0),
                                 None,
                             )?;
+                            self.remember_candidate_window_visibility(Some(false));
                             ipc_service.clear_text()?;
 
                             preview.clear();

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1341,9 +1341,10 @@ impl TextServiceFactory {
         let trace_request_id = current_input_trace_request_id();
         let total_start = trace_request_id.map(|_| Instant::now());
         let result: Result<()> = (|| {
-            let position = if update_pos {
+            let should_update_pos = update_pos && visible != Some(false);
+            let position = if should_update_pos {
                 let position_start = trace_request_id.map(|_| Instant::now());
-                let position = self.candidate_window_position()?;
+                let position = self.candidate_window_position_for_update()?;
                 if let (Some(request_id), Some(position_start)) = (trace_request_id, position_start)
                 {
                     Self::log_client_performance(
@@ -1360,6 +1361,11 @@ impl TextServiceFactory {
                 }
                 position
             } else {
+                if update_pos {
+                    tracing::debug!(
+                        "Skip candidate_window_position while candidate window is hidden"
+                    );
+                }
                 None
             };
             ipc_service.update_candidate_window(
@@ -1411,7 +1417,29 @@ impl TextServiceFactory {
         } else {
             None
         };
-        self.sync_candidate_window_update(ipc_service, candidates, selection_index, visible, true)
+        let update_pos = visible == Some(true);
+        self.sync_candidate_window_update(
+            ipc_service,
+            candidates,
+            selection_index,
+            visible,
+            update_pos,
+        )
+    }
+
+    #[inline]
+    fn actions_need_context_update(actions: &[ClientAction]) -> bool {
+        actions.iter().any(|action| {
+            matches!(
+                action,
+                ClientAction::AppendText(_)
+                    | ClientAction::AppendTextRaw(_)
+                    | ClientAction::AppendTextDirect(_)
+                    | ClientAction::ShrinkText(_)
+                    | ClientAction::ShrinkTextRaw(_)
+                    | ClientAction::ShrinkTextDirect(_)
+            )
+        })
     }
 
     #[inline]
@@ -3428,7 +3456,7 @@ impl TextServiceFactory {
             let mut selection_index = composition.selection_index;
             let mut temporary_latin = composition.temporary_latin;
             let mut temporary_latin_shift_pending = composition.temporary_latin_shift_pending;
-            let mut ipc_service = IMEState::ipc_service()?.context("ipc_service is None")?;
+            let mut ipc_service;
             let mut transition = transition;
             let mut deferred_clause_navigation_ready_ui_sync = None;
 
@@ -3499,7 +3527,10 @@ impl TextServiceFactory {
                 }};
             }
 
-            self.update_context(&preview)?;
+            if Self::actions_need_context_update(actions) {
+                self.update_context(&preview)?;
+            }
+            ipc_service = IMEState::ipc_service()?.context("ipc_service is None")?;
 
             for (action_index, action) in actions.iter().enumerate() {
                 match action {

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1345,7 +1345,11 @@ impl TextServiceFactory {
                 self.should_update_candidate_window_position(update_pos, visible);
             let position = if should_update_pos {
                 let position_start = trace_request_id.map(|_| Instant::now());
-                let position = self.candidate_window_position_for_update()?;
+                let position = if visible == Some(true) {
+                    self.candidate_window_position()?
+                } else {
+                    self.candidate_window_position_for_update()?
+                };
                 if let (Some(request_id), Some(position_start)) = (trace_request_id, position_start)
                 {
                     Self::log_client_performance(

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -25,6 +25,7 @@ const INPUT_STYLE_DIRECT: i32 = 1;
 const CLIENT_LOG_CONFIG_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 static CLIENT_REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+static IPC_CONNECTION_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 static CLIENT_LOG_CONFIG_CACHE: OnceLock<Mutex<ClientLogConfigCache>> = OnceLock::new();
 
 thread_local! {
@@ -40,6 +41,7 @@ struct ClientLogConfigCache {
 // connect to kkc server
 #[derive(Debug, Clone)]
 pub struct IPCService {
+    connection_id: u64,
     // kkc server client
     azookey_client: AzookeyServiceClient<tonic::transport::channel::Channel>,
     // candidate window server client
@@ -170,6 +172,7 @@ impl Drop for ClientInputTraceGuard {
 impl IPCService {
     pub fn new() -> Result<Self> {
         let runtime = Arc::new(tokio::runtime::Runtime::new()?);
+        let connection_id = IPC_CONNECTION_SEQUENCE.fetch_add(1, Ordering::Relaxed);
 
         let server_channel = runtime.block_on(
             Endpoint::try_from("http://[::]:50051")?.connect_with_connector(service_fn(
@@ -225,6 +228,7 @@ impl IPCService {
         tracing::debug!("Connected to server: {:?}", azookey_client);
 
         Ok(Self {
+            connection_id,
             azookey_client,
             window_client,
             runtime,
@@ -266,6 +270,7 @@ impl IPCService {
 
     fn reconnect(&mut self) -> anyhow::Result<()> {
         let refreshed = Self::new()?;
+        self.connection_id = refreshed.connection_id;
         self.azookey_client = refreshed.azookey_client;
         self.window_client = refreshed.window_client;
         self.runtime = refreshed.runtime;
@@ -534,6 +539,10 @@ impl IPCService {
         let response = response.into_inner();
         self.observe_server_session("set_context", response.server_session_id);
         Ok(())
+    }
+
+    pub(crate) fn connection_id(&self) -> u64 {
+        self.connection_id
     }
 
     fn enqueue_client_performance(

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -25,6 +25,12 @@ use shared::proto::WindowPosition;
 
 use super::factory::TextServiceFactory;
 
+#[derive(Clone, Copy)]
+enum CandidateWindowPositionMode {
+    Force,
+    Throttled,
+}
+
 #[implement(ITfEditSession)]
 struct EditSession<'a, T> {
     callback: Rc<dyn Fn(u32) -> anyhow::Result<T>>,
@@ -310,8 +316,10 @@ impl TextServiceFactory {
         Ok(())
     }
 
-    #[tracing::instrument]
-    pub fn candidate_window_position(&self) -> Result<Option<WindowPosition>> {
+    fn candidate_window_position_with_mode(
+        &self,
+        mode: CandidateWindowPositionMode,
+    ) -> Result<Option<WindowPosition>> {
         let trace_request_id = current_input_trace_request_id();
         let total_start = trace_request_id.map(|_| Instant::now());
         {
@@ -333,10 +341,25 @@ impl TextServiceFactory {
                 }
             };
 
-            if !text_service
-                .update_pos_state
-                .try_begin_update(Instant::now())
+            let now = Instant::now();
+            if matches!(mode, CandidateWindowPositionMode::Throttled)
+                && text_service
+                    .candidate_window_position_state
+                    .should_throttle(now)
             {
+                tracing::debug!("Skip throttled candidate_window_position call");
+                if let (Some(request_id), Some(total_start)) = (trace_request_id, total_start) {
+                    Self::log_candidate_window_position_performance(
+                        request_id,
+                        "total",
+                        total_start,
+                        "status=skipped;reason=throttled".to_string(),
+                    );
+                }
+                return Ok(None);
+            }
+
+            if !text_service.update_pos_state.try_begin_update(now) {
                 tracing::debug!("Skip re-entrant candidate_window_position call");
                 if let (Some(request_id), Some(total_start)) = (trace_request_id, total_start) {
                     Self::log_candidate_window_position_performance(
@@ -348,6 +371,9 @@ impl TextServiceFactory {
                 }
                 return Ok(None);
             }
+            text_service
+                .candidate_window_position_state
+                .mark_attempt(now);
         }
 
         let result: Result<Option<WindowPosition>> = (|| {
@@ -423,8 +449,17 @@ impl TextServiceFactory {
     }
 
     #[tracing::instrument]
+    pub fn candidate_window_position(&self) -> Result<Option<WindowPosition>> {
+        self.candidate_window_position_with_mode(CandidateWindowPositionMode::Force)
+    }
+
+    pub(crate) fn candidate_window_position_for_update(&self) -> Result<Option<WindowPosition>> {
+        self.candidate_window_position_with_mode(CandidateWindowPositionMode::Throttled)
+    }
+
+    #[tracing::instrument]
     pub fn update_pos(&self) -> Result<()> {
-        if let Some(position) = self.candidate_window_position()? {
+        if let Some(position) = self.candidate_window_position_for_update()? {
             if let Some(mut ipc_service) = IMEState::ipc_service()? {
                 ipc_service.update_candidate_window(None, Some(position), None, None, None)?;
                 IMEState::set_ipc_service(ipc_service)?;

--- a/crates/client/src/tsf/surrounded_text.rs
+++ b/crates/client/src/tsf/surrounded_text.rs
@@ -126,14 +126,16 @@ impl TextServiceFactory {
         let trace_request_id = current_input_trace_request_id();
         let total_start = trace_request_id.map(|_| Instant::now());
         let result: Result<()> = (|| unsafe {
-            let text_service = self.borrow()?;
-
-            let context = text_service.context::<ITfContext>()?;
-            let parent_context = self.to_parent_context_if_exists(Some(context))?;
+            let (tid, parent_context) = {
+                let text_service = self.borrow()?;
+                let context = text_service.context::<ITfContext>()?;
+                let parent_context = self.to_parent_context_if_exists(Some(context))?;
+                (text_service.tid, parent_context)
+            };
 
             let edit_session_start = trace_request_id.map(|_| Instant::now());
             let preceding_text = edit_session::<String>(
-                text_service.tid,
+                tid,
                 parent_context.clone(),
                 Rc::new({
                     let preview_count = preview.chars().count() as i32;
@@ -218,7 +220,38 @@ impl TextServiceFactory {
                 return Ok(());
             };
 
-            ipc_service.set_context(preceding_text)?;
+            let connection_id = ipc_service.connection_id();
+            let should_set_context = {
+                let text_service = self.borrow_mut()?;
+                text_service
+                    .surrounding_text_context_state
+                    .should_send(connection_id, &preceding_text)
+            };
+            if !should_set_context {
+                if let Some(request_id) = trace_request_id {
+                    Self::log_update_context_performance(
+                        request_id,
+                        "set_context",
+                        Instant::now(),
+                        format!(
+                            "status=skipped;reason=unchanged;preview_len={};context_len={};connection_id={connection_id}",
+                            preview.chars().count(),
+                            preceding_text.chars().count()
+                        ),
+                    );
+                }
+                return Ok(());
+            }
+
+            ipc_service.set_context(preceding_text.clone())?;
+            let connection_id = ipc_service.connection_id();
+            {
+                let mut text_service = self.borrow_mut()?;
+                text_service
+                    .surrounding_text_context_state
+                    .remember(connection_id, &preceding_text);
+            }
+            IMEState::set_ipc_service(ipc_service)?;
 
             Ok(())
         })();

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -83,6 +83,31 @@ impl CandidateWindowPositionState {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CandidateWindowVisibilityState {
+    visible: bool,
+}
+
+impl CandidateWindowVisibilityState {
+    pub fn apply_visibility_update(&mut self, visible: Option<bool>) {
+        if let Some(visible) = visible {
+            self.visible = visible;
+        }
+    }
+
+    pub fn should_update_position(&self, update_pos: bool, visible: Option<bool>) -> bool {
+        if !update_pos {
+            return false;
+        }
+
+        match visible {
+            Some(true) => true,
+            Some(false) => false,
+            None => self.visible,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SurroundingTextContextState {
     connection_id: Option<u64>,
@@ -110,6 +135,7 @@ pub struct TextService {
     pub composition: RefCell<Composition>,
     pub update_pos_state: UpdatePosState,
     pub candidate_window_position_state: CandidateWindowPositionState,
+    pub candidate_window_visibility_state: CandidateWindowVisibilityState,
     pub surrounding_text_context_state: SurroundingTextContextState,
     pub sink_cookies: HashMap<GUID, u32>,
     pub display_attribute_atom: HashMap<GUID, u32>,
@@ -146,7 +172,9 @@ impl TextService {
 
 #[cfg(test)]
 mod tests {
-    use super::{CandidateWindowPositionState, SurroundingTextContextState};
+    use super::{
+        CandidateWindowPositionState, CandidateWindowVisibilityState, SurroundingTextContextState,
+    };
     use std::time::{Duration, Instant};
 
     #[test]
@@ -171,5 +199,21 @@ mod tests {
 
         assert!(state.should_throttle(now + Duration::from_millis(10)));
         assert!(!state.should_throttle(now + Duration::from_millis(60)));
+    }
+
+    #[test]
+    fn candidate_window_visibility_state_keeps_none_updates_dependent_on_known_visibility() {
+        let mut state = CandidateWindowVisibilityState::default();
+
+        assert!(!state.should_update_position(true, None));
+        assert!(state.should_update_position(true, Some(true)));
+        assert!(!state.should_update_position(true, Some(false)));
+        assert!(!state.should_update_position(false, Some(true)));
+
+        state.apply_visibility_update(Some(true));
+        assert!(state.should_update_position(true, None));
+
+        state.apply_visibility_update(Some(false));
+        assert!(!state.should_update_position(true, None));
     }
 }

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -65,6 +65,42 @@ impl UpdatePosState {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CandidateWindowPositionState {
+    last_attempt_at: Option<Instant>,
+}
+
+impl CandidateWindowPositionState {
+    const THROTTLE_INTERVAL: Duration = Duration::from_millis(50);
+
+    pub fn should_throttle(&self, now: Instant) -> bool {
+        self.last_attempt_at
+            .is_some_and(|last| now.duration_since(last) < Self::THROTTLE_INTERVAL)
+    }
+
+    pub fn mark_attempt(&mut self, now: Instant) {
+        self.last_attempt_at = Some(now);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SurroundingTextContextState {
+    connection_id: Option<u64>,
+    context: String,
+}
+
+impl SurroundingTextContextState {
+    pub fn should_send(&self, connection_id: u64, context: &str) -> bool {
+        self.connection_id != Some(connection_id) || self.context != context
+    }
+
+    pub fn remember(&mut self, connection_id: u64, context: &str) {
+        self.connection_id = Some(connection_id);
+        self.context.clear();
+        self.context.push_str(context);
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct TextService {
     pub tid: u32,
@@ -73,6 +109,8 @@ pub struct TextService {
     pub layout_sink_context: Option<ITfContext>,
     pub composition: RefCell<Composition>,
     pub update_pos_state: UpdatePosState,
+    pub candidate_window_position_state: CandidateWindowPositionState,
+    pub surrounding_text_context_state: SurroundingTextContextState,
     pub sink_cookies: HashMap<GUID, u32>,
     pub display_attribute_atom: HashMap<GUID, u32>,
     pub mode: InputMode,
@@ -103,5 +141,35 @@ impl TextService {
 
     pub fn borrow_mut_composition(&self) -> Result<RefMut<Composition>> {
         Ok(self.composition.try_borrow_mut()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CandidateWindowPositionState, SurroundingTextContextState};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn surrounding_text_context_state_resends_after_connection_change() {
+        let mut state = SurroundingTextContextState::default();
+
+        assert!(state.should_send(1, "context"));
+        state.remember(1, "context");
+
+        assert!(!state.should_send(1, "context"));
+        assert!(state.should_send(2, "context"));
+        assert!(state.should_send(1, "changed"));
+    }
+
+    #[test]
+    fn candidate_window_position_state_throttles_recent_attempts() {
+        let mut state = CandidateWindowPositionState::default();
+        let now = Instant::now();
+
+        assert!(!state.should_throttle(now));
+        state.mark_attempt(now);
+
+        assert!(state.should_throttle(now + Duration::from_millis(10)));
+        assert!(!state.should_throttle(now + Duration::from_millis(60)));
     }
 }

--- a/crates/client/src/tsf/thread_mgr_event_sink.rs
+++ b/crates/client/src/tsf/thread_mgr_event_sink.rs
@@ -17,8 +17,12 @@ impl TextServiceFactory {
         let (changed, ipc_service) = IMEState::set_keyboard_disabled_and_clone_ipc(disabled)?;
 
         if let Some(mut ipc_service) = ipc_service {
-            let _ =
+            let update_result =
                 ipc_service.update_candidate_window(Some(false), None, Some(vec![]), Some(0), None);
+            if update_result.is_ok() {
+                self.remember_candidate_window_visibility(Some(false));
+            }
+            let _ = update_result;
 
             IMEState::set_ipc_service(ipc_service)?;
         }


### PR DESCRIPTION
## Summary
- `update_context` を append / shrink 系 action のときだけ実行するようにし、通常 hot path の周辺文脈取得を減らしました。
- 直前と同じ surrounding text は IPC connection ごとに `SetContext` を省略し、reconnect 後は再送されるようにしました。
- 候補ウィンドウが非表示のときは位置取得を省略し、layout / candidate update 由来の `candidate_window_position` は短時間 throttle するようにしました。
- `candidate_window_position` の失敗は警告と performance log に留め、入力処理全体を止めない挙動を維持しました。

Closes #89

## Background
- Related: #81
- 通常入力の `handle_action` では、action 処理前に毎回 `update_context(&preview)` が呼ばれていました。
- 候補更新時には `candidate_window_position()` が TSF edit session を作って `GetTextExt` を呼ぶため、入力先アプリや TSF host の状態によって入力の引っかかりにつながる可能性がありました。
- #90 で IPC reconnect recovery が入ったため、`SetContext` 省略状態は IPC connection の変化を考慮して管理します。

## Changes
- update_context gating
  - append / shrink 系 action が含まれるときだけ `update_context` を実行
  - selection / clause move / candidate window show / IME mode change など、surrounding text を更新しない action では文脈取得を省略
  - `update_context` 後に `IPCService` を取り直し、`SetContext` 中の reconnect が後続 action に反映されるように補強
- SetContext dedupe
  - `TextService` に `SurroundingTextContextState` を追加
  - IPC `connection_id` と context 文字列が前回送信済みなら `SetContext` を省略
  - reconnect で connection が変わった場合は同じ context でも再送
- candidate window position throttling
  - candidate window が hidden 指定のときは位置取得を skip
  - layout / candidate update 由来の位置取得は 50ms throttle
  - explicit show / IME mode update などの force path は従来通り位置取得を試行
- performance logging
  - `update_context` / `candidate_window_position` / `sync_candidate_window_update` の skip / error / elapsed を request id 付きで記録
  - unchanged context や throttle による skip 理由を log detail に含める
- tests
  - surrounding text context dedupe が connection change で再送になる unit test を追加
  - candidate window position throttle state の unit test を追加

## Verification
- [x] Codex review
  - `SetContext` 中の IPC reconnect が clone のまま捨てられるケースを補強済み
- [x] format / 差分チェック
  - `cargo fmt --check`
  - `git diff --check`
- [x] ローカル Windows VM targeted text_service tests
  - `.local/vm_test_client_composition.sh feature/89-update-context-throttle text_service skip`
  - result: 2 tests passed
  - log: `.local/logs/vm-client-test-20260612-235818.log`
- [x] ローカル Windows VM composition test
  - `.local/vm_test_client_composition.sh feature/89-update-context-throttle composition skip`
  - result: 104 tests passed
  - log: `.local/logs/vm-client-test-20260613-001928.log`
- [x] GitHub Actions build
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/27425407409
- [x] ローカル Windows VM build / install smoke
  - artifact: `.local/artifacts/azookey-setup-feature_89-update-context-throttle-20260613-004238.exe`
  - install log: `.local/logs/win11-install-20260613-013141.log`
  - installer exit code: 0
- [x] ローカル Windows VM input smoke
  - Notepad で azooKey を active にして `aiueo` -> `あいうえお` の通常入力を確認
  - 候補ウィンドウ表示時も入力位置付近に候補 UI が表示されることを確認
  - `azookey-server` / `launcher` / `ui` process が入力後も起動していることを確認