### PR TITLE
perf(vm): prune orphan disks and speed local builds

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -17,7 +17,7 @@ cp .build/release/azookey-server.lib ../
 
 [tasks.build_x64]
 command = "cargo"
-args = ["build", "${@}"]
+args = ["build", "--workspace", "--exclude", "frontend", "${@}"]
 
 [tasks.build_x86]
 command = "cargo"
@@ -37,8 +37,20 @@ command = "node"
 args = ["scripts/sync-version.mjs"]
 
 [tasks.build_installer]
-command = "iscc"
-args = ["./installer/Installer.iss"]
+script_runner = "powershell"
+script_extension = "ps1"
+script = """
+$isccArgs = @()
+if ($env:AZOOKEY_FAST_INSTALLER -eq "1") {
+    $isccArgs += "/DLocalFastInstaller=1"
+}
+$isccArgs += "./installer/Installer.iss"
+
+& iscc @isccArgs
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+"""
 
 [tasks.post_build]
 description = "Copy necessary files"
@@ -52,17 +64,21 @@ if ([string]::IsNullOrEmpty($str)) {
     $str=$str.Substring(2)
 }
 
+$targetRoot = $env:CARGO_TARGET_DIR
+if ([string]::IsNullOrEmpty($targetRoot)) {
+    $targetRoot = "target"
+}
 
 mkdir build/x86 -Force
 
-cp target/$str/ui.exe build
-cp target/$str/azookey-server.exe build
-cp target/$str/azookey_windows.dll build
-cp target/$str/launcher.exe build
-cp target/$str/frontend.exe build
+cp (Join-Path $targetRoot "$str/ui.exe") build
+cp (Join-Path $targetRoot "$str/azookey-server.exe") build
+cp (Join-Path $targetRoot "$str/azookey_windows.dll") build
+cp (Join-Path $targetRoot "$str/launcher.exe") build
+cp (Join-Path $targetRoot "$str/frontend.exe") build
 
 
-cp target/i686-pc-windows-msvc/$str/azookey_windows.dll build/x86
+cp (Join-Path $targetRoot "i686-pc-windows-msvc/$str/azookey_windows.dll") build/x86
 
 cp server-swift/.build/x86_64-unknown-windows-msvc/release/azookey-server.dll build
 

--- a/installer/Installer.iss
+++ b/installer/Installer.iss
@@ -34,7 +34,12 @@ DisableProgramGroupPage=yes
 ;PrivilegesRequired=lowest
 OutputDir=../build
 OutputBaseFilename=azookey-setup
+#ifdef LocalFastInstaller
+Compression=zip
+SolidCompression=no
+#else
 SolidCompression=yes
+#endif
 WizardStyle=modern
 PrivilegesRequired=admin
 CloseApplications=yes

--- a/scripts/vm_build.sh
+++ b/scripts/vm_build.sh
@@ -583,22 +583,32 @@ function Use-NodeModulesCache {
   $hash = (Get-FileHash -Algorithm SHA256 -Path $packageLock).Hash.ToLowerInvariant()
   $cacheDir = Join-Path $CacheRoot "node_modules\$hash"
   $nodeModules = Join-Path $FrontendDir "node_modules"
-  New-Junction -Path $nodeModules -Target $cacheDir
 
   $sentinel = Join-Path $cacheDir ".azookey-node-modules-ready"
-  if (Test-Path $sentinel) {
+  $cachePackageLock = Join-Path $cacheDir ".package-lock.json"
+  if ((Test-Path $sentinel) -and (Test-Path $cachePackageLock)) {
+    New-Junction -Path $nodeModules -Target $cacheDir
     Write-Host "reused node_modules cache: $cacheDir"
     return
   }
 
-  Write-Host "running npm ci into node_modules cache: $cacheDir"
+  if (Test-Path $sentinel) {
+    Write-Host "node_modules cache sentinel exists but cache content is incomplete; rebuilding: $cacheDir"
+  }
+
+  Write-Host "running npm ci before caching node_modules: $cacheDir"
+  Reset-Path -Path $nodeModules
+  Reset-Path -Path $cacheDir
   Push-Location $FrontendDir
   try {
     npm.cmd ci --prefer-offline --no-audit
     if ($LASTEXITCODE -ne 0) {
       throw "npm ci failed with exit code $LASTEXITCODE"
     }
+    New-Item -Path (Split-Path -Parent $cacheDir) -ItemType Directory -Force | Out-Null
+    Move-Item -LiteralPath $nodeModules -Destination $cacheDir
     Set-Content -LiteralPath $sentinel -Encoding ASCII -Value $hash
+    New-Junction -Path $nodeModules -Target $cacheDir
   } finally {
     Pop-Location
   }

--- a/scripts/vm_build.sh
+++ b/scripts/vm_build.sh
@@ -21,6 +21,7 @@ VM_CACHE_DISK_REQUIRED="${VM_CACHE_DISK_REQUIRED:-0}"
 VM_CACHE_DISK_SIZE_MB="${VM_CACHE_DISK_SIZE_MB:-65536}"
 VM_CACHE_STORAGE_CONTROLLER="${VM_CACHE_STORAGE_CONTROLLER:-SATA}"
 VM_CACHE_DISK_PORT="${VM_CACHE_DISK_PORT:-2}"
+VM_CACHE_GUEST_DISK_NUMBER="${VM_CACHE_GUEST_DISK_NUMBER:-}"
 VM_CACHE_DRIVE_LETTER="${VM_CACHE_DRIVE_LETTER:-Z}"
 VM_CACHE_VOLUME_LABEL="${VM_CACHE_VOLUME_LABEL:-AZOOKEYCACHE}"
 VM_BUILD_CACHE_ROOT_WIN="${VM_BUILD_CACHE_ROOT_WIN:-}"
@@ -465,7 +466,7 @@ param(
   [Parameter(Mandatory = $false)][string]$CacheVolumeLabel = "AZOOKEYCACHE",
   [Parameter(Mandatory = $false)][string]$CacheRootOverride = "",
   [Parameter(Mandatory = $false)][string]$FastInstaller = "0",
-  [Parameter(Mandatory = $false)][string]$AllowRawCacheDisk = "0"
+  [Parameter(Mandatory = $false)][string]$CacheDiskNumber = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -510,7 +511,7 @@ function Initialize-BuildCacheRoot {
     [string]$VolumeLabel,
     [string]$RootOverride,
     [string]$FallbackRoot,
-    [string]$AllowRawDisk
+    [string]$DiskNumber
   )
 
   if (![string]::IsNullOrWhiteSpace($RootOverride)) {
@@ -520,21 +521,20 @@ function Initialize-BuildCacheRoot {
 
   $drive = $DriveLetter.TrimEnd(":")
   $volume = Get-Volume -FileSystemLabel $VolumeLabel -ErrorAction SilentlyContinue | Select-Object -First 1
-  if (!$volume -and $AllowRawDisk -eq "1") {
-    $rawDisk = Get-Disk -ErrorAction SilentlyContinue |
-      Where-Object PartitionStyle -eq "RAW" |
-      Sort-Object Number |
-      Select-Object -First 1
-
-    if ($rawDisk) {
-      Write-Host "initializing build cache disk #$($rawDisk.Number) as ${drive}: ($VolumeLabel)"
-      Initialize-Disk -Number $rawDisk.Number -PartitionStyle GPT -PassThru | Out-Null
-      $partition = New-Partition -DiskNumber $rawDisk.Number -UseMaximumSize -DriveLetter $drive
-      Format-Volume -Partition $partition -FileSystem NTFS -NewFileSystemLabel $VolumeLabel -Confirm:$false | Out-Null
-      $volume = Get-Volume -DriveLetter $drive
+  if (!$volume -and ![string]::IsNullOrWhiteSpace($DiskNumber)) {
+    $rawDiskNumber = [int]$DiskNumber
+    $rawDisk = Get-Disk -Number $rawDiskNumber -ErrorAction Stop
+    if ($rawDisk.PartitionStyle -ne "RAW") {
+      throw "cache disk #$rawDiskNumber is not RAW; refusing to format it as $VolumeLabel"
     }
+
+    Write-Host "initializing explicitly selected build cache disk #$rawDiskNumber as ${drive}: ($VolumeLabel)"
+    Initialize-Disk -Number $rawDiskNumber -PartitionStyle GPT -PassThru | Out-Null
+    $partition = New-Partition -DiskNumber $rawDiskNumber -UseMaximumSize -DriveLetter $drive
+    Format-Volume -Partition $partition -FileSystem NTFS -NewFileSystemLabel $VolumeLabel -Confirm:$false | Out-Null
+    $volume = Get-Volume -DriveLetter $drive
   } elseif (!$volume) {
-    Write-Host "raw cache disk initialization is disabled; falling back to $FallbackRoot"
+    Write-Host "cache disk volume not found and no explicit guest disk number was provided; falling back to $FallbackRoot"
   }
 
   if ($volume) {
@@ -675,7 +675,7 @@ $cacheRoot = Initialize-BuildCacheRoot `
   -VolumeLabel $CacheVolumeLabel `
   -RootOverride $CacheRootOverride `
   -FallbackRoot $fallbackCacheRoot `
-  -AllowRawDisk $AllowRawCacheDisk
+  -DiskNumber $CacheDiskNumber
 Write-Host "build cache root: $cacheRoot"
 
 $env:CARGO_TARGET_DIR = Join-Path $cacheRoot "cargo-target"
@@ -945,13 +945,8 @@ main() {
   scp_to_vm "$TMP_SRC_ARCHIVE" "$REMOTE_TAR_SCP"
   scp_to_vm "$TMP_REMOTE_PS" "$REMOTE_PS_SCP"
 
-  local allow_raw_cache_disk="0"
-  if [[ -n "$VM_CACHE_DISK_PATH" ]]; then
-    allow_raw_cache_disk="1"
-  fi
-
   log "VM 上でビルドを実行します（時間がかかる場合があります）"
-  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -SourceTarPath \"$REMOTE_TAR_WIN\" -SourceDir \"$REMOTE_SRC_WIN\" -ArtifactDir \"$REMOTE_ART_WIN\" -HostTimestampUtc \"$HOST_TIMESTAMP_UTC\" -CacheDriveLetter \"$VM_CACHE_DRIVE_LETTER\" -CacheVolumeLabel \"$VM_CACHE_VOLUME_LABEL\" -CacheRootOverride \"$VM_BUILD_CACHE_ROOT_WIN\" -FastInstaller \"$VM_FAST_INSTALLER\" -AllowRawCacheDisk \"$allow_raw_cache_disk\""
+  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -SourceTarPath \"$REMOTE_TAR_WIN\" -SourceDir \"$REMOTE_SRC_WIN\" -ArtifactDir \"$REMOTE_ART_WIN\" -HostTimestampUtc \"$HOST_TIMESTAMP_UTC\" -CacheDriveLetter \"$VM_CACHE_DRIVE_LETTER\" -CacheVolumeLabel \"$VM_CACHE_VOLUME_LABEL\" -CacheRootOverride \"$VM_BUILD_CACHE_ROOT_WIN\" -FastInstaller \"$VM_FAST_INSTALLER\" -CacheDiskNumber \"$VM_CACHE_GUEST_DISK_NUMBER\""
 
   log "成果物を WSL 側へ回収します"
   scp_from_vm "$REMOTE_ART_SCP" "$LOCAL_ARTIFACT"

--- a/scripts/vm_build.sh
+++ b/scripts/vm_build.sh
@@ -140,7 +140,7 @@ machine_cfg_file() {
 
 machine_snapshot_dir() {
   vbox showvminfo "$VM_NAME" --machinereadable |
-    awk -F= '$1 == "SnapshotFolder" { value=$2 } END { gsub(/"/, "", value); print value }'
+    awk -F= '$1 == "SnapFldr" { value=$2 } END { gsub(/"/, "", value); print value }'
 }
 
 ensure_vm_cache_disk() {

--- a/scripts/vm_build.sh
+++ b/scripts/vm_build.sh
@@ -10,11 +10,21 @@ RESTORE_BEFORE_BUILD="${RESTORE_BEFORE_BUILD:-1}"
 RESTORE_AFTER_BUILD="${RESTORE_AFTER_BUILD:-1}"
 ALLOW_DIRTY_WORKTREE="${ALLOW_DIRTY_WORKTREE:-1}"
 DISCARD_SAVED_STATE_BEFORE_BUILD="${DISCARD_SAVED_STATE_BEFORE_BUILD:-0}"
+PRUNE_ORPHAN_MEDIA_AFTER_RESTORE="${PRUNE_ORPHAN_MEDIA_AFTER_RESTORE:-1}"
 SSH_USER="${SSH_USER:-}"
 SSH_PORT="${SSH_PORT:-}"
 SSH_KEY="${SSH_KEY:-}"
 VBOX_MANAGE="${VBOX_MANAGE:-}"
 STAGING_VM_NAME="${STAGING_VM_NAME:-}"
+VM_CACHE_DISK_PATH="${VM_CACHE_DISK_PATH:-}"
+VM_CACHE_DISK_REQUIRED="${VM_CACHE_DISK_REQUIRED:-0}"
+VM_CACHE_DISK_SIZE_MB="${VM_CACHE_DISK_SIZE_MB:-65536}"
+VM_CACHE_STORAGE_CONTROLLER="${VM_CACHE_STORAGE_CONTROLLER:-SATA}"
+VM_CACHE_DISK_PORT="${VM_CACHE_DISK_PORT:-2}"
+VM_CACHE_DRIVE_LETTER="${VM_CACHE_DRIVE_LETTER:-Z}"
+VM_CACHE_VOLUME_LABEL="${VM_CACHE_VOLUME_LABEL:-AZOOKEYCACHE}"
+VM_BUILD_CACHE_ROOT_WIN="${VM_BUILD_CACHE_ROOT_WIN:-}"
+VM_FAST_INSTALLER="${VM_FAST_INSTALLER:-0}"
 
 if [[ -z "$VBOX_MANAGE" ]]; then
   if command -v VBoxManage >/dev/null 2>&1; then
@@ -53,7 +63,7 @@ LOCAL_ARTIFACT="$ARTIFACT_DIR/azookey-setup-${TARGET_BRANCH_SLUG}-$TIMESTAMP.exe
 REMOTE_TMP_WIN="C:\\Users\\$SSH_USER\\AppData\\Local\\Temp"
 REMOTE_TAR_WIN="$REMOTE_TMP_WIN\\azookey-src.tar.gz"
 REMOTE_PS_WIN="$REMOTE_TMP_WIN\\azookey-vm-build.ps1"
-REMOTE_SRC_WIN="C:\\work\\azookey-src-$TIMESTAMP"
+REMOTE_SRC_WIN="${REMOTE_SRC_WIN:-C:\\work\\azookey-src}"
 REMOTE_ART_WIN="C:\\work\\artifacts"
 
 REMOTE_TAR_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-src.tar.gz"
@@ -86,17 +96,17 @@ vbox() {
 
 matches_fixed() {
   if command -v rg >/dev/null 2>&1; then
-    rg -F "$1" -q
+    rg -F "$1" >/dev/null
   else
-    grep -F "$1" -q
+    grep -F "$1" >/dev/null
   fi
 }
 
 matches_regex() {
   if command -v rg >/dev/null 2>&1; then
-    rg -q "$1"
+    rg "$1" >/dev/null
   else
-    grep -q -- "$1"
+    grep -- "$1" >/dev/null
   fi
 }
 
@@ -111,6 +121,139 @@ is_named_vm_running() {
 
 snapshot_exists() {
   vbox snapshot "$VM_NAME" list --machinereadable | matches_fixed "=\"$SNAPSHOT_NAME\""
+}
+
+host_path_for_vbox() {
+  local path="$1"
+  if [[ "$path" == /* ]] && command -v wslpath >/dev/null 2>&1; then
+    wslpath -w "$path"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
+machine_cfg_file() {
+  vbox showvminfo "$VM_NAME" --machinereadable |
+    awk -F= '$1 == "CfgFile" { value=$2 } END { gsub(/"/, "", value); print value }'
+}
+
+ensure_vm_cache_disk() {
+  if [[ -z "$VM_CACHE_DISK_PATH" ]]; then
+    return 0
+  fi
+
+  if [[ "$VM_CACHE_DISK_PATH" == /* ]]; then
+    mkdir -p "$(dirname "$VM_CACHE_DISK_PATH")"
+  fi
+
+  local cache_disk
+  cache_disk="$(host_path_for_vbox "$VM_CACHE_DISK_PATH")"
+  cache_disk="${cache_disk//$'\r'/}"
+
+  local info vm_state current_key current_medium cache_disk_cmp current_medium_cmp required_port_count
+  info="$(vbox showvminfo "$VM_NAME" --machinereadable)"
+  vm_state="$(printf '%s\n' "$info" | awk -F= '$1 == "VMState" { gsub(/"/, "", $2); print $2 }')"
+  vm_state="${vm_state//$'\r'/}"
+  current_key="\"${VM_CACHE_STORAGE_CONTROLLER}-${VM_CACHE_DISK_PORT}-0\""
+  current_medium="$(printf '%s\n' "$info" |
+    awk -F= -v key="$current_key" '$1 == key { gsub(/^"/, "", $2); gsub(/"$/, "", $2); print $2; exit }')"
+  current_medium="${current_medium//$'\r'/}"
+  current_medium="${current_medium//\"/}"
+  current_medium="${current_medium//\\\\/\\}"
+  cache_disk_cmp="$(printf '%s' "$cache_disk" | tr '[:upper:]' '[:lower:]')"
+  current_medium_cmp="$(printf '%s' "$current_medium" | tr '[:upper:]' '[:lower:]')"
+
+  if [[ "$current_medium_cmp" == "$cache_disk_cmp" ]]; then
+    return 0
+  fi
+
+  if [[ "$vm_state" == "saved" ]]; then
+    log "保存状態の VM には cache disk を後付けできないため、この実行では cache disk をスキップします: $cache_disk"
+    if [[ "$VM_CACHE_DISK_REQUIRED" == "1" ]]; then
+      exit 1
+    fi
+    return 0
+  fi
+
+  if ! vbox showmediuminfo disk "$cache_disk" >/dev/null 2>&1; then
+    if [[ "$VM_CACHE_DISK_PATH" == /* && -f "$VM_CACHE_DISK_PATH" ]]; then
+      log "既存の cache disk を登録します: $cache_disk"
+      vbox openmedium disk "$cache_disk" >/dev/null
+    else
+      log "cache disk を作成します: $cache_disk (${VM_CACHE_DISK_SIZE_MB}MB)"
+      vbox createmedium disk --filename "$cache_disk" --size "$VM_CACHE_DISK_SIZE_MB" --format VDI >/dev/null
+    fi
+    vbox modifymedium disk "$cache_disk" --type writethrough >/dev/null
+  fi
+
+  if [[ -n "$current_medium" && "$current_medium" != "none" ]]; then
+    log "cache disk 用 port が使用中です: ${VM_CACHE_STORAGE_CONTROLLER}-${VM_CACHE_DISK_PORT}-0 -> $current_medium"
+    exit 1
+  fi
+
+  required_port_count=$((VM_CACHE_DISK_PORT + 1))
+  vbox storagectl "$VM_NAME" --name "$VM_CACHE_STORAGE_CONTROLLER" --portcount "$required_port_count" >/dev/null
+  log "cache disk を VM に接続します: $cache_disk"
+  vbox storageattach "$VM_NAME" \
+    --storagectl "$VM_CACHE_STORAGE_CONTROLLER" \
+    --port "$VM_CACHE_DISK_PORT" \
+    --device 0 \
+    --type hdd \
+    --medium "$cache_disk" >/dev/null
+}
+
+prune_orphan_leaf_media() {
+  if [[ "$PRUNE_ORPHAN_MEDIA_AFTER_RESTORE" != "1" ]]; then
+    return 0
+  fi
+
+  local cfg_file vm_dir
+  cfg_file="$(machine_cfg_file)"
+  cfg_file="${cfg_file//\\\\/\\}"
+  if [[ -z "$cfg_file" ]]; then
+    log "VM 設定ファイルが取得できないため orphan media prune をスキップします"
+    return 0
+  fi
+  vm_dir="${cfg_file%\\*}"
+
+  local candidates=()
+  mapfile -t candidates < <(
+    vbox list hdds --long | tr -d '\r' |
+      VM_DIR="$vm_dir" awk '
+        BEGIN {
+          RS="\n\n"; FS="\n";
+          vm_dir = ENVIRON["VM_DIR"];
+          gsub(/\\/, "/", vm_dir);
+        }
+        {
+          uuid=""; loc=""; size=""; use="no"; child="no";
+          for (i=1; i<=NF; i++) {
+            line=$i;
+            if (line ~ /^UUID:/) { sub(/^UUID:[[:space:]]*/, "", line); uuid=line }
+            if (line ~ /^Location:/) { sub(/^Location:[[:space:]]*/, "", line); loc=line }
+            if (line ~ /^Size on disk:/) { sub(/^Size on disk:[[:space:]]*/, "", line); size=line }
+            if (line ~ /^In use by VMs:/) { use="yes" }
+            if (line ~ /^Child UUIDs:/) { child="yes" }
+          }
+          loc_norm = loc;
+          gsub(/\\/, "/", loc_norm);
+          if (uuid != "" && use == "no" && child == "no" && index(loc_norm, vm_dir) == 1 && loc_norm ~ /\.vdi$/) {
+            print uuid "\t" size "\t" loc
+          }
+        }'
+  )
+
+  if (( ${#candidates[@]} == 0 )); then
+    log "未接続 leaf VDI はありません"
+    return 0
+  fi
+
+  local entry uuid size loc
+  for entry in "${candidates[@]}"; do
+    IFS=$'\t' read -r uuid size loc <<<"$entry"
+    log "未接続 leaf VDI を削除します: $uuid ($size) $loc"
+    vbox closemedium disk "$uuid" --delete </dev/null
+  done
 }
 
 ssh_run() {
@@ -204,6 +347,11 @@ cleanup() {
 
     if snapshot_exists; then
       vbox snapshot "$VM_NAME" restore "$SNAPSHOT_NAME" >/dev/null || true
+      if [[ "$DISCARD_SAVED_STATE_BEFORE_BUILD" == "1" ]]; then
+        vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
+      fi
+      ensure_vm_cache_disk || true
+      prune_orphan_leaf_media || true
       FINAL_RESTORE_DONE=1
     else
       log "復元対象スナップショットが見つからないためスキップします: $SNAPSHOT_NAME"
@@ -311,18 +459,145 @@ param(
   [Parameter(Mandatory = $true)][string]$SourceTarPath,
   [Parameter(Mandatory = $true)][string]$SourceDir,
   [Parameter(Mandatory = $true)][string]$ArtifactDir,
-  [Parameter(Mandatory = $true)][string]$HostTimestampUtc
+  [Parameter(Mandatory = $true)][string]$HostTimestampUtc,
+  [Parameter(Mandatory = $false)][string]$CacheDriveLetter = "Z",
+  [Parameter(Mandatory = $false)][string]$CacheVolumeLabel = "AZOOKEYCACHE",
+  [Parameter(Mandatory = $false)][string]$CacheRootOverride = "",
+  [Parameter(Mandatory = $false)][string]$FastInstaller = "0"
 )
 
 $ErrorActionPreference = "Stop"
 $env:Path += ";$env:USERPROFILE\\.cargo\\bin"
+if ($FastInstaller -eq "1") {
+  $env:AZOOKEY_FAST_INSTALLER = "1"
+} else {
+  Remove-Item Env:AZOOKEY_FAST_INSTALLER -ErrorAction SilentlyContinue
+}
 
 $LLAMA_CPU_URL = "https://github.com/fkunn1326/llama.cpp/releases/download/b4846/llama-b4846-bin-win-avx-x64.zip"
 $LLAMA_CUDA_URL = "https://github.com/fkunn1326/llama.cpp/releases/download/b4846/llama-b4846-bin-win-cuda-cu12.4-x64.zip"
 $LLAMA_VULKAN_URL = "https://github.com/fkunn1326/llama.cpp/releases/download/b4846/llama-b4846-bin-win-vulkan-x64.zip"
 $ZENZ_MODEL_URL = "https://huggingface.co/Miwa-Keita/zenz-v3-small-gguf/resolve/main/ggml-model-Q5_K_M.gguf"
 $downloadAllAssets = $env:DOWNLOAD_ALL_ASSETS -eq "1"
-$cacheRoot = "C:\work\azooKey-Windows"
+$fallbackCacheRoot = "C:\work\azooKey-Windows"
+$script:StepTimings = New-Object System.Collections.Generic.List[object]
+
+function Measure-Step {
+  param(
+    [string]$Name,
+    [scriptblock]$Action
+  )
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
+  Write-Host "[timing] begin $Name"
+  try {
+    & $Action
+  } finally {
+    $sw.Stop()
+    $seconds = [Math]::Round($sw.Elapsed.TotalSeconds, 3)
+    $script:StepTimings.Add([pscustomobject]@{
+      Name = $Name
+      Seconds = $seconds
+    }) | Out-Null
+    Write-Host "[timing] end $Name ${seconds}s"
+  }
+}
+
+function Initialize-BuildCacheRoot {
+  param(
+    [string]$DriveLetter,
+    [string]$VolumeLabel,
+    [string]$RootOverride,
+    [string]$FallbackRoot
+  )
+
+  if (![string]::IsNullOrWhiteSpace($RootOverride)) {
+    New-Item -Path $RootOverride -ItemType Directory -Force | Out-Null
+    return $RootOverride
+  }
+
+  $drive = $DriveLetter.TrimEnd(":")
+  $volume = Get-Volume -FileSystemLabel $VolumeLabel -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (!$volume) {
+    $rawDisk = Get-Disk -ErrorAction SilentlyContinue |
+      Where-Object PartitionStyle -eq "RAW" |
+      Sort-Object Number |
+      Select-Object -First 1
+
+    if ($rawDisk) {
+      Write-Host "initializing build cache disk #$($rawDisk.Number) as ${drive}: ($VolumeLabel)"
+      Initialize-Disk -Number $rawDisk.Number -PartitionStyle GPT -PassThru | Out-Null
+      $partition = New-Partition -DiskNumber $rawDisk.Number -UseMaximumSize -DriveLetter $drive
+      Format-Volume -Partition $partition -FileSystem NTFS -NewFileSystemLabel $VolumeLabel -Confirm:$false | Out-Null
+      $volume = Get-Volume -DriveLetter $drive
+    }
+  }
+
+  if ($volume) {
+    $cacheDrive = $drive
+    if (![string]::IsNullOrWhiteSpace($volume.DriveLetter)) {
+      $cacheDrive = $volume.DriveLetter
+    }
+    $root = "${cacheDrive}:\azookey-build-cache"
+    New-Item -Path $root -ItemType Directory -Force | Out-Null
+    return $root
+  }
+
+  Write-Host "build cache disk not found; falling back to $FallbackRoot"
+  New-Item -Path $FallbackRoot -ItemType Directory -Force | Out-Null
+  return $FallbackRoot
+}
+
+function Reset-Path {
+  param([string]$Path)
+  if (Test-Path $Path) {
+    Remove-Item -Path $Path -Recurse -Force
+  }
+}
+
+function New-Junction {
+  param(
+    [string]$Path,
+    [string]$Target
+  )
+  New-Item -Path $Target -ItemType Directory -Force | Out-Null
+  Reset-Path -Path $Path
+  New-Item -ItemType Junction -Path $Path -Target $Target | Out-Null
+}
+
+function Use-NodeModulesCache {
+  param(
+    [string]$FrontendDir,
+    [string]$CacheRoot
+  )
+
+  $packageLock = Join-Path $FrontendDir "package-lock.json"
+  if (!(Test-Path $packageLock)) {
+    throw "package-lock.json not found: $packageLock"
+  }
+
+  $hash = (Get-FileHash -Algorithm SHA256 -Path $packageLock).Hash.ToLowerInvariant()
+  $cacheDir = Join-Path $CacheRoot "node_modules\$hash"
+  $nodeModules = Join-Path $FrontendDir "node_modules"
+  New-Junction -Path $nodeModules -Target $cacheDir
+
+  $sentinel = Join-Path $cacheDir ".azookey-node-modules-ready"
+  if (Test-Path $sentinel) {
+    Write-Host "reused node_modules cache: $cacheDir"
+    return
+  }
+
+  Write-Host "running npm ci into node_modules cache: $cacheDir"
+  Push-Location $FrontendDir
+  try {
+    npm.cmd ci --prefer-offline --no-audit
+    if ($LASTEXITCODE -ne 0) {
+      throw "npm ci failed with exit code $LASTEXITCODE"
+    }
+    Set-Content -LiteralPath $sentinel -Encoding ASCII -Value $hash
+  } finally {
+    Pop-Location
+  }
+}
 
 function Sync-GuestClock {
   param([string]$TimestampUtc)
@@ -390,15 +665,36 @@ function Replace-TreeFromCache {
   return $true
 }
 
-if (Test-Path $SourceDir) {
-  Remove-Item -Recurse -Force $SourceDir
-}
-New-Item -Path $SourceDir -ItemType Directory -Force | Out-Null
+$cacheRoot = Initialize-BuildCacheRoot `
+  -DriveLetter $CacheDriveLetter `
+  -VolumeLabel $CacheVolumeLabel `
+  -RootOverride $CacheRootOverride `
+  -FallbackRoot $fallbackCacheRoot
+Write-Host "build cache root: $cacheRoot"
 
-tar -xzf $SourceTarPath -C $SourceDir
+$env:CARGO_TARGET_DIR = Join-Path $cacheRoot "cargo-target"
+$env:npm_config_cache = Join-Path $cacheRoot "npm-cache"
+New-Item -Path $env:CARGO_TARGET_DIR -ItemType Directory -Force | Out-Null
+New-Item -Path $env:npm_config_cache -ItemType Directory -Force | Out-Null
+Write-Host "CARGO_TARGET_DIR=$env:CARGO_TARGET_DIR"
+Write-Host "npm_config_cache=$env:npm_config_cache"
+
+Measure-Step "extract source" {
+  Reset-Path -Path $SourceDir
+  New-Item -Path $SourceDir -ItemType Directory -Force | Out-Null
+  tar -xzf $SourceTarPath -C $SourceDir
+  if ($LASTEXITCODE -ne 0) {
+    throw "tar extraction failed with exit code $LASTEXITCODE"
+  }
+}
 Set-Location $SourceDir
 Write-Host "source extracted: $SourceDir"
 Sync-GuestClock -TimestampUtc $HostTimestampUtc
+
+$sourceSwiftBuildDir = Join-Path $SourceDir "server-swift\.build"
+$cachedSwiftBuildDir = Join-Path $cacheRoot "swift-build"
+New-Junction -Path $sourceSwiftBuildDir -Target $cachedSwiftBuildDir
+Write-Host "swift .build cache: $cachedSwiftBuildDir"
 
 $llamaCpuDir = Join-Path $SourceDir "llama_cpu"
 $llamaCudaDir = Join-Path $SourceDir "llama_cuda"
@@ -449,14 +745,12 @@ if ($downloadAllAssets) {
   New-Item -Path $llamaVulkanDir -ItemType Directory -Force | Out-Null
 
   if (!(Test-Path (Join-Path $llamaCudaDir "llama.dll"))) {
-    if (!(Copy-TreeIfExists -SourceDir (Join-Path $cacheRoot "llama_cuda") -DestDir $llamaCudaDir)) {
-      Copy-Item (Join-Path $llamaCpuDir "llama.dll") -Destination (Join-Path $llamaCudaDir "llama.dll") -Force
-    }
+    Copy-Item (Join-Path $llamaCpuDir "llama.dll") -Destination (Join-Path $llamaCudaDir "llama.dll") -Force
+    Write-Host "created minimal llama cuda assets for fast local build"
   }
   if (!(Test-Path (Join-Path $llamaVulkanDir "llama.dll"))) {
-    if (!(Copy-TreeIfExists -SourceDir (Join-Path $cacheRoot "llama_vulkan") -DestDir $llamaVulkanDir)) {
-      Copy-Item (Join-Path $llamaCpuDir "llama.dll") -Destination (Join-Path $llamaVulkanDir "llama.dll") -Force
-    }
+    Copy-Item (Join-Path $llamaCpuDir "llama.dll") -Destination (Join-Path $llamaVulkanDir "llama.dll") -Force
+    Write-Host "created minimal llama vulkan assets for fast local build"
   }
   if (!(Test-Path $zenzPath)) {
     $cachedZenzPath = Join-Path $cacheRoot "zenz.gguf"
@@ -476,10 +770,12 @@ $cachedMainDictDir = Join-Path $cacheRoot "server-swift\\azooKey_dictionary_stor
 # NOTE:
 # WSL(tar) -> Windows(tar -xzf) で日本語ファイル名が壊れる環境があるため、
 # 辞書は Windows 側 clone のキャッシュを優先して上書きする。
-if (!(Replace-TreeFromCache -CacheDir $cachedEmojiDictDir -DestDir $emojiDictDir -Label "emoji dictionary")) {
+$emojiDictReused = Replace-TreeFromCache -CacheDir $cachedEmojiDictDir -DestDir $emojiDictDir -Label "emoji dictionary"
+if (-not $emojiDictReused) {
   Write-Host "emoji dictionary cache not found; using extracted source files"
 }
-if (!(Replace-TreeFromCache -CacheDir $cachedMainDictDir -DestDir $mainDictDir -Label "main dictionary")) {
+$mainDictReused = Replace-TreeFromCache -CacheDir $cachedMainDictDir -DestDir $mainDictDir -Label "main dictionary"
+if (-not $mainDictReused) {
   Write-Host "main dictionary cache not found; using extracted source files"
 }
 
@@ -567,17 +863,25 @@ if (-not (Get-Command cargo-make -ErrorAction SilentlyContinue)) {
   cargo install --locked cargo-make
 }
 
-Set-Location (Join-Path $SourceDir "frontend")
-Write-Host "running npm ci"
-npm.cmd ci --prefer-offline --no-audit
+Measure-Step "prepare node_modules" {
+  Use-NodeModulesCache -FrontendDir (Join-Path $SourceDir "frontend") -CacheRoot $cacheRoot
+}
 
 Set-Location $SourceDir
-Write-Host "running cargo make build --release"
-cargo make build --release
+Measure-Step "cargo make build --release" {
+  cargo make build --release
+  if ($LASTEXITCODE -ne 0) {
+    throw "cargo make build failed with exit code $LASTEXITCODE"
+  }
+}
 
 New-Item -Path $ArtifactDir -ItemType Directory -Force | Out-Null
 Copy-Item (Join-Path $SourceDir "build\\azookey-setup.exe") -Destination (Join-Path $ArtifactDir "azookey-setup.exe") -Force
 Write-Host "build finished: $ArtifactDir\\azookey-setup.exe"
+Write-Host "[timing] summary"
+foreach ($item in $script:StepTimings) {
+  Write-Host ("[timing] {0}: {1}s" -f $item.Name, $item.Seconds)
+}
 PS1
 }
 
@@ -608,10 +912,14 @@ main() {
       if [[ "$DISCARD_SAVED_STATE_BEFORE_BUILD" == "1" ]]; then
         vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
       fi
+      ensure_vm_cache_disk
+      prune_orphan_leaf_media
     else
       log "復元対象スナップショットが見つからないためスキップします: $SNAPSHOT_NAME"
     fi
   fi
+
+  ensure_vm_cache_disk
 
   if ! is_vm_running; then
     VM_TOUCHED=1
@@ -632,7 +940,7 @@ main() {
   scp_to_vm "$TMP_REMOTE_PS" "$REMOTE_PS_SCP"
 
   log "VM 上でビルドを実行します（時間がかかる場合があります）"
-  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -SourceTarPath \"$REMOTE_TAR_WIN\" -SourceDir \"$REMOTE_SRC_WIN\" -ArtifactDir \"$REMOTE_ART_WIN\" -HostTimestampUtc \"$HOST_TIMESTAMP_UTC\""
+  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -SourceTarPath \"$REMOTE_TAR_WIN\" -SourceDir \"$REMOTE_SRC_WIN\" -ArtifactDir \"$REMOTE_ART_WIN\" -HostTimestampUtc \"$HOST_TIMESTAMP_UTC\" -CacheDriveLetter \"$VM_CACHE_DRIVE_LETTER\" -CacheVolumeLabel \"$VM_CACHE_VOLUME_LABEL\" -CacheRootOverride \"$VM_BUILD_CACHE_ROOT_WIN\" -FastInstaller \"$VM_FAST_INSTALLER\""
 
   log "成果物を WSL 側へ回収します"
   scp_from_vm "$REMOTE_ART_SCP" "$LOCAL_ARTIFACT"
@@ -648,6 +956,11 @@ main() {
     if snapshot_exists; then
       log "ビルド後にクリーン状態へ戻すため復元します: $SNAPSHOT_NAME"
       vbox snapshot "$VM_NAME" restore "$SNAPSHOT_NAME" >/dev/null
+      if [[ "$DISCARD_SAVED_STATE_BEFORE_BUILD" == "1" ]]; then
+        vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
+      fi
+      ensure_vm_cache_disk
+      prune_orphan_leaf_media
       FINAL_RESTORE_DONE=1
     else
       log "復元対象スナップショットが見つからないためスキップします: $SNAPSHOT_NAME"

--- a/scripts/vm_build.sh
+++ b/scripts/vm_build.sh
@@ -585,8 +585,8 @@ function Use-NodeModulesCache {
   $nodeModules = Join-Path $FrontendDir "node_modules"
 
   $sentinel = Join-Path $cacheDir ".azookey-node-modules-ready"
-  $cachePackageLock = Join-Path $cacheDir ".package-lock.json"
-  if ((Test-Path $sentinel) -and (Test-Path $cachePackageLock)) {
+  $cacheHashMarker = Join-Path $cacheDir ".azookey-package-lock.sha256"
+  if ((Test-Path $sentinel) -and (Test-Path $cacheHashMarker)) {
     New-Junction -Path $nodeModules -Target $cacheDir
     Write-Host "reused node_modules cache: $cacheDir"
     return
@@ -607,6 +607,7 @@ function Use-NodeModulesCache {
     }
     New-Item -Path (Split-Path -Parent $cacheDir) -ItemType Directory -Force | Out-Null
     Move-Item -LiteralPath $nodeModules -Destination $cacheDir
+    Set-Content -LiteralPath $cacheHashMarker -Encoding ASCII -Value $hash
     Set-Content -LiteralPath $sentinel -Encoding ASCII -Value $hash
     New-Junction -Path $nodeModules -Target $cacheDir
   } finally {

--- a/scripts/vm_build.sh
+++ b/scripts/vm_build.sh
@@ -237,7 +237,8 @@ prune_orphan_leaf_media() {
           }
           loc_norm = loc;
           gsub(/\\/, "/", loc_norm);
-          if (uuid != "" && use == "no" && child == "no" && index(loc_norm, vm_dir) == 1 && loc_norm ~ /\.vdi$/) {
+          in_scope = (loc_norm == vm_dir || index(loc_norm, vm_dir "/") == 1);
+          if (uuid != "" && use == "no" && child == "no" && in_scope && loc_norm ~ /\.vdi$/) {
             print uuid "\t" size "\t" loc
           }
         }'
@@ -463,7 +464,8 @@ param(
   [Parameter(Mandatory = $false)][string]$CacheDriveLetter = "Z",
   [Parameter(Mandatory = $false)][string]$CacheVolumeLabel = "AZOOKEYCACHE",
   [Parameter(Mandatory = $false)][string]$CacheRootOverride = "",
-  [Parameter(Mandatory = $false)][string]$FastInstaller = "0"
+  [Parameter(Mandatory = $false)][string]$FastInstaller = "0",
+  [Parameter(Mandatory = $false)][string]$AllowRawCacheDisk = "0"
 )
 
 $ErrorActionPreference = "Stop"
@@ -507,7 +509,8 @@ function Initialize-BuildCacheRoot {
     [string]$DriveLetter,
     [string]$VolumeLabel,
     [string]$RootOverride,
-    [string]$FallbackRoot
+    [string]$FallbackRoot,
+    [string]$AllowRawDisk
   )
 
   if (![string]::IsNullOrWhiteSpace($RootOverride)) {
@@ -517,7 +520,7 @@ function Initialize-BuildCacheRoot {
 
   $drive = $DriveLetter.TrimEnd(":")
   $volume = Get-Volume -FileSystemLabel $VolumeLabel -ErrorAction SilentlyContinue | Select-Object -First 1
-  if (!$volume) {
+  if (!$volume -and $AllowRawDisk -eq "1") {
     $rawDisk = Get-Disk -ErrorAction SilentlyContinue |
       Where-Object PartitionStyle -eq "RAW" |
       Sort-Object Number |
@@ -530,6 +533,8 @@ function Initialize-BuildCacheRoot {
       Format-Volume -Partition $partition -FileSystem NTFS -NewFileSystemLabel $VolumeLabel -Confirm:$false | Out-Null
       $volume = Get-Volume -DriveLetter $drive
     }
+  } elseif (!$volume) {
+    Write-Host "raw cache disk initialization is disabled; falling back to $FallbackRoot"
   }
 
   if ($volume) {
@@ -669,7 +674,8 @@ $cacheRoot = Initialize-BuildCacheRoot `
   -DriveLetter $CacheDriveLetter `
   -VolumeLabel $CacheVolumeLabel `
   -RootOverride $CacheRootOverride `
-  -FallbackRoot $fallbackCacheRoot
+  -FallbackRoot $fallbackCacheRoot `
+  -AllowRawDisk $AllowRawCacheDisk
 Write-Host "build cache root: $cacheRoot"
 
 $env:CARGO_TARGET_DIR = Join-Path $cacheRoot "cargo-target"
@@ -939,8 +945,13 @@ main() {
   scp_to_vm "$TMP_SRC_ARCHIVE" "$REMOTE_TAR_SCP"
   scp_to_vm "$TMP_REMOTE_PS" "$REMOTE_PS_SCP"
 
+  local allow_raw_cache_disk="0"
+  if [[ -n "$VM_CACHE_DISK_PATH" ]]; then
+    allow_raw_cache_disk="1"
+  fi
+
   log "VM 上でビルドを実行します（時間がかかる場合があります）"
-  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -SourceTarPath \"$REMOTE_TAR_WIN\" -SourceDir \"$REMOTE_SRC_WIN\" -ArtifactDir \"$REMOTE_ART_WIN\" -HostTimestampUtc \"$HOST_TIMESTAMP_UTC\" -CacheDriveLetter \"$VM_CACHE_DRIVE_LETTER\" -CacheVolumeLabel \"$VM_CACHE_VOLUME_LABEL\" -CacheRootOverride \"$VM_BUILD_CACHE_ROOT_WIN\" -FastInstaller \"$VM_FAST_INSTALLER\""
+  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -SourceTarPath \"$REMOTE_TAR_WIN\" -SourceDir \"$REMOTE_SRC_WIN\" -ArtifactDir \"$REMOTE_ART_WIN\" -HostTimestampUtc \"$HOST_TIMESTAMP_UTC\" -CacheDriveLetter \"$VM_CACHE_DRIVE_LETTER\" -CacheVolumeLabel \"$VM_CACHE_VOLUME_LABEL\" -CacheRootOverride \"$VM_BUILD_CACHE_ROOT_WIN\" -FastInstaller \"$VM_FAST_INSTALLER\" -AllowRawCacheDisk \"$allow_raw_cache_disk\""
 
   log "成果物を WSL 側へ回収します"
   scp_from_vm "$REMOTE_ART_SCP" "$LOCAL_ARTIFACT"

--- a/scripts/vm_build.sh
+++ b/scripts/vm_build.sh
@@ -138,6 +138,11 @@ machine_cfg_file() {
     awk -F= '$1 == "CfgFile" { value=$2 } END { gsub(/"/, "", value); print value }'
 }
 
+machine_snapshot_dir() {
+  vbox showvminfo "$VM_NAME" --machinereadable |
+    awk -F= '$1 == "SnapshotFolder" { value=$2 } END { gsub(/"/, "", value); print value }'
+}
+
 ensure_vm_cache_disk() {
   if [[ -z "$VM_CACHE_DISK_PATH" ]]; then
     return 0
@@ -151,7 +156,7 @@ ensure_vm_cache_disk() {
   cache_disk="$(host_path_for_vbox "$VM_CACHE_DISK_PATH")"
   cache_disk="${cache_disk//$'\r'/}"
 
-  local info vm_state current_key current_medium cache_disk_cmp current_medium_cmp required_port_count
+  local info vm_state current_key current_medium cache_disk_cmp current_medium_cmp required_port_count current_port_count
   info="$(vbox showvminfo "$VM_NAME" --machinereadable)"
   vm_state="$(printf '%s\n' "$info" | awk -F= '$1 == "VMState" { gsub(/"/, "", $2); print $2 }')"
   vm_state="${vm_state//$'\r'/}"
@@ -193,7 +198,29 @@ ensure_vm_cache_disk() {
   fi
 
   required_port_count=$((VM_CACHE_DISK_PORT + 1))
-  vbox storagectl "$VM_NAME" --name "$VM_CACHE_STORAGE_CONTROLLER" --portcount "$required_port_count" >/dev/null
+  current_port_count="$(printf '%s\n' "$info" |
+    awk -F= -v controller="$VM_CACHE_STORAGE_CONTROLLER" '
+      {
+        key=$1; value=$2;
+        gsub(/^"/, "", value); gsub(/"$/, "", value);
+        if (key ~ /^storagecontrollername[0-9]+$/ && value == controller) {
+          idx=key; sub(/^storagecontrollername/, "", idx); controller_idx=idx;
+        }
+        if (key ~ /^storagecontrollerportcount[0-9]+$/) {
+          idx=key; sub(/^storagecontrollerportcount/, "", idx); port_count[idx]=value;
+        }
+      }
+      END {
+        if (controller_idx != "") print port_count[controller_idx];
+      }')"
+  current_port_count="${current_port_count//$'\r'/}"
+  if [[ ! "$current_port_count" =~ ^[0-9]+$ ]]; then
+    log "storage controller の port count が取得できません: $VM_CACHE_STORAGE_CONTROLLER"
+    exit 1
+  fi
+  if (( current_port_count < required_port_count )); then
+    vbox storagectl "$VM_NAME" --name "$VM_CACHE_STORAGE_CONTROLLER" --portcount "$required_port_count" >/dev/null
+  fi
   log "cache disk を VM に接続します: $cache_disk"
   vbox storageattach "$VM_NAME" \
     --storagectl "$VM_CACHE_STORAGE_CONTROLLER" \
@@ -208,7 +235,7 @@ prune_orphan_leaf_media() {
     return 0
   fi
 
-  local cfg_file vm_dir
+  local cfg_file vm_dir snapshot_dir
   cfg_file="$(machine_cfg_file)"
   cfg_file="${cfg_file//\\\\/\\}"
   if [[ -z "$cfg_file" ]]; then
@@ -216,15 +243,22 @@ prune_orphan_leaf_media() {
     return 0
   fi
   vm_dir="${cfg_file%\\*}"
+  snapshot_dir="$(machine_snapshot_dir)"
+  snapshot_dir="${snapshot_dir//\\\\/\\}"
+  if [[ -z "$snapshot_dir" ]]; then
+    snapshot_dir="$vm_dir\\Snapshots"
+  fi
 
   local candidates=()
   mapfile -t candidates < <(
     vbox list hdds --long | tr -d '\r' |
-      VM_DIR="$vm_dir" awk '
+      SNAPSHOT_DIR="$snapshot_dir" awk '
         BEGIN {
           RS="\n\n"; FS="\n";
-          vm_dir = ENVIRON["VM_DIR"];
-          gsub(/\\/, "/", vm_dir);
+          snapshot_dir = ENVIRON["SNAPSHOT_DIR"];
+          gsub(/\\/, "/", snapshot_dir);
+          gsub(/\/+$/, "", snapshot_dir);
+          snapshot_dir = tolower(snapshot_dir "/");
         }
         {
           uuid=""; loc=""; size=""; use="no"; child="no";
@@ -238,7 +272,8 @@ prune_orphan_leaf_media() {
           }
           loc_norm = loc;
           gsub(/\\/, "/", loc_norm);
-          in_scope = (loc_norm == vm_dir || index(loc_norm, vm_dir "/") == 1);
+          loc_norm_lc = tolower(loc_norm);
+          in_scope = (index(loc_norm_lc, snapshot_dir) == 1);
           if (uuid != "" && use == "no" && child == "no" && in_scope && loc_norm ~ /\.vdi$/) {
             print uuid "\t" size "\t" loc
           }

--- a/scripts/vm_test_client_composition.sh
+++ b/scripts/vm_test_client_composition.sh
@@ -171,7 +171,7 @@ machine_cfg_file() {
 
 machine_snapshot_dir() {
   vbox showvminfo "$VM_NAME" --machinereadable |
-    awk -F= '$1 == "SnapshotFolder" { value=$2 } END { gsub(/"/, "", value); print value }'
+    awk -F= '$1 == "SnapFldr" { value=$2 } END { gsub(/"/, "", value); print value }'
 }
 
 ensure_vm_cache_disk() {

--- a/scripts/vm_test_client_composition.sh
+++ b/scripts/vm_test_client_composition.sh
@@ -7,6 +7,7 @@ RESTORE_BEFORE_TEST="${RESTORE_BEFORE_TEST:-1}"
 RESTORE_AFTER_TEST="${RESTORE_AFTER_TEST:-1}"
 ALLOW_DIRTY_WORKTREE="${ALLOW_DIRTY_WORKTREE:-1}"
 DISCARD_SAVED_STATE_BEFORE_TEST="${DISCARD_SAVED_STATE_BEFORE_TEST:-0}"
+PRUNE_ORPHAN_MEDIA_AFTER_RESTORE="${PRUNE_ORPHAN_MEDIA_AFTER_RESTORE:-1}"
 SSH_USER="${SSH_USER:-}"
 SSH_PORT="${SSH_PORT:-}"
 SSH_KEY="${SSH_KEY:-}"
@@ -16,6 +17,11 @@ SSH_TEST_TIMEOUT_SEC="${SSH_TEST_TIMEOUT_SEC:-7200}"
 SCP_COMMAND_TIMEOUT_SEC="${SCP_COMMAND_TIMEOUT_SEC:-300}"
 VBOX_MANAGE="${VBOX_MANAGE:-}"
 STAGING_VM_NAME="${STAGING_VM_NAME:-}"
+VM_CACHE_DISK_PATH="${VM_CACHE_DISK_PATH:-}"
+VM_CACHE_DISK_REQUIRED="${VM_CACHE_DISK_REQUIRED:-0}"
+VM_CACHE_DISK_SIZE_MB="${VM_CACHE_DISK_SIZE_MB:-65536}"
+VM_CACHE_STORAGE_CONTROLLER="${VM_CACHE_STORAGE_CONTROLLER:-SATA}"
+VM_CACHE_DISK_PORT="${VM_CACHE_DISK_PORT:-2}"
 
 if [[ -z "$VBOX_MANAGE" ]]; then
   if command -v VBoxManage >/dev/null 2>&1; then
@@ -66,7 +72,7 @@ REMOTE_TMP_WIN="C:\\Users\\$SSH_USER\\AppData\\Local\\Temp"
 REMOTE_TAR_WIN="$REMOTE_TMP_WIN\\azookey-src.tar.gz"
 REMOTE_PS_WIN="$REMOTE_TMP_WIN\\azookey-vm-client-test.ps1"
 REMOTE_SWIFT_VENDOR_TAR_WIN="$REMOTE_TMP_WIN\\azookey-swift-vendor.tar.gz"
-REMOTE_SRC_WIN="C:\\w\\azt-$TIMESTAMP"
+REMOTE_SRC_WIN="${REMOTE_SRC_WIN:-C:\\w\\azt}"
 
 REMOTE_TAR_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-src.tar.gz"
 REMOTE_PS_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-vm-client-test.ps1"
@@ -122,17 +128,17 @@ vbox() {
 
 matches_fixed() {
   if command -v rg >/dev/null 2>&1; then
-    rg -F "$1" -q
+    rg -F "$1" >/dev/null
   else
-    grep -F "$1" -q
+    grep -F "$1" >/dev/null
   fi
 }
 
 matches_regex() {
   if command -v rg >/dev/null 2>&1; then
-    rg -q "$1"
+    rg "$1" >/dev/null
   else
-    grep -q -- "$1"
+    grep -- "$1" >/dev/null
   fi
 }
 
@@ -147,6 +153,139 @@ is_named_vm_running() {
 
 snapshot_exists() {
   vbox snapshot "$VM_NAME" list --machinereadable | matches_fixed "=\"$SNAPSHOT_NAME\""
+}
+
+host_path_for_vbox() {
+  local path="$1"
+  if [[ "$path" == /* ]] && command -v wslpath >/dev/null 2>&1; then
+    wslpath -w "$path"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
+machine_cfg_file() {
+  vbox showvminfo "$VM_NAME" --machinereadable |
+    awk -F= '$1 == "CfgFile" { value=$2 } END { gsub(/"/, "", value); print value }'
+}
+
+ensure_vm_cache_disk() {
+  if [[ -z "$VM_CACHE_DISK_PATH" ]]; then
+    return 0
+  fi
+
+  if [[ "$VM_CACHE_DISK_PATH" == /* ]]; then
+    mkdir -p "$(dirname "$VM_CACHE_DISK_PATH")"
+  fi
+
+  local cache_disk
+  cache_disk="$(host_path_for_vbox "$VM_CACHE_DISK_PATH")"
+  cache_disk="${cache_disk//$'\r'/}"
+
+  local info vm_state current_key current_medium cache_disk_cmp current_medium_cmp required_port_count
+  info="$(vbox showvminfo "$VM_NAME" --machinereadable)"
+  vm_state="$(printf '%s\n' "$info" | awk -F= '$1 == "VMState" { gsub(/"/, "", $2); print $2 }')"
+  vm_state="${vm_state//$'\r'/}"
+  current_key="\"${VM_CACHE_STORAGE_CONTROLLER}-${VM_CACHE_DISK_PORT}-0\""
+  current_medium="$(printf '%s\n' "$info" |
+    awk -F= -v key="$current_key" '$1 == key { gsub(/^"/, "", $2); gsub(/"$/, "", $2); print $2; exit }')"
+  current_medium="${current_medium//$'\r'/}"
+  current_medium="${current_medium//\"/}"
+  current_medium="${current_medium//\\\\/\\}"
+  cache_disk_cmp="$(printf '%s' "$cache_disk" | tr '[:upper:]' '[:lower:]')"
+  current_medium_cmp="$(printf '%s' "$current_medium" | tr '[:upper:]' '[:lower:]')"
+
+  if [[ "$current_medium_cmp" == "$cache_disk_cmp" ]]; then
+    return 0
+  fi
+
+  if [[ "$vm_state" == "saved" ]]; then
+    log "保存状態の VM には cache disk を後付けできないため、この実行では cache disk をスキップします: $cache_disk"
+    if [[ "$VM_CACHE_DISK_REQUIRED" == "1" ]]; then
+      exit 1
+    fi
+    return 0
+  fi
+
+  if ! vbox showmediuminfo disk "$cache_disk" >/dev/null 2>&1; then
+    if [[ "$VM_CACHE_DISK_PATH" == /* && -f "$VM_CACHE_DISK_PATH" ]]; then
+      log "既存の cache disk を登録します: $cache_disk"
+      vbox openmedium disk "$cache_disk" >/dev/null
+    else
+      log "cache disk を作成します: $cache_disk (${VM_CACHE_DISK_SIZE_MB}MB)"
+      vbox createmedium disk --filename "$cache_disk" --size "$VM_CACHE_DISK_SIZE_MB" --format VDI >/dev/null
+    fi
+    vbox modifymedium disk "$cache_disk" --type writethrough >/dev/null
+  fi
+
+  if [[ -n "$current_medium" && "$current_medium" != "none" ]]; then
+    log "cache disk 用 port が使用中です: ${VM_CACHE_STORAGE_CONTROLLER}-${VM_CACHE_DISK_PORT}-0 -> $current_medium"
+    exit 1
+  fi
+
+  required_port_count=$((VM_CACHE_DISK_PORT + 1))
+  vbox storagectl "$VM_NAME" --name "$VM_CACHE_STORAGE_CONTROLLER" --portcount "$required_port_count" >/dev/null
+  log "cache disk を VM に接続します: $cache_disk"
+  vbox storageattach "$VM_NAME" \
+    --storagectl "$VM_CACHE_STORAGE_CONTROLLER" \
+    --port "$VM_CACHE_DISK_PORT" \
+    --device 0 \
+    --type hdd \
+    --medium "$cache_disk" >/dev/null
+}
+
+prune_orphan_leaf_media() {
+  if [[ "$PRUNE_ORPHAN_MEDIA_AFTER_RESTORE" != "1" ]]; then
+    return 0
+  fi
+
+  local cfg_file vm_dir
+  cfg_file="$(machine_cfg_file)"
+  cfg_file="${cfg_file//\\\\/\\}"
+  if [[ -z "$cfg_file" ]]; then
+    log "VM 設定ファイルが取得できないため orphan media prune をスキップします"
+    return 0
+  fi
+  vm_dir="${cfg_file%\\*}"
+
+  local candidates=()
+  mapfile -t candidates < <(
+    vbox list hdds --long | tr -d '\r' |
+      VM_DIR="$vm_dir" awk '
+        BEGIN {
+          RS="\n\n"; FS="\n";
+          vm_dir = ENVIRON["VM_DIR"];
+          gsub(/\\/, "/", vm_dir);
+        }
+        {
+          uuid=""; loc=""; size=""; use="no"; child="no";
+          for (i=1; i<=NF; i++) {
+            line=$i;
+            if (line ~ /^UUID:/) { sub(/^UUID:[[:space:]]*/, "", line); uuid=line }
+            if (line ~ /^Location:/) { sub(/^Location:[[:space:]]*/, "", line); loc=line }
+            if (line ~ /^Size on disk:/) { sub(/^Size on disk:[[:space:]]*/, "", line); size=line }
+            if (line ~ /^In use by VMs:/) { use="yes" }
+            if (line ~ /^Child UUIDs:/) { child="yes" }
+          }
+          loc_norm = loc;
+          gsub(/\\/, "/", loc_norm);
+          if (uuid != "" && use == "no" && child == "no" && index(loc_norm, vm_dir) == 1 && loc_norm ~ /\.vdi$/) {
+            print uuid "\t" size "\t" loc
+          }
+        }'
+  )
+
+  if (( ${#candidates[@]} == 0 )); then
+    log "未接続 leaf VDI はありません"
+    return 0
+  fi
+
+  local entry uuid size loc
+  for entry in "${candidates[@]}"; do
+    IFS=$'\t' read -r uuid size loc <<<"$entry"
+    log "未接続 leaf VDI を削除します: $uuid ($size) $loc"
+    vbox closemedium disk "$uuid" --delete </dev/null
+  done
 }
 
 ssh_run() {
@@ -263,6 +402,11 @@ cleanup() {
 
     if snapshot_exists; then
       vbox snapshot "$VM_NAME" restore "$SNAPSHOT_NAME" >/dev/null || true
+      if [[ "$DISCARD_SAVED_STATE_BEFORE_TEST" == "1" ]]; then
+        vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
+      fi
+      ensure_vm_cache_disk || true
+      prune_orphan_leaf_media || true
       FINAL_RESTORE_DONE=1
     fi
   fi
@@ -801,8 +945,12 @@ main() {
       if [[ "$DISCARD_SAVED_STATE_BEFORE_TEST" == "1" ]]; then
         vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
       fi
+      ensure_vm_cache_disk
+      prune_orphan_leaf_media
     fi
   fi
+
+  ensure_vm_cache_disk
 
   if ! is_vm_running; then
     VM_TOUCHED=1
@@ -844,6 +992,11 @@ main() {
     if snapshot_exists; then
       log "test 後にクリーン状態へ戻すため復元します: $SNAPSHOT_NAME"
       vbox snapshot "$VM_NAME" restore "$SNAPSHOT_NAME" >/dev/null
+      if [[ "$DISCARD_SAVED_STATE_BEFORE_TEST" == "1" ]]; then
+        vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
+      fi
+      ensure_vm_cache_disk
+      prune_orphan_leaf_media
       FINAL_RESTORE_DONE=1
     fi
   fi

--- a/scripts/vm_test_client_composition.sh
+++ b/scripts/vm_test_client_composition.sh
@@ -169,6 +169,11 @@ machine_cfg_file() {
     awk -F= '$1 == "CfgFile" { value=$2 } END { gsub(/"/, "", value); print value }'
 }
 
+machine_snapshot_dir() {
+  vbox showvminfo "$VM_NAME" --machinereadable |
+    awk -F= '$1 == "SnapshotFolder" { value=$2 } END { gsub(/"/, "", value); print value }'
+}
+
 ensure_vm_cache_disk() {
   if [[ -z "$VM_CACHE_DISK_PATH" ]]; then
     return 0
@@ -182,7 +187,7 @@ ensure_vm_cache_disk() {
   cache_disk="$(host_path_for_vbox "$VM_CACHE_DISK_PATH")"
   cache_disk="${cache_disk//$'\r'/}"
 
-  local info vm_state current_key current_medium cache_disk_cmp current_medium_cmp required_port_count
+  local info vm_state current_key current_medium cache_disk_cmp current_medium_cmp required_port_count current_port_count
   info="$(vbox showvminfo "$VM_NAME" --machinereadable)"
   vm_state="$(printf '%s\n' "$info" | awk -F= '$1 == "VMState" { gsub(/"/, "", $2); print $2 }')"
   vm_state="${vm_state//$'\r'/}"
@@ -224,7 +229,29 @@ ensure_vm_cache_disk() {
   fi
 
   required_port_count=$((VM_CACHE_DISK_PORT + 1))
-  vbox storagectl "$VM_NAME" --name "$VM_CACHE_STORAGE_CONTROLLER" --portcount "$required_port_count" >/dev/null
+  current_port_count="$(printf '%s\n' "$info" |
+    awk -F= -v controller="$VM_CACHE_STORAGE_CONTROLLER" '
+      {
+        key=$1; value=$2;
+        gsub(/^"/, "", value); gsub(/"$/, "", value);
+        if (key ~ /^storagecontrollername[0-9]+$/ && value == controller) {
+          idx=key; sub(/^storagecontrollername/, "", idx); controller_idx=idx;
+        }
+        if (key ~ /^storagecontrollerportcount[0-9]+$/) {
+          idx=key; sub(/^storagecontrollerportcount/, "", idx); port_count[idx]=value;
+        }
+      }
+      END {
+        if (controller_idx != "") print port_count[controller_idx];
+      }')"
+  current_port_count="${current_port_count//$'\r'/}"
+  if [[ ! "$current_port_count" =~ ^[0-9]+$ ]]; then
+    log "storage controller の port count が取得できません: $VM_CACHE_STORAGE_CONTROLLER"
+    exit 1
+  fi
+  if (( current_port_count < required_port_count )); then
+    vbox storagectl "$VM_NAME" --name "$VM_CACHE_STORAGE_CONTROLLER" --portcount "$required_port_count" >/dev/null
+  fi
   log "cache disk を VM に接続します: $cache_disk"
   vbox storageattach "$VM_NAME" \
     --storagectl "$VM_CACHE_STORAGE_CONTROLLER" \
@@ -239,7 +266,7 @@ prune_orphan_leaf_media() {
     return 0
   fi
 
-  local cfg_file vm_dir
+  local cfg_file vm_dir snapshot_dir
   cfg_file="$(machine_cfg_file)"
   cfg_file="${cfg_file//\\\\/\\}"
   if [[ -z "$cfg_file" ]]; then
@@ -247,15 +274,22 @@ prune_orphan_leaf_media() {
     return 0
   fi
   vm_dir="${cfg_file%\\*}"
+  snapshot_dir="$(machine_snapshot_dir)"
+  snapshot_dir="${snapshot_dir//\\\\/\\}"
+  if [[ -z "$snapshot_dir" ]]; then
+    snapshot_dir="$vm_dir\\Snapshots"
+  fi
 
   local candidates=()
   mapfile -t candidates < <(
     vbox list hdds --long | tr -d '\r' |
-      VM_DIR="$vm_dir" awk '
+      SNAPSHOT_DIR="$snapshot_dir" awk '
         BEGIN {
           RS="\n\n"; FS="\n";
-          vm_dir = ENVIRON["VM_DIR"];
-          gsub(/\\/, "/", vm_dir);
+          snapshot_dir = ENVIRON["SNAPSHOT_DIR"];
+          gsub(/\\/, "/", snapshot_dir);
+          gsub(/\/+$/, "", snapshot_dir);
+          snapshot_dir = tolower(snapshot_dir "/");
         }
         {
           uuid=""; loc=""; size=""; use="no"; child="no";
@@ -269,7 +303,8 @@ prune_orphan_leaf_media() {
           }
           loc_norm = loc;
           gsub(/\\/, "/", loc_norm);
-          in_scope = (loc_norm == vm_dir || index(loc_norm, vm_dir "/") == 1);
+          loc_norm_lc = tolower(loc_norm);
+          in_scope = (index(loc_norm_lc, snapshot_dir) == 1);
           if (uuid != "" && use == "no" && child == "no" && in_scope && loc_norm ~ /\.vdi$/) {
             print uuid "\t" size "\t" loc
           }

--- a/scripts/vm_test_client_composition.sh
+++ b/scripts/vm_test_client_composition.sh
@@ -269,7 +269,8 @@ prune_orphan_leaf_media() {
           }
           loc_norm = loc;
           gsub(/\\/, "/", loc_norm);
-          if (uuid != "" && use == "no" && child == "no" && index(loc_norm, vm_dir) == 1 && loc_norm ~ /\.vdi$/) {
+          in_scope = (loc_norm == vm_dir || index(loc_norm, vm_dir "/") == 1);
+          if (uuid != "" && use == "no" && child == "no" && in_scope && loc_norm ~ /\.vdi$/) {
             print uuid "\t" size "\t" loc
           }
         }'


### PR DESCRIPTION
## Summary
- VM build / test の snapshot restore 後に、VM ディレクトリ配下の未接続 leaf VDI を自動 prune するようにしました。
- VM build に optional な cache disk / cache root を追加し、`CARGO_TARGET_DIR`、npm cache、`node_modules`、Swift `.build` を snapshot restore の外へ逃がせるようにしました。
- ローカル build の重複を減らし、frontend を workspace build から除外したうえで Tauri build に任せるようにしました。
- ローカル高速 build 用に Inno Setup の fast compression と minimal llama CUDA / Vulkan assets を opt-in で使えるようにしました。
- build step ごとの timing log を追加し、次の高速化対象を見つけやすくしました。

## Background
- VirtualBox の snapshot restore cycle で、VM の Snapshots ディレクトリ配下に未接続の leaf differencing VDI が残り、D ドライブを圧迫していました。
- 手元では未接続 VDI の削除後に D ドライブ空き容量が回復し、以後の build / restore cycle でも orphan count が 0 のまま維持できることを確認しました。
- build は 30 分前後かかっており、特に Rust workspace build、Tauri frontend build、Inno Setup compression が大きな固定費になっていました。
- 外部 cache disk はより大きな高速化余地がありますが、現在の snapshot が saved state のため、disk 後付けは default では skip し、環境変数で opt-in できる形にしています。

## Changes
- VirtualBox orphan media cleanup
  - `PRUNE_ORPHAN_MEDIA_AFTER_RESTORE=1` を build / test script の default に追加
  - restore 後に `VBoxManage list hdds --long` から未接続かつ child を持たない leaf `.vdi` を検出して削除
  - 削除対象は VirtualBox の `SnapFldr` 配下に限定し、attached media や親 media を触らないように制限
  - path prefix 判定は directory boundary を要求し、兄弟ディレクトリを誤って対象にしないようにしました
- Optional VM cache disk / cache root
  - `VM_CACHE_DISK_PATH` / `VM_CACHE_DISK_REQUIRED` / `VM_CACHE_DISK_SIZE_MB` などの環境変数を追加
  - VM が mutable な場合は dynamic VDI を作成・登録して writethrough disk として attach
  - VM が saved state の場合は default では log して skip し、required 指定時だけ fail
  - guest 側 PowerShell は既存の cache volume label を優先し、見つからない場合は fallback cache root を使う
  - 未フォーマット RAW disk の初期化は `VM_CACHE_GUEST_DISK_NUMBER` が明示された場合だけ実行し、対象 disk が RAW でない場合は fail
- Build cache and stable workspace
  - remote source directory を timestamp 付きから stable path に変更し、毎回 reset して展開
  - `CARGO_TARGET_DIR` と `npm_config_cache` を cache root 配下へ設定
  - Swift `.build` と frontend `node_modules` を cache root への junction に変更
  - `node_modules` は `package-lock.json` hash ごとに cache し、sentinel で再利用可否を判定
- Build speed adjustments
  - `build_x64` を `cargo build --workspace --exclude frontend` に変更し、frontend binary は Tauri build 側に一本化
  - `AZOOKEY_FAST_INSTALLER=1` のときだけ Inno Setup に `LocalFastInstaller` define を渡し、`Compression=zip` / `SolidCompression=no` を使用
  - local fast asset mode では CUDA / Vulkan llama asset を full tree ではなく `llama.dll` の minimal copy に変更
  - build PowerShell に step timing summary を追加
- Test script alignment
  - `scripts/vm_test_client_composition.sh` にも orphan media cleanup と optional cache disk attach hook を追加
  - `rg -q` / `grep -q` の pipefail SIGPIPE 回避のため match helper を調整

## Verification
- [x] 差分チェック
  - `git diff --check`
  - `git diff --cached --check`
- [x] script syntax / config parse
  - `bash -n scripts/vm_build.sh scripts/vm_test_client_composition.sh`
  - `bash -n scripts/vm_build.sh scripts/vm_test_client_composition.sh .local/vm_build_master.sh .local/vm_test_client_composition.sh`
  - `python3` / `tomllib` で `Makefile.toml` parse
- [x] embedded PowerShell parse
  - `scripts/vm_build.sh`
  - `.local/vm_build_master.sh`
- [x] prune path boundary smoke
  - VM dir `D:/VMs/win` に対して `D:/VMs/win/Snapshots/a.vdi` は対象
  - VM dir `D:/VMs/win` に対して `D:/VMs/win-old/Snapshots/a.vdi` は対象外
- [x] VM cleanup state
  - VM snapshot: `build done`
  - VM state: saved
  - orphan leaf VDI count: 0
  - cache disk attachment: none
  - D drive free: 119G
  - C drive free: 489G
- [x] ローカル VM compatibility build
  - `.local/vm_build_master.sh feature/vm-build-cache-and-prune`
  - total elapsed: 1903s
  - `cargo make build --release`: 1548.563s
  - Inno Setup: 225.594s
  - artifact: `.local/artifacts/azookey-setup-feature_vm-build-cache-and-prune-20260615-211735.exe` (208M)
  - D drive before / after: 119G / 119G
  - orphan leaf VDI count: 0
- [x] ローカル VM fast local build
  - `.local/vm_build_master.sh feature/vm-build-cache-and-prune`
  - total elapsed: 1739s
  - `cargo make build --release`: 1430.727s
  - Inno Setup: 65.359s
  - artifact: `.local/artifacts/azookey-setup-feature_vm-build-cache-and-prune-20260615-231552.exe` (134M)
  - D drive before / after: 119G / 119G
  - orphan leaf VDI count: 0
- [x] Codex review
  - latest reviewed commit: `c2b3840`
  - result: no major issues
- [x] GitHub Actions build
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/27580988658
  - result: build passed

## Notes
- `VM_CACHE_DISK_PATH` は公開 script では default empty のため、環境依存の disk path は repository に固定していません。
- 現在の saved-state snapshot では cache disk の後付けができないため、外部 cache disk による大きめの高速化は、poweroff snapshot を安定化してから有効化する想定です。
- 未フォーマット RAW disk の自動探索・自動初期化はしません。初期化が必要な場合は、対象が cache disk であることを確認して `VM_CACHE_GUEST_DISK_NUMBER` を明示します。
- `DISCARD_SAVED_STATE_BEFORE_BUILD=1` は Windows Update / sshd 復帰待ちが長くなることがあるため、default は無効のままにしています。

