### PR TITLE
fix(client): align CapsLock eisu shortcut with keyboard layout

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v4

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -23,17 +23,24 @@ use super::{
 #[cfg(test)]
 use shared::RomajiRule;
 use shared::{zenzai_cpu_backend_supported, AppConfig, NumpadInputMode, SpaceInputMode};
+use windows::core::{w, PCWSTR};
 use windows::Win32::{
     Foundation::{LPARAM, WPARAM},
+    System::Registry::{RegGetValueW, HKEY, HKEY_LOCAL_MACHINE, RRF_RT_REG_SZ},
     UI::{
         Input::KeyboardAndMouse::{
-            VK_CONTROL, VK_LCONTROL, VK_LMENU, VK_MENU, VK_RCONTROL, VK_RMENU, VK_SHIFT,
+            GetAsyncKeyState, VK_CONTROL, VK_LCONTROL, VK_LMENU, VK_LSHIFT, VK_MENU, VK_RCONTROL,
+            VK_RMENU, VK_RSHIFT, VK_SHIFT,
         },
         TextServices::{ITfComposition, ITfCompositionSink_Impl, ITfContext},
     },
 };
 
 use anyhow::{Context, Result};
+
+const VK_CAPITAL_KEY_CODE: usize = 0x14;
+const VK_TRANSLATED_CAPSLOCK_KEY_CODE: usize = 0xF0;
+const CAPSLOCK_SCAN_CODE: isize = 0x3A;
 
 mod clause_state;
 pub(super) use clause_state::{
@@ -102,6 +109,12 @@ pub struct Composition {
     pub temporary_latin: bool,
     pub temporary_latin_shift_pending: bool,
     pub tip_composition: Option<ITfComposition>,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum CapsLockKeyboardLayout {
+    Japanese,
+    English,
 }
 
 #[derive(Clone, Debug)]
@@ -190,28 +203,164 @@ impl TextServiceFactory {
     }
 
     #[inline]
-    fn is_ctrl_pressed() -> bool {
+    pub(crate) fn is_ctrl_pressed() -> bool {
         VK_CONTROL.is_pressed() || VK_LCONTROL.is_pressed() || VK_RCONTROL.is_pressed()
     }
 
     #[inline]
-    fn is_alt_pressed() -> bool {
+    pub(crate) fn is_alt_pressed() -> bool {
         VK_MENU.is_pressed() || VK_LMENU.is_pressed() || VK_RMENU.is_pressed()
     }
 
     #[inline]
-    fn is_shift_pressed() -> bool {
+    pub(crate) fn is_shift_pressed() -> bool {
         VK_SHIFT.is_pressed()
+            || VK_LSHIFT.is_pressed()
+            || VK_RSHIFT.is_pressed()
+            || unsafe {
+                [VK_SHIFT, VK_LSHIFT, VK_RSHIFT]
+                    .iter()
+                    .any(|key| GetAsyncKeyState(key.0 as i32) as u16 & 0x8000 != 0)
+            }
     }
 
     #[inline]
-    fn is_shift_key(wparam: WPARAM) -> bool {
+    pub(crate) fn is_shift_key(wparam: WPARAM) -> bool {
         matches!(wparam.0, 0x10 | 0xA0 | 0xA1)
     }
 
     #[inline]
     fn is_shift_alphabet_shortcut(wparam: WPARAM, is_shift_pressed: bool) -> bool {
         is_shift_pressed && (0x41..=0x5A).contains(&wparam.0)
+    }
+
+    #[inline]
+    fn is_eisu_shortcut(
+        key_code: usize,
+        lparam: LPARAM,
+        is_shift_pressed: bool,
+        is_ctrl_pressed: bool,
+        is_alt_pressed: bool,
+        keyboard_layout: CapsLockKeyboardLayout,
+    ) -> bool {
+        if is_ctrl_pressed || is_alt_pressed {
+            return false;
+        }
+
+        match keyboard_layout {
+            CapsLockKeyboardLayout::Japanese => {
+                !is_shift_pressed
+                    && (key_code == VK_CAPITAL_KEY_CODE
+                        || Self::is_translated_capslock_key(key_code, lparam))
+            }
+            CapsLockKeyboardLayout::English => {
+                is_shift_pressed
+                    && (key_code == VK_CAPITAL_KEY_CODE
+                        || Self::is_translated_capslock_key(key_code, lparam))
+            }
+        }
+    }
+
+    #[inline]
+    fn is_translated_capslock_key(key_code: usize, lparam: LPARAM) -> bool {
+        key_code == VK_TRANSLATED_CAPSLOCK_KEY_CODE
+            && ((lparam.0 >> 16) & 0xff) == CAPSLOCK_SCAN_CODE
+    }
+
+    #[inline]
+    fn caps_lock_keyboard_layout_from_hardware_registry(
+        layer_driver: Option<&str>,
+        keyboard_identifier: Option<&str>,
+    ) -> CapsLockKeyboardLayout {
+        if let Some(layer_driver) = layer_driver.map(str::trim) {
+            if layer_driver.eq_ignore_ascii_case("kbd101.dll") {
+                return CapsLockKeyboardLayout::English;
+            }
+
+            if layer_driver.eq_ignore_ascii_case("kbd106.dll") {
+                return CapsLockKeyboardLayout::Japanese;
+            }
+        }
+
+        if let Some(keyboard_identifier) = keyboard_identifier.map(str::trim) {
+            if keyboard_identifier.contains("101") {
+                return CapsLockKeyboardLayout::English;
+            }
+
+            if keyboard_identifier.contains("106") {
+                return CapsLockKeyboardLayout::Japanese;
+            }
+        }
+
+        CapsLockKeyboardLayout::Japanese
+    }
+
+    fn registry_string_value(root: HKEY, sub_key: PCWSTR, value: PCWSTR) -> Option<String> {
+        let mut byte_len = 0u32;
+        let result = unsafe {
+            RegGetValueW(
+                root,
+                sub_key,
+                value,
+                RRF_RT_REG_SZ,
+                None,
+                None,
+                Some(&mut byte_len),
+            )
+        };
+        if !result.is_ok() || byte_len == 0 {
+            return None;
+        }
+
+        let mut buffer = vec![0u16; (byte_len as usize + 1) / 2];
+        let result = unsafe {
+            RegGetValueW(
+                root,
+                sub_key,
+                value,
+                RRF_RT_REG_SZ,
+                None,
+                Some(buffer.as_mut_ptr().cast()),
+                Some(&mut byte_len),
+            )
+        };
+        if !result.is_ok() {
+            return None;
+        }
+
+        let end = buffer
+            .iter()
+            .position(|ch| *ch == 0)
+            .unwrap_or(buffer.len());
+        Some(String::from_utf16_lossy(&buffer[..end]))
+    }
+
+    fn current_caps_lock_keyboard_layout() -> CapsLockKeyboardLayout {
+        let layer_driver = Self::registry_string_value(
+            HKEY_LOCAL_MACHINE,
+            w!("SYSTEM\\CurrentControlSet\\Services\\i8042prt\\Parameters"),
+            w!("LayerDriver JPN"),
+        );
+        let keyboard_identifier = Self::registry_string_value(
+            HKEY_LOCAL_MACHINE,
+            w!("SYSTEM\\CurrentControlSet\\Services\\i8042prt\\Parameters"),
+            w!("OverrideKeyboardIdentifier"),
+        );
+
+        Self::caps_lock_keyboard_layout_from_hardware_registry(
+            layer_driver.as_deref(),
+            keyboard_identifier.as_deref(),
+        )
+    }
+
+    #[inline]
+    fn input_text_for_mode(input_char: char, mode: &InputMode) -> String {
+        match mode {
+            InputMode::Kana if input_char.is_ascii_uppercase() => {
+                input_char.to_ascii_lowercase().to_string()
+            }
+            _ => input_char.to_string(),
+        }
     }
 
     #[inline]
@@ -2701,7 +2850,7 @@ impl TextServiceFactory {
                     CompositionState::Composing,
                     vec![
                         ClientAction::StartComposition,
-                        ClientAction::AppendText(char.to_string()),
+                        ClientAction::AppendText(Self::input_text_for_mode(*char, mode)),
                     ],
                 )),
                 UserAction::Number {
@@ -2810,7 +2959,9 @@ impl TextServiceFactory {
                 }
                 UserAction::Input(char) => Some((
                     CompositionState::Composing,
-                    vec![ClientAction::AppendText(char.to_string())],
+                    vec![ClientAction::AppendText(Self::input_text_for_mode(
+                        *char, mode,
+                    ))],
                 )),
                 UserAction::Number {
                     value,
@@ -2947,7 +3098,9 @@ impl TextServiceFactory {
                 }
                 UserAction::Input(char) => Some((
                     CompositionState::Composing,
-                    vec![ClientAction::ShrinkText(char.to_string())],
+                    vec![ClientAction::ShrinkText(Self::input_text_for_mode(
+                        *char, mode,
+                    ))],
                 )),
                 UserAction::Number {
                     value,
@@ -3078,8 +3231,23 @@ impl TextServiceFactory {
 
             let is_ctrl_pressed = Self::is_ctrl_pressed();
             let is_alt_pressed = Self::is_alt_pressed();
-            let is_shift_pressed = Self::is_shift_pressed();
+            let is_shift_pressed = {
+                let tracked_shift = self
+                    .borrow()
+                    .map(|text_service| text_service.shift_key_down)
+                    .unwrap_or(false);
+                tracked_shift || Self::is_shift_pressed()
+            };
             let is_ctrl_space = is_ctrl_pressed && wparam.0 == 0x20;
+            let keyboard_layout = Self::current_caps_lock_keyboard_layout();
+            let is_eisu = Self::is_eisu_shortcut(
+                wparam.0,
+                lparam,
+                is_shift_pressed,
+                is_ctrl_pressed,
+                is_alt_pressed,
+                keyboard_layout,
+            );
             let is_ctrl_enter = is_ctrl_pressed && wparam.0 == 0x0D;
             let is_ctrl_down = is_ctrl_pressed && wparam.0 == 0x28;
             let ctrl_conversion_function =
@@ -3122,7 +3290,7 @@ impl TextServiceFactory {
                 return Ok(None);
             }
 
-            if is_ctrl_space || is_alt_backquote {
+            if is_ctrl_space || is_alt_backquote || is_eisu {
                 let shortcuts = &app_config.shortcuts;
 
                 if is_ctrl_space && !shortcuts.ctrl_space_toggle {
@@ -3133,6 +3301,13 @@ impl TextServiceFactory {
                 }
 
                 if is_alt_backquote && !shortcuts.alt_backquote_toggle {
+                    self.clear_temporary_latin_shift_pending_if_needed(!Self::is_shift_key(
+                        wparam,
+                    ))?;
+                    return Ok(None);
+                }
+
+                if is_eisu && !shortcuts.eisu_toggle {
                     self.clear_temporary_latin_shift_pending_if_needed(!Self::is_shift_key(
                         wparam,
                     ))?;
@@ -3162,7 +3337,7 @@ impl TextServiceFactory {
             let should_clear_shift_pending =
                 composition.temporary_latin_shift_pending && !is_shift_key;
 
-            let action = if is_alt_backquote {
+            let action = if is_alt_backquote || is_eisu {
                 UserAction::ToggleInputMode
             } else if is_ctrl_enter {
                 UserAction::CommitFirstClause
@@ -3398,6 +3573,92 @@ impl TextServiceFactory {
             Ok(handled) => Ok(handled),
             Err(error) => {
                 tracing::error!("handle_key_up failed: {error:?}");
+                self.recover_after_key_error();
+                Ok(false)
+            }
+        }
+    }
+
+    #[tracing::instrument]
+    pub fn handle_preserved_eisu_shortcut(&self, context: Option<&ITfContext>) -> Result<bool> {
+        let result: Result<bool> = (|| {
+            let Some(context) = context else {
+                self.set_keyboard_disabled_state(true)?;
+                return Ok(false);
+            };
+
+            self.borrow_mut()?.context = Some(context.clone());
+
+            let keyboard_disabled = keyboard_disabled_from_context(context);
+            self.set_keyboard_disabled_state(keyboard_disabled)?;
+            if keyboard_disabled {
+                self.cancel_composition_for_disabled_context();
+                return Ok(false);
+            }
+
+            let is_shift_pressed = {
+                let tracked_shift = self
+                    .borrow()
+                    .map(|text_service| text_service.shift_key_down)
+                    .unwrap_or(false);
+                tracked_shift || Self::is_shift_pressed()
+            };
+            let is_ctrl_pressed = Self::is_ctrl_pressed();
+            let is_alt_pressed = Self::is_alt_pressed();
+            let keyboard_layout = Self::current_caps_lock_keyboard_layout();
+            if !Self::is_eisu_shortcut(
+                VK_CAPITAL_KEY_CODE,
+                LPARAM(0),
+                is_shift_pressed,
+                is_ctrl_pressed,
+                is_alt_pressed,
+                keyboard_layout,
+            ) {
+                return Ok(false);
+            }
+
+            let config_snapshot = IMEState::app_config_snapshot()?;
+            let app_config = config_snapshot.app_config();
+            if !app_config.shortcuts.eisu_toggle {
+                return Ok(false);
+            }
+
+            #[allow(clippy::let_and_return)]
+            let (composition, mode) = {
+                let text_service = self.borrow()?;
+                let composition = text_service.borrow_composition()?.clone();
+                let mode = IMEState::input_mode()?;
+                (composition, mode)
+            };
+
+            let Some((transition, mut actions)) = Self::plan_actions_for_user_action_with_lookup(
+                &composition,
+                &UserAction::ToggleInputMode,
+                &mode,
+                is_shift_pressed,
+                app_config,
+                config_snapshot.romaji_lookup(),
+                false,
+            ) else {
+                return Ok(false);
+            };
+
+            if composition.temporary_latin
+                && !actions
+                    .iter()
+                    .any(|action| matches!(action, ClientAction::SetTemporaryLatin(false)))
+            {
+                actions.insert(0, ClientAction::SetTemporaryLatin(false));
+            }
+
+            self.handle_action_with_config_snapshot(&actions, transition, config_snapshot)?;
+            Ok(true)
+        })();
+
+        match result {
+            Ok(handled) => Ok(handled),
+            Err(error) => {
+                tracing::error!("handle_preserved_eisu_shortcut failed: {error:?}");
                 self.recover_after_key_error();
                 Ok(false)
             }

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -3239,15 +3239,21 @@ impl TextServiceFactory {
                 tracked_shift || Self::is_shift_pressed()
             };
             let is_ctrl_space = is_ctrl_pressed && wparam.0 == 0x20;
-            let keyboard_layout = Self::current_caps_lock_keyboard_layout();
-            let is_eisu = Self::is_eisu_shortcut(
-                wparam.0,
-                lparam,
-                is_shift_pressed,
-                is_ctrl_pressed,
-                is_alt_pressed,
-                keyboard_layout,
-            );
+            let is_capslock_key = wparam.0 == VK_CAPITAL_KEY_CODE
+                || Self::is_translated_capslock_key(wparam.0, lparam);
+            let is_eisu = if is_capslock_key {
+                let keyboard_layout = Self::current_caps_lock_keyboard_layout();
+                Self::is_eisu_shortcut(
+                    wparam.0,
+                    lparam,
+                    is_shift_pressed,
+                    is_ctrl_pressed,
+                    is_alt_pressed,
+                    keyboard_layout,
+                )
+            } else {
+                false
+            };
             let is_ctrl_enter = is_ctrl_pressed && wparam.0 == 0x0D;
             let is_ctrl_down = is_ctrl_pressed && wparam.0 == 0x28;
             let ctrl_conversion_function =

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    Candidates, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut,
-    ClauseNavigationReadyUiSync, ClauseSnapshot, ClauseState, Composition, CompositionReducer,
-    CompositionState, FutureClauseSnapshot, TextServiceFactory,
+    Candidates, CapsLockKeyboardLayout, ClauseActionBackend, ClauseActionEffect,
+    ClauseActionStateMut, ClauseNavigationReadyUiSync, ClauseSnapshot, ClauseState, Composition,
+    CompositionReducer, CompositionState, FutureClauseSnapshot, TextServiceFactory,
 };
 use crate::engine::{
     client_action::{ClientAction, SetSelectionType, SetTextType},
@@ -9,6 +9,7 @@ use crate::engine::{
     user_action::{Function, Navigation, UserAction},
 };
 use shared::{get_default_romaji_rows, AppConfig, PunctuationStyle, RomajiRule, WidthMode};
+use windows::Win32::Foundation::LPARAM;
 
 pub(super) fn row(input: &str, output: &str, next_input: &str) -> RomajiRule {
     RomajiRule {
@@ -231,6 +232,151 @@ fn ctrl_conversion_shortcuts_do_not_capture_non_ctrl_or_alt_modified_keys() {
     assert_eq!(
         TextServiceFactory::ctrl_conversion_shortcut_function(0x41, true, false),
         None
+    );
+}
+
+#[test]
+fn eisu_shortcut_matches_ms_ime_capslock_rules_by_keyboard_layout() {
+    assert!(TextServiceFactory::is_eisu_shortcut(
+        0x14,
+        LPARAM(0),
+        false,
+        false,
+        false,
+        CapsLockKeyboardLayout::Japanese
+    ));
+    assert!(TextServiceFactory::is_eisu_shortcut(
+        0xF0,
+        LPARAM(0x003A0000),
+        false,
+        false,
+        false,
+        CapsLockKeyboardLayout::Japanese
+    ));
+    assert!(!TextServiceFactory::is_eisu_shortcut(
+        0xF0,
+        LPARAM(0x003A0000),
+        true,
+        false,
+        false,
+        CapsLockKeyboardLayout::Japanese
+    ));
+    assert!(!TextServiceFactory::is_eisu_shortcut(
+        0x14,
+        LPARAM(0),
+        true,
+        false,
+        false,
+        CapsLockKeyboardLayout::Japanese
+    ));
+    assert!(!TextServiceFactory::is_eisu_shortcut(
+        0x14,
+        LPARAM(0),
+        false,
+        false,
+        false,
+        CapsLockKeyboardLayout::English
+    ));
+    assert!(TextServiceFactory::is_eisu_shortcut(
+        0x14,
+        LPARAM(0),
+        true,
+        false,
+        false,
+        CapsLockKeyboardLayout::English
+    ));
+    assert!(TextServiceFactory::is_eisu_shortcut(
+        0xF0,
+        LPARAM(0x003A0000),
+        true,
+        false,
+        false,
+        CapsLockKeyboardLayout::English
+    ));
+    assert!(!TextServiceFactory::is_eisu_shortcut(
+        0xF0,
+        LPARAM(0x002A0000),
+        true,
+        false,
+        false,
+        CapsLockKeyboardLayout::English
+    ));
+    assert!(!TextServiceFactory::is_eisu_shortcut(
+        0xF0,
+        LPARAM(0x003A0000),
+        false,
+        false,
+        false,
+        CapsLockKeyboardLayout::English
+    ));
+    assert!(!TextServiceFactory::is_eisu_shortcut(
+        0x14,
+        LPARAM(0),
+        false,
+        true,
+        false,
+        CapsLockKeyboardLayout::Japanese
+    ));
+    assert!(!TextServiceFactory::is_eisu_shortcut(
+        0x14,
+        LPARAM(0),
+        false,
+        false,
+        true,
+        CapsLockKeyboardLayout::Japanese
+    ));
+    assert!(!TextServiceFactory::is_eisu_shortcut(
+        0x41,
+        LPARAM(0),
+        false,
+        false,
+        false,
+        CapsLockKeyboardLayout::Japanese
+    ));
+}
+
+#[test]
+fn keyboard_layout_hardware_registry_maps_japanese_default_and_english_override() {
+    assert_eq!(
+        TextServiceFactory::caps_lock_keyboard_layout_from_hardware_registry(None, None),
+        CapsLockKeyboardLayout::Japanese
+    );
+    assert_eq!(
+        TextServiceFactory::caps_lock_keyboard_layout_from_hardware_registry(
+            Some("kbd106.dll"),
+            Some("PCAT_106KEY")
+        ),
+        CapsLockKeyboardLayout::Japanese
+    );
+    assert_eq!(
+        TextServiceFactory::caps_lock_keyboard_layout_from_hardware_registry(
+            Some("kbd101.dll"),
+            Some("PCAT_101KEY")
+        ),
+        CapsLockKeyboardLayout::English
+    );
+    assert_eq!(
+        TextServiceFactory::caps_lock_keyboard_layout_from_hardware_registry(
+            None,
+            Some("PCAT_101KEY")
+        ),
+        CapsLockKeyboardLayout::English
+    );
+}
+
+#[test]
+fn kana_input_lowercases_ascii_uppercase_from_capslock() {
+    assert_eq!(
+        TextServiceFactory::input_text_for_mode('A', &InputMode::Kana),
+        "a"
+    );
+    assert_eq!(
+        TextServiceFactory::input_text_for_mode('A', &InputMode::Latin),
+        "A"
+    );
+    assert_eq!(
+        TextServiceFactory::input_text_for_mode('Ａ', &InputMode::Kana),
+        "Ａ"
     );
 }
 

--- a/crates/client/src/globals.rs
+++ b/crates/client/src/globals.rs
@@ -31,6 +31,10 @@ pub const GUID_PROFILE: GUID = GUID::from_u128(0xffdefe7a_2fc2_11ef_b16b_94e70b2
 // DisplayAttribute用のGUID
 pub const GUID_DISPLAY_ATTRIBUTE: GUID = GUID::from_u128(0xffdefe7b_2fc2_11ef_b16b_94e70b2c378c);
 
+// Preserved key for CapsLock input mode toggle.
+pub const GUID_PRESERVED_KEY_EISU_CAPSLOCK_ANY_MODIFIER: GUID =
+    GUID::from_u128(0xffdefe7c_2fc2_11ef_b16b_94e70b2c378c);
+
 pub const DISPLAY_ATTRIBUTE: TF_DISPLAYATTRIBUTE = TF_DISPLAYATTRIBUTE {
     crText: TF_DA_COLOR {
         r#type: TF_CT_NONE,

--- a/crates/client/src/tsf/key_event_sink.rs
+++ b/crates/client/src/tsf/key_event_sink.rs
@@ -79,6 +79,7 @@ impl ITfKeyEventSink_Impl for TextServiceFactory_Impl {
     #[macros::anyhow]
     fn OnSetFocus(&self, fforeground: BOOL) -> Result<()> {
         if !fforeground.as_bool() {
+            self.clear_tracked_modifier_key_state();
             self.set_keyboard_disabled_state(true)?;
         }
 
@@ -94,6 +95,12 @@ impl TextServiceFactory_Impl {
 
         if let Ok(mut text_service) = self.borrow_mut() {
             text_service.shift_key_down = is_down;
+        }
+    }
+
+    fn clear_tracked_modifier_key_state(&self) {
+        if let Ok(mut text_service) = self.borrow_mut() {
+            text_service.shift_key_down = false;
         }
     }
 }

--- a/crates/client/src/tsf/key_event_sink.rs
+++ b/crates/client/src/tsf/key_event_sink.rs
@@ -1,3 +1,5 @@
+use crate::globals::GUID_PRESERVED_KEY_EISU_CAPSLOCK_ANY_MODIFIER;
+
 use windows::{
     core::GUID,
     Win32::{
@@ -8,7 +10,7 @@ use windows::{
 
 use anyhow::Result;
 
-use super::factory::TextServiceFactory_Impl;
+use super::factory::{TextServiceFactory, TextServiceFactory_Impl};
 
 // sink (aka event listener) for key events
 impl ITfKeyEventSink_Impl for TextServiceFactory_Impl {
@@ -20,6 +22,8 @@ impl ITfKeyEventSink_Impl for TextServiceFactory_Impl {
         wparam: WPARAM,
         lparam: LPARAM,
     ) -> Result<BOOL> {
+        self.update_shift_key_state(wparam, true);
+
         // this function checks if the key event will be handled by "OnKeyUp" function
         // so we need to return TRUE if we want to handle the key event
         let result = self.process_key(pic, wparam, lparam)?.is_some();
@@ -30,6 +34,8 @@ impl ITfKeyEventSink_Impl for TextServiceFactory_Impl {
     #[macros::anyhow]
     #[tracing::instrument]
     fn OnKeyDown(&self, pic: Option<&ITfContext>, wparam: WPARAM, lparam: LPARAM) -> Result<BOOL> {
+        self.update_shift_key_state(wparam, true);
+
         // this function is called when a key is pressed
         // we can handle key events here
         let result = self.handle_key(pic, wparam, lparam)?;
@@ -45,19 +51,29 @@ impl ITfKeyEventSink_Impl for TextServiceFactory_Impl {
         lparam: LPARAM,
     ) -> Result<BOOL> {
         let result = self.process_key_up(pic, wparam, lparam)?.is_some();
+        self.update_shift_key_state(wparam, false);
         Ok(result.into())
     }
 
     #[macros::anyhow]
     fn OnKeyUp(&self, pic: Option<&ITfContext>, wparam: WPARAM, lparam: LPARAM) -> Result<BOOL> {
         let result = self.handle_key_up(pic, wparam, lparam)?;
+        self.update_shift_key_state(wparam, false);
         Ok(result.into())
     }
 
     #[macros::anyhow]
-    fn OnPreservedKey(&self, _pic: Option<&ITfContext>, _rguid: *const GUID) -> Result<BOOL> {
-        // this function is actually not used
-        Ok(true.into())
+    fn OnPreservedKey(&self, pic: Option<&ITfContext>, rguid: *const GUID) -> Result<BOOL> {
+        let Some(rguid) = (unsafe { rguid.as_ref() }) else {
+            return Ok(false.into());
+        };
+
+        if *rguid != GUID_PRESERVED_KEY_EISU_CAPSLOCK_ANY_MODIFIER {
+            return Ok(false.into());
+        }
+
+        let handled = self.handle_preserved_eisu_shortcut(pic)?;
+        Ok(handled.into())
     }
 
     #[macros::anyhow]
@@ -67,5 +83,17 @@ impl ITfKeyEventSink_Impl for TextServiceFactory_Impl {
         }
 
         Ok(())
+    }
+}
+
+impl TextServiceFactory_Impl {
+    fn update_shift_key_state(&self, wparam: WPARAM, is_down: bool) {
+        if !TextServiceFactory::is_shift_key(wparam) {
+            return;
+        }
+
+        if let Ok(mut text_service) = self.borrow_mut() {
+            text_service.shift_key_down = is_down;
+        }
     }
 }

--- a/crates/client/src/tsf/text_input_proccesor.rs
+++ b/crates/client/src/tsf/text_input_proccesor.rs
@@ -181,6 +181,7 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
         // clear display attribute
         text_service.display_attribute_atom.clear();
 
+        text_service.shift_key_down = false;
         text_service.tid = 0;
         text_service.thread_mgr = None;
 

--- a/crates/client/src/tsf/text_input_proccesor.rs
+++ b/crates/client/src/tsf/text_input_proccesor.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
     engine::{ipc_service, state::IMEState},
-    globals::{DllModule, GUID_DISPLAY_ATTRIBUTE},
+    globals::{DllModule, GUID_DISPLAY_ATTRIBUTE, GUID_PRESERVED_KEY_EISU_CAPSLOCK_ANY_MODIFIER},
 };
 
 use super::factory::TextServiceFactory_Impl;
@@ -15,6 +15,7 @@ use windows::{
             CLSID_TF_CategoryMgr, ITfCategoryMgr, ITfKeyEventSink, ITfKeystrokeMgr,
             ITfLangBarItemButton, ITfLangBarItemMgr, ITfSource, ITfTextInputProcessorEx_Impl,
             ITfTextInputProcessor_Impl, ITfThreadFocusSink, ITfThreadMgr, ITfThreadMgrEventSink,
+            TF_MOD_IGNORE_ALL_MODIFIER, TF_PRESERVEDKEY,
         },
     },
 };
@@ -51,13 +52,15 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
         // initialize key event sink
         tracing::debug!("AdviseKeyEventSink");
 
+        let keystroke_mgr = thread_mgr.cast::<ITfKeystrokeMgr>()?;
         unsafe {
-            thread_mgr.cast::<ITfKeystrokeMgr>()?.AdviseKeyEventSink(
+            keystroke_mgr.AdviseKeyEventSink(
                 tid,
                 &text_service.this::<ITfKeyEventSink>()?,
                 BOOL::from(true),
             )?;
         };
+        preserve_eisu_keys(&keystroke_mgr, tid);
 
         // initialize thread manager event sink
         tracing::debug!("AdviseThreadMgrEventSink");
@@ -136,10 +139,10 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
 
             // remove key event sink
             tracing::debug!("UnadviseKeyEventSink");
+            let keystroke_mgr = thread_mgr.cast::<ITfKeystrokeMgr>()?;
+            unpreserve_eisu_keys(&keystroke_mgr);
             unsafe {
-                thread_mgr
-                    .cast::<ITfKeystrokeMgr>()?
-                    .UnadviseKeyEventSink(text_service.tid)?;
+                keystroke_mgr.UnadviseKeyEventSink(text_service.tid)?;
             };
 
             tracing::debug!("Remove langbar");
@@ -184,6 +187,39 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
         tracing::debug!("Deactivate success");
 
         Ok(())
+    }
+}
+
+fn eisu_capslock_preserved_keys() -> [(windows::core::GUID, TF_PRESERVEDKEY); 1] {
+    [(
+        GUID_PRESERVED_KEY_EISU_CAPSLOCK_ANY_MODIFIER,
+        TF_PRESERVEDKEY {
+            uVKey: 0x14,
+            uModifiers: TF_MOD_IGNORE_ALL_MODIFIER,
+        },
+    )]
+}
+
+fn preserve_eisu_keys(keystroke_mgr: &ITfKeystrokeMgr, tid: u32) {
+    let description = "azooKey input mode toggle"
+        .encode_utf16()
+        .collect::<Vec<_>>();
+    for (guid, preserved_key) in eisu_capslock_preserved_keys() {
+        let result = unsafe { keystroke_mgr.PreserveKey(tid, &guid, &preserved_key, &description) };
+
+        if let Err(error) = result {
+            tracing::warn!(?error, ?guid, "Failed to preserve CapsLock eisu shortcut");
+        }
+    }
+}
+
+fn unpreserve_eisu_keys(keystroke_mgr: &ITfKeystrokeMgr) {
+    for (guid, preserved_key) in eisu_capslock_preserved_keys() {
+        let result = unsafe { keystroke_mgr.UnpreserveKey(&guid, &preserved_key) };
+
+        if let Err(error) = result {
+            tracing::debug!(?error, ?guid, "Failed to unpreserve CapsLock eisu shortcut");
+        }
     }
 }
 

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -141,6 +141,7 @@ pub struct TextService {
     pub display_attribute_atom: HashMap<GUID, u32>,
     pub mode: InputMode,
     pub this: Option<ITfTextInputProcessor>,
+    pub shift_key_down: bool,
 }
 
 impl TextService {

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -436,8 +436,8 @@ pub fn zenzai_cpu_backend_supported() -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppConfig, ConfigError, DebugConfig, GeneralConfig, NumpadInputMode, CONFIG_VERSION,
-        SETTINGS_FILENAME,
+        AppConfig, ConfigError, DebugConfig, GeneralConfig, NumpadInputMode, ShortcutConfig,
+        CONFIG_VERSION, SETTINGS_FILENAME,
     };
     use std::{
         env,
@@ -529,6 +529,19 @@ mod tests {
         assert!(!deserialized.server_log_enabled);
         assert_eq!(deserialized.server_log_level, "warn");
         assert!(deserialized.server_crash_trace_enabled);
+    }
+
+    #[test]
+    fn shortcut_toggles_default_to_on() {
+        let default_config = ShortcutConfig::default();
+        assert!(default_config.ctrl_space_toggle);
+        assert!(default_config.alt_backquote_toggle);
+        assert!(default_config.eisu_toggle);
+
+        let deserialized: ShortcutConfig = serde_json::from_str("{}").unwrap();
+        assert!(deserialized.ctrl_space_toggle);
+        assert!(deserialized.alt_backquote_toggle);
+        assert!(deserialized.eisu_toggle);
     }
 
     #[test]
@@ -756,6 +769,8 @@ pub struct ShortcutConfig {
     pub ctrl_space_toggle: bool,
     #[serde(default = "default_shortcut_enabled")]
     pub alt_backquote_toggle: bool,
+    #[serde(default = "default_shortcut_enabled")]
+    pub eisu_toggle: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -852,6 +867,7 @@ impl Default for ShortcutConfig {
         Self {
             ctrl_space_toggle: true,
             alt_backquote_toggle: true,
+            eisu_toggle: true,
         }
     }
 }

--- a/frontend/src/pages/general.tsx
+++ b/frontend/src/pages/general.tsx
@@ -241,6 +241,7 @@ export const General = () => {
     const [shortcutValue, setShortcutValue] = useState({
         ctrlSpaceToggle: true,
         altBackquoteToggle: true,
+        eisuToggle: true,
     });
     const [generalValue, setGeneralValue] = useState<GeneralConfigState>(
         DEFAULT_GENERAL_CONFIG,
@@ -267,6 +268,7 @@ export const General = () => {
                 setShortcutValue({
                     ctrlSpaceToggle: shortcuts.ctrl_space_toggle ?? true,
                     altBackquoteToggle: shortcuts.alt_backquote_toggle ?? true,
+                    eisuToggle: shortcuts.eisu_toggle ?? true,
                 });
 
                 setGeneralValue(normalizeGeneralConfig(data.general));
@@ -422,6 +424,18 @@ export const General = () => {
 
         if (data) {
             setShortcutValue((prev) => ({ ...prev, altBackquoteToggle: nextValue }));
+        }
+    };
+
+    const handleEisuToggle = async () => {
+        const nextValue = !shortcutValue.eisuToggle;
+        const data = await updateConfig((config) => {
+            config.shortcuts = config.shortcuts ?? {};
+            config.shortcuts.eisu_toggle = nextValue;
+        });
+
+        if (data) {
+            setShortcutValue((prev) => ({ ...prev, eisuToggle: nextValue }));
         }
     };
 
@@ -832,27 +846,39 @@ export const General = () => {
                     </div>
                 </section>
 
-                <section className="space-y-2">
+                <section className="space-y-3">
                     <h1 className="text-sm font-bold text-foreground">入力モード切替ショートカット</h1>
-                    <div className="flex items-center space-x-4 rounded-md border p-4">
-                        <Keyboard />
-                        <div className="flex-1 space-y-1">
-                            <p className="text-sm font-medium leading-none">Ctrl + Space を有効化</p>
-                            <p className="text-xs text-muted-foreground">
-                                英数/かな切り替えのショートカットとして Ctrl + Space を使用します
-                            </p>
+                    <div className="divide-y rounded-md border">
+                        <div className="flex items-center gap-4 p-4">
+                            <Keyboard className="h-4 w-4 shrink-0" />
+                            <div className="flex-1 space-y-1">
+                                <p className="text-sm font-medium leading-none">Ctrl + Space を有効化</p>
+                                <p className="text-xs text-muted-foreground">
+                                    英数/かな切り替えのショートカットとして Ctrl + Space を使用します
+                                </p>
+                            </div>
+                            <Switch checked={shortcutValue.ctrlSpaceToggle} onCheckedChange={handleCtrlSpaceToggle} />
                         </div>
-                        <Switch checked={shortcutValue.ctrlSpaceToggle} onCheckedChange={handleCtrlSpaceToggle} />
-                    </div>
-                    <div className="flex items-center space-x-4 rounded-md border p-4">
-                        <Keyboard />
-                        <div className="flex-1 space-y-1">
-                            <p className="text-sm font-medium leading-none">Alt + ` を有効化</p>
-                            <p className="text-xs text-muted-foreground">
-                                英数/かな切り替えのショートカットとして Alt + ` を使用します
-                            </p>
+                        <div className="flex items-center gap-4 p-4">
+                            <Keyboard className="h-4 w-4 shrink-0" />
+                            <div className="flex-1 space-y-1">
+                                <p className="text-sm font-medium leading-none">Alt + ` を有効化</p>
+                                <p className="text-xs text-muted-foreground">
+                                    英数/かな切り替えのショートカットとして Alt + ` を使用します
+                                </p>
+                            </div>
+                            <Switch checked={shortcutValue.altBackquoteToggle} onCheckedChange={handleAltBackquoteToggle} />
                         </div>
-                        <Switch checked={shortcutValue.altBackquoteToggle} onCheckedChange={handleAltBackquoteToggle} />
+                        <div className="flex items-center gap-4 p-4">
+                            <Keyboard className="h-4 w-4 shrink-0" />
+                            <div className="flex-1 space-y-1">
+                                <p className="text-sm font-medium leading-none">英数 (CapsLock) を有効化</p>
+                                <p className="text-xs text-muted-foreground">
+                                    英数/かな切り替えのショートカットとして英数 (CapsLock) を使用します
+                                </p>
+                            </div>
+                            <Switch checked={shortcutValue.eisuToggle} onCheckedChange={handleEisuToggle} />
+                        </div>
                     </div>
                 </section>
 


### PR DESCRIPTION
## Summary
- 英数 (CapsLock) キーによる英数/かな切り替えを追加し、設定画面から有効/無効を切り替えられるようにしました。
- CapsLock / Shift+CapsLock の扱いをキーボードレイアウトごとに分岐し、MS IME と同じく日本語配列では CapsLock 単体、英語配列では Shift+CapsLock を入力切り替えとして扱うようにしました。
- CapsLock による大文字固定と入力モード切り替えが同時に走らないよう、TSF の通常 key event と PreservedKey の両方で CapsLock scancode を扱うようにしました。
- GitHub Actions の Swift build が VS2026 image に流れて落ちないよう、Windows runner を `windows-2022` に固定しました。

Closes #97

## Background
- Issue #97 では、JIS 配列の英数キー相当として CapsLock 単体で英数/かな入力を切り替えたい要望がありました。
- 調査したところ、MS IME では日本語 106/109 配列では CapsLock 単体が英数キー相当、英語 101/102 配列では Shift+CapsLock が英数キー相当として扱われます。
- VM で raw scancode を使って確認したところ、Windows / TSF では CapsLock が `VK_CAPITAL` ではなく `wparam=0xF0` + `scancode=0x3A` として届くケースがあり、通常の CapsLock 判定だけでは取り逃すことが分かりました。

## Changes
- CapsLock eisu shortcut
  - `ShortcutConfig` に `eisu_toggle` を追加し、既存設定では default true になるよう migration 互換を維持
  - 設定画面の「入力モード切替ショートカット」に「英数 (CapsLock) を有効化」を追加
  - `i8042prt` の `LayerDriver JPN` / `OverrideKeyboardIdentifier` を参照して CapsLock 用の日本語/英語レイアウトを判定
  - 日本語配列では CapsLock 単体、英語配列では Shift+CapsLock のみを入力モード切り替えとして扱うように変更
- TSF key handling
  - `VK_CAPITAL` の PreservedKey を登録し、OS/host 側に捕捉される CapsLock 経路でも入力切り替えを試行
  - `wparam=0xF0` + `scancode=0x3A` の translated CapsLock event を通常 key handling でも扱うように変更
  - Shift state を key event sink 側でも追跡し、Shift+CapsLock 判定が host による modifier state 差に依存しすぎないように補強
- Kana input normalization
  - CapsLock 有効時に `A` が Kana mode の romaji 入力へ流れた場合は `a` として扱い、`あ` 入力になるように変更
- tests
  - キーボードレイアウト別の CapsLock / Shift+CapsLock 判定テストを追加
  - hardware registry の fallback / 101 / 106 判定テストを追加
  - Kana mode で ASCII uppercase を lowercase 化する回帰テストを追加
  - shortcut config の default / serde default テストを追加

## Verification
- [x] Codex review
  - TSF に届く CapsLock event を一時ログで確認し、最終差分からデバッグログを削除済み
  - 日本語/英語配列の両方で `VK_CAPITAL` と `wparam=0xF0` + `scancode=0x3A` を扱う方針を確認済み
- [x] format / 差分チェック
  - `cargo fmt --check`
  - `git diff --check`
  - `git diff --cached --check`
- [x] CI failure triage
  - 失敗原因: `windows-latest` が `win25-vs2026` になり、Swift 6.1.2 同梱 Clang が MSVC 14.51 の Clang 20 requirement に未対応
  - 対応: workflow の runner を `windows-2022` に固定
- [x] GitHub Actions build
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/27540211005
- [x] ローカル shared test
  - `PROTOC=/home/batao9/workspaces/azooKey-Windows/.local/tmp/protoc/bin/protoc cargo test -p shared`
  - result: 12 tests passed
- [x] ローカル Windows VM targeted client test
  - `cargo test -p azookey-windows eisu_shortcut_matches_ms_ime_capslock_rules_by_keyboard_layout`
  - result: 1 test passed
- [x] ローカル Windows VM client release build
  - `cargo build -p azookey-windows --release`
  - result: build passed
  - final dll: `.local/artifacts/azookey_windows-feature_97-eisu-toggle-20260615-092214-final.dll`
- [x] ローカル Windows VM Japanese layout input test
  - layout: `kbd106.dll` / `PCAT_106KEY`
  - CapsLock + `a` -> `あ`
  - Shift+CapsLock + `a` -> `A`
  - evidence: `.local/vm-debug/issue97-final-jp-caps-alone-a.png`, `.local/vm-debug/issue97-final-jp-shift-caps-a.png`
- [x] ローカル Windows VM English layout input test
  - layout: `kbd101.dll` / `PCAT_101KEY`
  - CapsLock + `a` -> `A`
  - Shift+CapsLock + `a` -> `あ`
  - evidence: `.local/vm-debug/issue97-final-en-caps-alone-a.png`, `.local/vm-debug/issue97-final-en-shift-caps-a.png`
- [x] frontend type check
  - `node ../scripts/sync-version.mjs`
  - `node node_modules/typescript/bin/tsc`
- [ ] frontend Vite build
  - WSL 上の Windows node/npm が UNC path 上の Vite dependencies を解決できず失敗
  - `npm run build`: Windows npm が `C:\Windows\package.json` を見に行く UNC path 問題で失敗
  - `node node_modules/vite/bin/vite.js build`: `vite` / `@vitejs/plugin-react` / `@tailwindcss/vite` の package entry resolution が UNC path で失敗

## Notes
- 検証後、Win11 VM のキーボードレイアウトは日本語配列 (`kbd106.dll` / `PCAT_106KEY`) に戻して再起動済みです。
- ビルド VM は停止済みです。