### PR TITLE
fix: follow up CapsLock toggle and VM cleanup

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -17,7 +17,7 @@ cp .build/release/azookey-server.lib ../
 
 [tasks.build_x64]
 command = "cargo"
-args = ["build", "--workspace", "--exclude", "frontend", "${@}"]
+args = ["build", "${@}"]
 
 [tasks.build_x86]
 command = "cargo"
@@ -37,20 +37,8 @@ command = "node"
 args = ["scripts/sync-version.mjs"]
 
 [tasks.build_installer]
-script_runner = "powershell"
-script_extension = "ps1"
-script = """
-$isccArgs = @()
-if ($env:AZOOKEY_FAST_INSTALLER -eq "1") {
-    $isccArgs += "/DLocalFastInstaller=1"
-}
-$isccArgs += "./installer/Installer.iss"
-
-& iscc @isccArgs
-if ($LASTEXITCODE -ne 0) {
-    exit $LASTEXITCODE
-}
-"""
+command = "iscc"
+args = ["./installer/Installer.iss"]
 
 [tasks.post_build]
 description = "Copy necessary files"
@@ -64,21 +52,17 @@ if ([string]::IsNullOrEmpty($str)) {
     $str=$str.Substring(2)
 }
 
-$targetRoot = $env:CARGO_TARGET_DIR
-if ([string]::IsNullOrEmpty($targetRoot)) {
-    $targetRoot = "target"
-}
 
 mkdir build/x86 -Force
 
-cp (Join-Path $targetRoot "$str/ui.exe") build
-cp (Join-Path $targetRoot "$str/azookey-server.exe") build
-cp (Join-Path $targetRoot "$str/azookey_windows.dll") build
-cp (Join-Path $targetRoot "$str/launcher.exe") build
-cp (Join-Path $targetRoot "$str/frontend.exe") build
+cp target/$str/ui.exe build
+cp target/$str/azookey-server.exe build
+cp target/$str/azookey_windows.dll build
+cp target/$str/launcher.exe build
+cp target/$str/frontend.exe build
 
 
-cp (Join-Path $targetRoot "i686-pc-windows-msvc/$str/azookey_windows.dll") build/x86
+cp target/i686-pc-windows-msvc/$str/azookey_windows.dll build/x86
 
 cp server-swift/.build/x86_64-unknown-windows-msvc/release/azookey-server.dll build
 

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -29,8 +29,8 @@ use windows::Win32::{
     System::Registry::{RegGetValueW, HKEY, HKEY_LOCAL_MACHINE, RRF_RT_REG_SZ},
     UI::{
         Input::KeyboardAndMouse::{
-            GetAsyncKeyState, VK_CONTROL, VK_LCONTROL, VK_LMENU, VK_LSHIFT, VK_MENU, VK_RCONTROL,
-            VK_RMENU, VK_RSHIFT, VK_SHIFT,
+            GetAsyncKeyState, GetKeyboardType, VK_CONTROL, VK_LCONTROL, VK_LMENU, VK_LSHIFT,
+            VK_MENU, VK_RCONTROL, VK_RMENU, VK_RSHIFT, VK_SHIFT,
         },
         TextServices::{ITfComposition, ITfCompositionSink_Impl, ITfContext},
     },
@@ -41,6 +41,8 @@ use anyhow::{Context, Result};
 const VK_CAPITAL_KEY_CODE: usize = 0x14;
 const VK_TRANSLATED_CAPSLOCK_KEY_CODE: usize = 0xF0;
 const CAPSLOCK_SCAN_CODE: isize = 0x3A;
+const KEYBOARD_TYPE_ENHANCED_101_OR_102: i32 = 0x4;
+const KEYBOARD_TYPE_JAPANESE: i32 = 0x7;
 
 mod clause_state;
 pub(super) use clause_state::{
@@ -112,7 +114,7 @@ pub struct Composition {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-enum CapsLockKeyboardLayout {
+pub(crate) enum CapsLockKeyboardLayout {
     Japanese,
     English,
 }
@@ -268,6 +270,17 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn caps_lock_keyboard_layout_from_keyboard_type(
+        keyboard_type: Option<i32>,
+    ) -> Option<CapsLockKeyboardLayout> {
+        match keyboard_type {
+            Some(KEYBOARD_TYPE_ENHANCED_101_OR_102) => Some(CapsLockKeyboardLayout::English),
+            Some(KEYBOARD_TYPE_JAPANESE) => Some(CapsLockKeyboardLayout::Japanese),
+            _ => None,
+        }
+    }
+
+    #[inline]
     fn caps_lock_keyboard_layout_from_hardware_registry(
         layer_driver: Option<&str>,
         keyboard_identifier: Option<&str>,
@@ -293,6 +306,19 @@ impl TextServiceFactory {
         }
 
         CapsLockKeyboardLayout::Japanese
+    }
+
+    #[inline]
+    fn caps_lock_keyboard_layout_from_sources(
+        keyboard_type: Option<i32>,
+        layer_driver: Option<&str>,
+        keyboard_identifier: Option<&str>,
+    ) -> CapsLockKeyboardLayout {
+        if let Some(layout) = Self::caps_lock_keyboard_layout_from_keyboard_type(keyboard_type) {
+            return layout;
+        }
+
+        Self::caps_lock_keyboard_layout_from_hardware_registry(layer_driver, keyboard_identifier)
     }
 
     fn registry_string_value(root: HKEY, sub_key: PCWSTR, value: PCWSTR) -> Option<String> {
@@ -335,7 +361,8 @@ impl TextServiceFactory {
         Some(String::from_utf16_lossy(&buffer[..end]))
     }
 
-    fn current_caps_lock_keyboard_layout() -> CapsLockKeyboardLayout {
+    pub(crate) fn current_caps_lock_keyboard_layout() -> CapsLockKeyboardLayout {
+        let keyboard_type = unsafe { GetKeyboardType(0) };
         let layer_driver = Self::registry_string_value(
             HKEY_LOCAL_MACHINE,
             w!("SYSTEM\\CurrentControlSet\\Services\\i8042prt\\Parameters"),
@@ -347,7 +374,8 @@ impl TextServiceFactory {
             w!("OverrideKeyboardIdentifier"),
         );
 
-        Self::caps_lock_keyboard_layout_from_hardware_registry(
+        Self::caps_lock_keyboard_layout_from_sources(
+            Some(keyboard_type),
             layer_driver.as_deref(),
             keyboard_identifier.as_deref(),
         )

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -336,27 +336,50 @@ fn eisu_shortcut_matches_ms_ime_capslock_rules_by_keyboard_layout() {
 }
 
 #[test]
-fn keyboard_layout_hardware_registry_maps_japanese_default_and_english_override() {
+fn keyboard_layout_uses_current_keyboard_type_before_legacy_registry_override() {
     assert_eq!(
-        TextServiceFactory::caps_lock_keyboard_layout_from_hardware_registry(None, None),
+        TextServiceFactory::caps_lock_keyboard_layout_from_sources(
+            Some(4),
+            Some("kbd106.dll"),
+            Some("PCAT_106KEY")
+        ),
+        CapsLockKeyboardLayout::English
+    );
+    assert_eq!(
+        TextServiceFactory::caps_lock_keyboard_layout_from_sources(
+            Some(7),
+            Some("kbd101.dll"),
+            Some("PCAT_101KEY")
+        ),
+        CapsLockKeyboardLayout::Japanese
+    );
+}
+
+#[test]
+fn keyboard_layout_falls_back_to_hardware_registry_for_unknown_keyboard_type() {
+    assert_eq!(
+        TextServiceFactory::caps_lock_keyboard_layout_from_sources(None, None, None),
         CapsLockKeyboardLayout::Japanese
     );
     assert_eq!(
-        TextServiceFactory::caps_lock_keyboard_layout_from_hardware_registry(
+        TextServiceFactory::caps_lock_keyboard_layout_from_sources(
+            Some(0x51),
             Some("kbd106.dll"),
             Some("PCAT_106KEY")
         ),
         CapsLockKeyboardLayout::Japanese
     );
     assert_eq!(
-        TextServiceFactory::caps_lock_keyboard_layout_from_hardware_registry(
+        TextServiceFactory::caps_lock_keyboard_layout_from_sources(
+            Some(0x51),
             Some("kbd101.dll"),
             Some("PCAT_101KEY")
         ),
         CapsLockKeyboardLayout::English
     );
     assert_eq!(
-        TextServiceFactory::caps_lock_keyboard_layout_from_hardware_registry(
+        TextServiceFactory::caps_lock_keyboard_layout_from_sources(
+            Some(0x51),
             None,
             Some("PCAT_101KEY")
         ),

--- a/crates/client/src/tsf/text_input_proccesor.rs
+++ b/crates/client/src/tsf/text_input_proccesor.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
 use crate::{
-    engine::{ipc_service, state::IMEState},
+    engine::{composition::CapsLockKeyboardLayout, ipc_service, state::IMEState},
     globals::{DllModule, GUID_DISPLAY_ATTRIBUTE, GUID_PRESERVED_KEY_EISU_CAPSLOCK_ANY_MODIFIER},
 };
 
-use super::factory::TextServiceFactory_Impl;
+use super::factory::{TextServiceFactory, TextServiceFactory_Impl};
 use windows::{
     core::Interface as _,
     Win32::{
@@ -15,7 +15,7 @@ use windows::{
             CLSID_TF_CategoryMgr, ITfCategoryMgr, ITfKeyEventSink, ITfKeystrokeMgr,
             ITfLangBarItemButton, ITfLangBarItemMgr, ITfSource, ITfTextInputProcessorEx_Impl,
             ITfTextInputProcessor_Impl, ITfThreadFocusSink, ITfThreadMgr, ITfThreadMgrEventSink,
-            TF_MOD_IGNORE_ALL_MODIFIER, TF_PRESERVEDKEY,
+            TF_MOD_IGNORE_ALL_MODIFIER, TF_MOD_SHIFT, TF_PRESERVEDKEY,
         },
     },
 };
@@ -191,35 +191,64 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
     }
 }
 
-fn eisu_capslock_preserved_keys() -> [(windows::core::GUID, TF_PRESERVEDKEY); 1] {
-    [(
-        GUID_PRESERVED_KEY_EISU_CAPSLOCK_ANY_MODIFIER,
+fn eisu_capslock_preserved_key_for_layout(
+    keyboard_layout: CapsLockKeyboardLayout,
+) -> TF_PRESERVEDKEY {
+    TF_PRESERVEDKEY {
+        uVKey: 0x14,
+        uModifiers: match keyboard_layout {
+            CapsLockKeyboardLayout::Japanese => 0,
+            CapsLockKeyboardLayout::English => TF_MOD_SHIFT,
+        },
+    }
+}
+
+fn all_eisu_capslock_preserved_keys_to_unpreserve() -> [TF_PRESERVEDKEY; 3] {
+    [
+        eisu_capslock_preserved_key_for_layout(CapsLockKeyboardLayout::Japanese),
+        eisu_capslock_preserved_key_for_layout(CapsLockKeyboardLayout::English),
         TF_PRESERVEDKEY {
             uVKey: 0x14,
             uModifiers: TF_MOD_IGNORE_ALL_MODIFIER,
         },
-    )]
+    ]
 }
 
 fn preserve_eisu_keys(keystroke_mgr: &ITfKeystrokeMgr, tid: u32) {
     let description = "azooKey input mode toggle"
         .encode_utf16()
         .collect::<Vec<_>>();
-    for (guid, preserved_key) in eisu_capslock_preserved_keys() {
-        let result = unsafe { keystroke_mgr.PreserveKey(tid, &guid, &preserved_key, &description) };
+    let keyboard_layout = TextServiceFactory::current_caps_lock_keyboard_layout();
+    let preserved_key = eisu_capslock_preserved_key_for_layout(keyboard_layout);
+    let result = unsafe {
+        keystroke_mgr.PreserveKey(
+            tid,
+            &GUID_PRESERVED_KEY_EISU_CAPSLOCK_ANY_MODIFIER,
+            &preserved_key,
+            &description,
+        )
+    };
 
-        if let Err(error) = result {
-            tracing::warn!(?error, ?guid, "Failed to preserve CapsLock eisu shortcut");
-        }
+    if let Err(error) = result {
+        tracing::warn!(
+            ?error,
+            ?keyboard_layout,
+            "Failed to preserve CapsLock eisu shortcut"
+        );
     }
 }
 
 fn unpreserve_eisu_keys(keystroke_mgr: &ITfKeystrokeMgr) {
-    for (guid, preserved_key) in eisu_capslock_preserved_keys() {
-        let result = unsafe { keystroke_mgr.UnpreserveKey(&guid, &preserved_key) };
+    for preserved_key in all_eisu_capslock_preserved_keys_to_unpreserve() {
+        let result = unsafe {
+            keystroke_mgr.UnpreserveKey(
+                &GUID_PRESERVED_KEY_EISU_CAPSLOCK_ANY_MODIFIER,
+                &preserved_key,
+            )
+        };
 
         if let Err(error) = result {
-            tracing::debug!(?error, ?guid, "Failed to unpreserve CapsLock eisu shortcut");
+            tracing::debug!(?error, "Failed to unpreserve CapsLock eisu shortcut");
         }
     }
 }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -532,16 +532,16 @@ mod tests {
     }
 
     #[test]
-    fn shortcut_toggles_default_to_on() {
+    fn shortcut_toggles_default_to_expected_values() {
         let default_config = ShortcutConfig::default();
         assert!(default_config.ctrl_space_toggle);
         assert!(default_config.alt_backquote_toggle);
-        assert!(default_config.eisu_toggle);
+        assert!(!default_config.eisu_toggle);
 
         let deserialized: ShortcutConfig = serde_json::from_str("{}").unwrap();
         assert!(deserialized.ctrl_space_toggle);
         assert!(deserialized.alt_backquote_toggle);
-        assert!(deserialized.eisu_toggle);
+        assert!(!deserialized.eisu_toggle);
     }
 
     #[test]
@@ -769,7 +769,7 @@ pub struct ShortcutConfig {
     pub ctrl_space_toggle: bool,
     #[serde(default = "default_shortcut_enabled")]
     pub alt_backquote_toggle: bool,
-    #[serde(default = "default_shortcut_enabled")]
+    #[serde(default)]
     pub eisu_toggle: bool,
 }
 
@@ -867,7 +867,7 @@ impl Default for ShortcutConfig {
         Self {
             ctrl_space_toggle: true,
             alt_backquote_toggle: true,
-            eisu_toggle: true,
+            eisu_toggle: false,
         }
     }
 }

--- a/frontend/src/pages/general.tsx
+++ b/frontend/src/pages/general.tsx
@@ -241,7 +241,7 @@ export const General = () => {
     const [shortcutValue, setShortcutValue] = useState({
         ctrlSpaceToggle: true,
         altBackquoteToggle: true,
-        eisuToggle: true,
+        eisuToggle: false,
     });
     const [generalValue, setGeneralValue] = useState<GeneralConfigState>(
         DEFAULT_GENERAL_CONFIG,
@@ -268,7 +268,7 @@ export const General = () => {
                 setShortcutValue({
                     ctrlSpaceToggle: shortcuts.ctrl_space_toggle ?? true,
                     altBackquoteToggle: shortcuts.alt_backquote_toggle ?? true,
-                    eisuToggle: shortcuts.eisu_toggle ?? true,
+                    eisuToggle: shortcuts.eisu_toggle ?? false,
                 });
 
                 setGeneralValue(normalizeGeneralConfig(data.general));

--- a/installer/Installer.iss
+++ b/installer/Installer.iss
@@ -34,12 +34,7 @@ DisableProgramGroupPage=yes
 ;PrivilegesRequired=lowest
 OutputDir=../build
 OutputBaseFilename=azookey-setup
-#ifdef LocalFastInstaller
-Compression=zip
-SolidCompression=no
-#else
 SolidCompression=yes
-#endif
 WizardStyle=modern
 PrivilegesRequired=admin
 CloseApplications=yes

--- a/scripts/vm_build.sh
+++ b/scripts/vm_build.sh
@@ -16,16 +16,6 @@ SSH_PORT="${SSH_PORT:-}"
 SSH_KEY="${SSH_KEY:-}"
 VBOX_MANAGE="${VBOX_MANAGE:-}"
 STAGING_VM_NAME="${STAGING_VM_NAME:-}"
-VM_CACHE_DISK_PATH="${VM_CACHE_DISK_PATH:-}"
-VM_CACHE_DISK_REQUIRED="${VM_CACHE_DISK_REQUIRED:-0}"
-VM_CACHE_DISK_SIZE_MB="${VM_CACHE_DISK_SIZE_MB:-65536}"
-VM_CACHE_STORAGE_CONTROLLER="${VM_CACHE_STORAGE_CONTROLLER:-SATA}"
-VM_CACHE_DISK_PORT="${VM_CACHE_DISK_PORT:-2}"
-VM_CACHE_GUEST_DISK_NUMBER="${VM_CACHE_GUEST_DISK_NUMBER:-}"
-VM_CACHE_DRIVE_LETTER="${VM_CACHE_DRIVE_LETTER:-Z}"
-VM_CACHE_VOLUME_LABEL="${VM_CACHE_VOLUME_LABEL:-AZOOKEYCACHE}"
-VM_BUILD_CACHE_ROOT_WIN="${VM_BUILD_CACHE_ROOT_WIN:-}"
-VM_FAST_INSTALLER="${VM_FAST_INSTALLER:-0}"
 
 if [[ -z "$VBOX_MANAGE" ]]; then
   if command -v VBoxManage >/dev/null 2>&1; then
@@ -64,7 +54,7 @@ LOCAL_ARTIFACT="$ARTIFACT_DIR/azookey-setup-${TARGET_BRANCH_SLUG}-$TIMESTAMP.exe
 REMOTE_TMP_WIN="C:\\Users\\$SSH_USER\\AppData\\Local\\Temp"
 REMOTE_TAR_WIN="$REMOTE_TMP_WIN\\azookey-src.tar.gz"
 REMOTE_PS_WIN="$REMOTE_TMP_WIN\\azookey-vm-build.ps1"
-REMOTE_SRC_WIN="${REMOTE_SRC_WIN:-C:\\work\\azookey-src}"
+REMOTE_SRC_WIN="C:\\work\\azookey-src-$TIMESTAMP"
 REMOTE_ART_WIN="C:\\work\\artifacts"
 
 REMOTE_TAR_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-src.tar.gz"
@@ -97,17 +87,17 @@ vbox() {
 
 matches_fixed() {
   if command -v rg >/dev/null 2>&1; then
-    rg -F "$1" >/dev/null
+    rg -F "$1" -q
   else
-    grep -F "$1" >/dev/null
+    grep -F "$1" -q
   fi
 }
 
 matches_regex() {
   if command -v rg >/dev/null 2>&1; then
-    rg "$1" >/dev/null
+    rg -q "$1"
   else
-    grep -- "$1" >/dev/null
+    grep -q -- "$1"
   fi
 }
 
@@ -124,173 +114,14 @@ snapshot_exists() {
   vbox snapshot "$VM_NAME" list --machinereadable | matches_fixed "=\"$SNAPSHOT_NAME\""
 }
 
-host_path_for_vbox() {
-  local path="$1"
-  if [[ "$path" == /* ]] && command -v wslpath >/dev/null 2>&1; then
-    wslpath -w "$path"
-  else
-    printf '%s\n' "$path"
-  fi
-}
-
-machine_cfg_file() {
-  vbox showvminfo "$VM_NAME" --machinereadable |
-    awk -F= '$1 == "CfgFile" { value=$2 } END { gsub(/"/, "", value); print value }'
-}
-
-machine_snapshot_dir() {
-  vbox showvminfo "$VM_NAME" --machinereadable |
-    awk -F= '$1 == "SnapFldr" { value=$2 } END { gsub(/"/, "", value); print value }'
-}
-
-ensure_vm_cache_disk() {
-  if [[ -z "$VM_CACHE_DISK_PATH" ]]; then
-    return 0
-  fi
-
-  if [[ "$VM_CACHE_DISK_PATH" == /* ]]; then
-    mkdir -p "$(dirname "$VM_CACHE_DISK_PATH")"
-  fi
-
-  local cache_disk
-  cache_disk="$(host_path_for_vbox "$VM_CACHE_DISK_PATH")"
-  cache_disk="${cache_disk//$'\r'/}"
-
-  local info vm_state current_key current_medium cache_disk_cmp current_medium_cmp required_port_count current_port_count
-  info="$(vbox showvminfo "$VM_NAME" --machinereadable)"
-  vm_state="$(printf '%s\n' "$info" | awk -F= '$1 == "VMState" { gsub(/"/, "", $2); print $2 }')"
-  vm_state="${vm_state//$'\r'/}"
-  current_key="\"${VM_CACHE_STORAGE_CONTROLLER}-${VM_CACHE_DISK_PORT}-0\""
-  current_medium="$(printf '%s\n' "$info" |
-    awk -F= -v key="$current_key" '$1 == key { gsub(/^"/, "", $2); gsub(/"$/, "", $2); print $2; exit }')"
-  current_medium="${current_medium//$'\r'/}"
-  current_medium="${current_medium//\"/}"
-  current_medium="${current_medium//\\\\/\\}"
-  cache_disk_cmp="$(printf '%s' "$cache_disk" | tr '[:upper:]' '[:lower:]')"
-  current_medium_cmp="$(printf '%s' "$current_medium" | tr '[:upper:]' '[:lower:]')"
-
-  if [[ "$current_medium_cmp" == "$cache_disk_cmp" ]]; then
-    return 0
-  fi
-
-  if [[ "$vm_state" == "saved" ]]; then
-    log "保存状態の VM には cache disk を後付けできないため、この実行では cache disk をスキップします: $cache_disk"
-    if [[ "$VM_CACHE_DISK_REQUIRED" == "1" ]]; then
-      exit 1
-    fi
-    return 0
-  fi
-
-  if ! vbox showmediuminfo disk "$cache_disk" >/dev/null 2>&1; then
-    if [[ "$VM_CACHE_DISK_PATH" == /* && -f "$VM_CACHE_DISK_PATH" ]]; then
-      log "既存の cache disk を登録します: $cache_disk"
-      vbox openmedium disk "$cache_disk" >/dev/null
-    else
-      log "cache disk を作成します: $cache_disk (${VM_CACHE_DISK_SIZE_MB}MB)"
-      vbox createmedium disk --filename "$cache_disk" --size "$VM_CACHE_DISK_SIZE_MB" --format VDI >/dev/null
-    fi
-    vbox modifymedium disk "$cache_disk" --type writethrough >/dev/null
-  fi
-
-  if [[ -n "$current_medium" && "$current_medium" != "none" ]]; then
-    log "cache disk 用 port が使用中です: ${VM_CACHE_STORAGE_CONTROLLER}-${VM_CACHE_DISK_PORT}-0 -> $current_medium"
-    exit 1
-  fi
-
-  required_port_count=$((VM_CACHE_DISK_PORT + 1))
-  current_port_count="$(printf '%s\n' "$info" |
-    awk -F= -v controller="$VM_CACHE_STORAGE_CONTROLLER" '
-      {
-        key=$1; value=$2;
-        gsub(/^"/, "", value); gsub(/"$/, "", value);
-        if (key ~ /^storagecontrollername[0-9]+$/ && value == controller) {
-          idx=key; sub(/^storagecontrollername/, "", idx); controller_idx=idx;
-        }
-        if (key ~ /^storagecontrollerportcount[0-9]+$/) {
-          idx=key; sub(/^storagecontrollerportcount/, "", idx); port_count[idx]=value;
-        }
-      }
-      END {
-        if (controller_idx != "") print port_count[controller_idx];
-      }')"
-  current_port_count="${current_port_count//$'\r'/}"
-  if [[ ! "$current_port_count" =~ ^[0-9]+$ ]]; then
-    log "storage controller の port count が取得できません: $VM_CACHE_STORAGE_CONTROLLER"
-    exit 1
-  fi
-  if (( current_port_count < required_port_count )); then
-    vbox storagectl "$VM_NAME" --name "$VM_CACHE_STORAGE_CONTROLLER" --portcount "$required_port_count" >/dev/null
-  fi
-  log "cache disk を VM に接続します: $cache_disk"
-  vbox storageattach "$VM_NAME" \
-    --storagectl "$VM_CACHE_STORAGE_CONTROLLER" \
-    --port "$VM_CACHE_DISK_PORT" \
-    --device 0 \
-    --type hdd \
-    --medium "$cache_disk" >/dev/null
-}
-
-prune_orphan_leaf_media() {
+prune_orphan_media_after_restore() {
   if [[ "$PRUNE_ORPHAN_MEDIA_AFTER_RESTORE" != "1" ]]; then
     return 0
   fi
 
-  local cfg_file vm_dir snapshot_dir
-  cfg_file="$(machine_cfg_file)"
-  cfg_file="${cfg_file//\\\\/\\}"
-  if [[ -z "$cfg_file" ]]; then
-    log "VM 設定ファイルが取得できないため orphan media prune をスキップします"
-    return 0
+  if ! "$REPO_ROOT/scripts/vm_prune_orphan_media.sh" "$VM_NAME"; then
+    log "orphan media prune に失敗しました。処理を続行します"
   fi
-  vm_dir="${cfg_file%\\*}"
-  snapshot_dir="$(machine_snapshot_dir)"
-  snapshot_dir="${snapshot_dir//\\\\/\\}"
-  if [[ -z "$snapshot_dir" ]]; then
-    snapshot_dir="$vm_dir\\Snapshots"
-  fi
-
-  local candidates=()
-  mapfile -t candidates < <(
-    vbox list hdds --long | tr -d '\r' |
-      SNAPSHOT_DIR="$snapshot_dir" awk '
-        BEGIN {
-          RS="\n\n"; FS="\n";
-          snapshot_dir = ENVIRON["SNAPSHOT_DIR"];
-          gsub(/\\/, "/", snapshot_dir);
-          gsub(/\/+$/, "", snapshot_dir);
-          snapshot_dir = tolower(snapshot_dir "/");
-        }
-        {
-          uuid=""; loc=""; size=""; use="no"; child="no";
-          for (i=1; i<=NF; i++) {
-            line=$i;
-            if (line ~ /^UUID:/) { sub(/^UUID:[[:space:]]*/, "", line); uuid=line }
-            if (line ~ /^Location:/) { sub(/^Location:[[:space:]]*/, "", line); loc=line }
-            if (line ~ /^Size on disk:/) { sub(/^Size on disk:[[:space:]]*/, "", line); size=line }
-            if (line ~ /^In use by VMs:/) { use="yes" }
-            if (line ~ /^Child UUIDs:/) { child="yes" }
-          }
-          loc_norm = loc;
-          gsub(/\\/, "/", loc_norm);
-          loc_norm_lc = tolower(loc_norm);
-          in_scope = (index(loc_norm_lc, snapshot_dir) == 1);
-          if (uuid != "" && use == "no" && child == "no" && in_scope && loc_norm ~ /\.vdi$/) {
-            print uuid "\t" size "\t" loc
-          }
-        }'
-  )
-
-  if (( ${#candidates[@]} == 0 )); then
-    log "未接続 leaf VDI はありません"
-    return 0
-  fi
-
-  local entry uuid size loc
-  for entry in "${candidates[@]}"; do
-    IFS=$'\t' read -r uuid size loc <<<"$entry"
-    log "未接続 leaf VDI を削除します: $uuid ($size) $loc"
-    vbox closemedium disk "$uuid" --delete </dev/null
-  done
 }
 
 ssh_run() {
@@ -387,8 +218,7 @@ cleanup() {
       if [[ "$DISCARD_SAVED_STATE_BEFORE_BUILD" == "1" ]]; then
         vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
       fi
-      ensure_vm_cache_disk || true
-      prune_orphan_leaf_media || true
+      prune_orphan_media_after_restore
       FINAL_RESTORE_DONE=1
     else
       log "復元対象スナップショットが見つからないためスキップします: $SNAPSHOT_NAME"
@@ -496,159 +326,18 @@ param(
   [Parameter(Mandatory = $true)][string]$SourceTarPath,
   [Parameter(Mandatory = $true)][string]$SourceDir,
   [Parameter(Mandatory = $true)][string]$ArtifactDir,
-  [Parameter(Mandatory = $true)][string]$HostTimestampUtc,
-  [Parameter(Mandatory = $false)][string]$CacheDriveLetter = "Z",
-  [Parameter(Mandatory = $false)][string]$CacheVolumeLabel = "AZOOKEYCACHE",
-  [Parameter(Mandatory = $false)][string]$CacheRootOverride = "",
-  [Parameter(Mandatory = $false)][string]$FastInstaller = "0",
-  [Parameter(Mandatory = $false)][string]$CacheDiskNumber = ""
+  [Parameter(Mandatory = $true)][string]$HostTimestampUtc
 )
 
 $ErrorActionPreference = "Stop"
 $env:Path += ";$env:USERPROFILE\\.cargo\\bin"
-if ($FastInstaller -eq "1") {
-  $env:AZOOKEY_FAST_INSTALLER = "1"
-} else {
-  Remove-Item Env:AZOOKEY_FAST_INSTALLER -ErrorAction SilentlyContinue
-}
 
 $LLAMA_CPU_URL = "https://github.com/fkunn1326/llama.cpp/releases/download/b4846/llama-b4846-bin-win-avx-x64.zip"
 $LLAMA_CUDA_URL = "https://github.com/fkunn1326/llama.cpp/releases/download/b4846/llama-b4846-bin-win-cuda-cu12.4-x64.zip"
 $LLAMA_VULKAN_URL = "https://github.com/fkunn1326/llama.cpp/releases/download/b4846/llama-b4846-bin-win-vulkan-x64.zip"
 $ZENZ_MODEL_URL = "https://huggingface.co/Miwa-Keita/zenz-v3-small-gguf/resolve/main/ggml-model-Q5_K_M.gguf"
 $downloadAllAssets = $env:DOWNLOAD_ALL_ASSETS -eq "1"
-$fallbackCacheRoot = "C:\work\azooKey-Windows"
-$script:StepTimings = New-Object System.Collections.Generic.List[object]
-
-function Measure-Step {
-  param(
-    [string]$Name,
-    [scriptblock]$Action
-  )
-  $sw = [System.Diagnostics.Stopwatch]::StartNew()
-  Write-Host "[timing] begin $Name"
-  try {
-    & $Action
-  } finally {
-    $sw.Stop()
-    $seconds = [Math]::Round($sw.Elapsed.TotalSeconds, 3)
-    $script:StepTimings.Add([pscustomobject]@{
-      Name = $Name
-      Seconds = $seconds
-    }) | Out-Null
-    Write-Host "[timing] end $Name ${seconds}s"
-  }
-}
-
-function Initialize-BuildCacheRoot {
-  param(
-    [string]$DriveLetter,
-    [string]$VolumeLabel,
-    [string]$RootOverride,
-    [string]$FallbackRoot,
-    [string]$DiskNumber
-  )
-
-  if (![string]::IsNullOrWhiteSpace($RootOverride)) {
-    New-Item -Path $RootOverride -ItemType Directory -Force | Out-Null
-    return $RootOverride
-  }
-
-  $drive = $DriveLetter.TrimEnd(":")
-  $volume = Get-Volume -FileSystemLabel $VolumeLabel -ErrorAction SilentlyContinue | Select-Object -First 1
-  if (!$volume -and ![string]::IsNullOrWhiteSpace($DiskNumber)) {
-    $rawDiskNumber = [int]$DiskNumber
-    $rawDisk = Get-Disk -Number $rawDiskNumber -ErrorAction Stop
-    if ($rawDisk.PartitionStyle -ne "RAW") {
-      throw "cache disk #$rawDiskNumber is not RAW; refusing to format it as $VolumeLabel"
-    }
-
-    Write-Host "initializing explicitly selected build cache disk #$rawDiskNumber as ${drive}: ($VolumeLabel)"
-    Initialize-Disk -Number $rawDiskNumber -PartitionStyle GPT -PassThru | Out-Null
-    $partition = New-Partition -DiskNumber $rawDiskNumber -UseMaximumSize -DriveLetter $drive
-    Format-Volume -Partition $partition -FileSystem NTFS -NewFileSystemLabel $VolumeLabel -Confirm:$false | Out-Null
-    $volume = Get-Volume -DriveLetter $drive
-  } elseif (!$volume) {
-    Write-Host "cache disk volume not found and no explicit guest disk number was provided; falling back to $FallbackRoot"
-  }
-
-  if ($volume) {
-    $cacheDrive = $drive
-    if (![string]::IsNullOrWhiteSpace($volume.DriveLetter)) {
-      $cacheDrive = $volume.DriveLetter
-    }
-    $root = "${cacheDrive}:\azookey-build-cache"
-    New-Item -Path $root -ItemType Directory -Force | Out-Null
-    return $root
-  }
-
-  Write-Host "build cache disk not found; falling back to $FallbackRoot"
-  New-Item -Path $FallbackRoot -ItemType Directory -Force | Out-Null
-  return $FallbackRoot
-}
-
-function Reset-Path {
-  param([string]$Path)
-  if (Test-Path $Path) {
-    Remove-Item -Path $Path -Recurse -Force
-  }
-}
-
-function New-Junction {
-  param(
-    [string]$Path,
-    [string]$Target
-  )
-  New-Item -Path $Target -ItemType Directory -Force | Out-Null
-  Reset-Path -Path $Path
-  New-Item -ItemType Junction -Path $Path -Target $Target | Out-Null
-}
-
-function Use-NodeModulesCache {
-  param(
-    [string]$FrontendDir,
-    [string]$CacheRoot
-  )
-
-  $packageLock = Join-Path $FrontendDir "package-lock.json"
-  if (!(Test-Path $packageLock)) {
-    throw "package-lock.json not found: $packageLock"
-  }
-
-  $hash = (Get-FileHash -Algorithm SHA256 -Path $packageLock).Hash.ToLowerInvariant()
-  $cacheDir = Join-Path $CacheRoot "node_modules\$hash"
-  $nodeModules = Join-Path $FrontendDir "node_modules"
-
-  $sentinel = Join-Path $cacheDir ".azookey-node-modules-ready"
-  $cacheHashMarker = Join-Path $cacheDir ".azookey-package-lock.sha256"
-  if ((Test-Path $sentinel) -and (Test-Path $cacheHashMarker)) {
-    New-Junction -Path $nodeModules -Target $cacheDir
-    Write-Host "reused node_modules cache: $cacheDir"
-    return
-  }
-
-  if (Test-Path $sentinel) {
-    Write-Host "node_modules cache sentinel exists but cache content is incomplete; rebuilding: $cacheDir"
-  }
-
-  Write-Host "running npm ci before caching node_modules: $cacheDir"
-  Reset-Path -Path $nodeModules
-  Reset-Path -Path $cacheDir
-  Push-Location $FrontendDir
-  try {
-    npm.cmd ci --prefer-offline --no-audit
-    if ($LASTEXITCODE -ne 0) {
-      throw "npm ci failed with exit code $LASTEXITCODE"
-    }
-    New-Item -Path (Split-Path -Parent $cacheDir) -ItemType Directory -Force | Out-Null
-    Move-Item -LiteralPath $nodeModules -Destination $cacheDir
-    Set-Content -LiteralPath $cacheHashMarker -Encoding ASCII -Value $hash
-    Set-Content -LiteralPath $sentinel -Encoding ASCII -Value $hash
-    New-Junction -Path $nodeModules -Target $cacheDir
-  } finally {
-    Pop-Location
-  }
-}
+$cacheRoot = "C:\work\azooKey-Windows"
 
 function Sync-GuestClock {
   param([string]$TimestampUtc)
@@ -716,37 +405,15 @@ function Replace-TreeFromCache {
   return $true
 }
 
-$cacheRoot = Initialize-BuildCacheRoot `
-  -DriveLetter $CacheDriveLetter `
-  -VolumeLabel $CacheVolumeLabel `
-  -RootOverride $CacheRootOverride `
-  -FallbackRoot $fallbackCacheRoot `
-  -DiskNumber $CacheDiskNumber
-Write-Host "build cache root: $cacheRoot"
-
-$env:CARGO_TARGET_DIR = Join-Path $cacheRoot "cargo-target"
-$env:npm_config_cache = Join-Path $cacheRoot "npm-cache"
-New-Item -Path $env:CARGO_TARGET_DIR -ItemType Directory -Force | Out-Null
-New-Item -Path $env:npm_config_cache -ItemType Directory -Force | Out-Null
-Write-Host "CARGO_TARGET_DIR=$env:CARGO_TARGET_DIR"
-Write-Host "npm_config_cache=$env:npm_config_cache"
-
-Measure-Step "extract source" {
-  Reset-Path -Path $SourceDir
-  New-Item -Path $SourceDir -ItemType Directory -Force | Out-Null
-  tar -xzf $SourceTarPath -C $SourceDir
-  if ($LASTEXITCODE -ne 0) {
-    throw "tar extraction failed with exit code $LASTEXITCODE"
-  }
+if (Test-Path $SourceDir) {
+  Remove-Item -Recurse -Force $SourceDir
 }
+New-Item -Path $SourceDir -ItemType Directory -Force | Out-Null
+
+tar -xzf $SourceTarPath -C $SourceDir
 Set-Location $SourceDir
 Write-Host "source extracted: $SourceDir"
 Sync-GuestClock -TimestampUtc $HostTimestampUtc
-
-$sourceSwiftBuildDir = Join-Path $SourceDir "server-swift\.build"
-$cachedSwiftBuildDir = Join-Path $cacheRoot "swift-build"
-New-Junction -Path $sourceSwiftBuildDir -Target $cachedSwiftBuildDir
-Write-Host "swift .build cache: $cachedSwiftBuildDir"
 
 $llamaCpuDir = Join-Path $SourceDir "llama_cpu"
 $llamaCudaDir = Join-Path $SourceDir "llama_cuda"
@@ -797,12 +464,14 @@ if ($downloadAllAssets) {
   New-Item -Path $llamaVulkanDir -ItemType Directory -Force | Out-Null
 
   if (!(Test-Path (Join-Path $llamaCudaDir "llama.dll"))) {
-    Copy-Item (Join-Path $llamaCpuDir "llama.dll") -Destination (Join-Path $llamaCudaDir "llama.dll") -Force
-    Write-Host "created minimal llama cuda assets for fast local build"
+    if (!(Copy-TreeIfExists -SourceDir (Join-Path $cacheRoot "llama_cuda") -DestDir $llamaCudaDir)) {
+      Copy-Item (Join-Path $llamaCpuDir "llama.dll") -Destination (Join-Path $llamaCudaDir "llama.dll") -Force
+    }
   }
   if (!(Test-Path (Join-Path $llamaVulkanDir "llama.dll"))) {
-    Copy-Item (Join-Path $llamaCpuDir "llama.dll") -Destination (Join-Path $llamaVulkanDir "llama.dll") -Force
-    Write-Host "created minimal llama vulkan assets for fast local build"
+    if (!(Copy-TreeIfExists -SourceDir (Join-Path $cacheRoot "llama_vulkan") -DestDir $llamaVulkanDir)) {
+      Copy-Item (Join-Path $llamaCpuDir "llama.dll") -Destination (Join-Path $llamaVulkanDir "llama.dll") -Force
+    }
   }
   if (!(Test-Path $zenzPath)) {
     $cachedZenzPath = Join-Path $cacheRoot "zenz.gguf"
@@ -822,12 +491,10 @@ $cachedMainDictDir = Join-Path $cacheRoot "server-swift\\azooKey_dictionary_stor
 # NOTE:
 # WSL(tar) -> Windows(tar -xzf) で日本語ファイル名が壊れる環境があるため、
 # 辞書は Windows 側 clone のキャッシュを優先して上書きする。
-$emojiDictReused = Replace-TreeFromCache -CacheDir $cachedEmojiDictDir -DestDir $emojiDictDir -Label "emoji dictionary"
-if (-not $emojiDictReused) {
+if (!(Replace-TreeFromCache -CacheDir $cachedEmojiDictDir -DestDir $emojiDictDir -Label "emoji dictionary")) {
   Write-Host "emoji dictionary cache not found; using extracted source files"
 }
-$mainDictReused = Replace-TreeFromCache -CacheDir $cachedMainDictDir -DestDir $mainDictDir -Label "main dictionary"
-if (-not $mainDictReused) {
+if (!(Replace-TreeFromCache -CacheDir $cachedMainDictDir -DestDir $mainDictDir -Label "main dictionary")) {
   Write-Host "main dictionary cache not found; using extracted source files"
 }
 
@@ -915,25 +582,17 @@ if (-not (Get-Command cargo-make -ErrorAction SilentlyContinue)) {
   cargo install --locked cargo-make
 }
 
-Measure-Step "prepare node_modules" {
-  Use-NodeModulesCache -FrontendDir (Join-Path $SourceDir "frontend") -CacheRoot $cacheRoot
-}
+Set-Location (Join-Path $SourceDir "frontend")
+Write-Host "running npm ci"
+npm.cmd ci --prefer-offline --no-audit
 
 Set-Location $SourceDir
-Measure-Step "cargo make build --release" {
-  cargo make build --release
-  if ($LASTEXITCODE -ne 0) {
-    throw "cargo make build failed with exit code $LASTEXITCODE"
-  }
-}
+Write-Host "running cargo make build --release"
+cargo make build --release
 
 New-Item -Path $ArtifactDir -ItemType Directory -Force | Out-Null
 Copy-Item (Join-Path $SourceDir "build\\azookey-setup.exe") -Destination (Join-Path $ArtifactDir "azookey-setup.exe") -Force
 Write-Host "build finished: $ArtifactDir\\azookey-setup.exe"
-Write-Host "[timing] summary"
-foreach ($item in $script:StepTimings) {
-  Write-Host ("[timing] {0}: {1}s" -f $item.Name, $item.Seconds)
-}
 PS1
 }
 
@@ -964,14 +623,11 @@ main() {
       if [[ "$DISCARD_SAVED_STATE_BEFORE_BUILD" == "1" ]]; then
         vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
       fi
-      ensure_vm_cache_disk
-      prune_orphan_leaf_media
+      prune_orphan_media_after_restore
     else
       log "復元対象スナップショットが見つからないためスキップします: $SNAPSHOT_NAME"
     fi
   fi
-
-  ensure_vm_cache_disk
 
   if ! is_vm_running; then
     VM_TOUCHED=1
@@ -992,7 +648,7 @@ main() {
   scp_to_vm "$TMP_REMOTE_PS" "$REMOTE_PS_SCP"
 
   log "VM 上でビルドを実行します（時間がかかる場合があります）"
-  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -SourceTarPath \"$REMOTE_TAR_WIN\" -SourceDir \"$REMOTE_SRC_WIN\" -ArtifactDir \"$REMOTE_ART_WIN\" -HostTimestampUtc \"$HOST_TIMESTAMP_UTC\" -CacheDriveLetter \"$VM_CACHE_DRIVE_LETTER\" -CacheVolumeLabel \"$VM_CACHE_VOLUME_LABEL\" -CacheRootOverride \"$VM_BUILD_CACHE_ROOT_WIN\" -FastInstaller \"$VM_FAST_INSTALLER\" -CacheDiskNumber \"$VM_CACHE_GUEST_DISK_NUMBER\""
+  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -SourceTarPath \"$REMOTE_TAR_WIN\" -SourceDir \"$REMOTE_SRC_WIN\" -ArtifactDir \"$REMOTE_ART_WIN\" -HostTimestampUtc \"$HOST_TIMESTAMP_UTC\""
 
   log "成果物を WSL 側へ回収します"
   scp_from_vm "$REMOTE_ART_SCP" "$LOCAL_ARTIFACT"
@@ -1011,8 +667,7 @@ main() {
       if [[ "$DISCARD_SAVED_STATE_BEFORE_BUILD" == "1" ]]; then
         vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
       fi
-      ensure_vm_cache_disk
-      prune_orphan_leaf_media
+      prune_orphan_media_after_restore
       FINAL_RESTORE_DONE=1
     else
       log "復元対象スナップショットが見つからないためスキップします: $SNAPSHOT_NAME"

--- a/scripts/vm_prune_orphan_media.sh
+++ b/scripts/vm_prune_orphan_media.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VM_NAME="${1:-}"
+VBOX_MANAGE="${VBOX_MANAGE:-}"
+
+if [[ -z "$VM_NAME" ]]; then
+  echo "Usage: VBOX_MANAGE=... $0 <VM_NAME>" >&2
+  exit 1
+fi
+
+if [[ -z "$VBOX_MANAGE" ]]; then
+  if command -v VBoxManage >/dev/null 2>&1; then
+    VBOX_MANAGE="$(command -v VBoxManage)"
+  elif [[ -x "/mnt/c/Program Files/Oracle/VirtualBox/VBoxManage.exe" ]]; then
+    VBOX_MANAGE="/mnt/c/Program Files/Oracle/VirtualBox/VBoxManage.exe"
+  fi
+fi
+
+if [[ ! -x "$VBOX_MANAGE" ]]; then
+  echo "[vm-prune-orphan-media] VBoxManage が見つかりません。VBOX_MANAGE を設定してください: ${VBOX_MANAGE:-<unset>}" >&2
+  exit 1
+fi
+
+vbox() {
+  "$VBOX_MANAGE" "$@"
+}
+
+machine_cfg_file() {
+  vbox showvminfo "$VM_NAME" --machinereadable |
+    awk -F= '$1 == "CfgFile" { value=$2 } END { gsub(/"/, "", value); print value }'
+}
+
+machine_snapshot_dir() {
+  vbox showvminfo "$VM_NAME" --machinereadable |
+    awk -F= '$1 == "SnapFldr" { value=$2 } END { gsub(/"/, "", value); print value }'
+}
+
+log() {
+  printf '[vm-prune-orphan-media] %s\n' "$*"
+}
+
+cfg_file="$(machine_cfg_file)"
+cfg_file="${cfg_file//\\\\/\\}"
+if [[ -z "$cfg_file" ]]; then
+  log "VM 設定ファイルが取得できないため orphan media prune をスキップします"
+  exit 0
+fi
+
+vm_dir="${cfg_file%\\*}"
+snapshot_dir="$(machine_snapshot_dir)"
+snapshot_dir="${snapshot_dir//\\\\/\\}"
+if [[ -z "$snapshot_dir" ]]; then
+  snapshot_dir="$vm_dir\\Snapshots"
+fi
+
+candidates=()
+mapfile -t candidates < <(
+  vbox list hdds --long | tr -d '\r' |
+    SNAPSHOT_DIR="$snapshot_dir" awk '
+      BEGIN {
+        RS="\n\n"; FS="\n";
+        snapshot_dir = ENVIRON["SNAPSHOT_DIR"];
+        gsub(/\\/, "/", snapshot_dir);
+        gsub(/\/+$/, "", snapshot_dir);
+        snapshot_dir = tolower(snapshot_dir "/");
+      }
+      {
+        uuid=""; loc=""; size=""; use="no"; child="no";
+        for (i=1; i<=NF; i++) {
+          line=$i;
+          if (line ~ /^UUID:/) { sub(/^UUID:[[:space:]]*/, "", line); uuid=line }
+          if (line ~ /^Location:/) { sub(/^Location:[[:space:]]*/, "", line); loc=line }
+          if (line ~ /^Size on disk:/) { sub(/^Size on disk:[[:space:]]*/, "", line); size=line }
+          if (line ~ /^In use by VMs:/) { use="yes" }
+          if (line ~ /^Child UUIDs:/) { child="yes" }
+        }
+        loc_norm = loc;
+        gsub(/\\/, "/", loc_norm);
+        loc_norm_lc = tolower(loc_norm);
+        in_scope = (index(loc_norm_lc, snapshot_dir) == 1);
+        if (uuid != "" && use == "no" && child == "no" && in_scope && loc_norm ~ /\.vdi$/) {
+          print uuid "\t" size "\t" loc
+        }
+      }'
+)
+
+if (( ${#candidates[@]} == 0 )); then
+  log "未接続 leaf VDI はありません"
+  exit 0
+fi
+
+for entry in "${candidates[@]}"; do
+  IFS=$'\t' read -r uuid size loc <<<"$entry"
+  log "未接続 leaf VDI を削除します: $uuid ($size) $loc"
+  vbox closemedium disk "$uuid" --delete </dev/null
+done

--- a/scripts/vm_test_client_composition.sh
+++ b/scripts/vm_test_client_composition.sh
@@ -17,11 +17,6 @@ SSH_TEST_TIMEOUT_SEC="${SSH_TEST_TIMEOUT_SEC:-7200}"
 SCP_COMMAND_TIMEOUT_SEC="${SCP_COMMAND_TIMEOUT_SEC:-300}"
 VBOX_MANAGE="${VBOX_MANAGE:-}"
 STAGING_VM_NAME="${STAGING_VM_NAME:-}"
-VM_CACHE_DISK_PATH="${VM_CACHE_DISK_PATH:-}"
-VM_CACHE_DISK_REQUIRED="${VM_CACHE_DISK_REQUIRED:-0}"
-VM_CACHE_DISK_SIZE_MB="${VM_CACHE_DISK_SIZE_MB:-65536}"
-VM_CACHE_STORAGE_CONTROLLER="${VM_CACHE_STORAGE_CONTROLLER:-SATA}"
-VM_CACHE_DISK_PORT="${VM_CACHE_DISK_PORT:-2}"
 
 if [[ -z "$VBOX_MANAGE" ]]; then
   if command -v VBoxManage >/dev/null 2>&1; then
@@ -72,7 +67,7 @@ REMOTE_TMP_WIN="C:\\Users\\$SSH_USER\\AppData\\Local\\Temp"
 REMOTE_TAR_WIN="$REMOTE_TMP_WIN\\azookey-src.tar.gz"
 REMOTE_PS_WIN="$REMOTE_TMP_WIN\\azookey-vm-client-test.ps1"
 REMOTE_SWIFT_VENDOR_TAR_WIN="$REMOTE_TMP_WIN\\azookey-swift-vendor.tar.gz"
-REMOTE_SRC_WIN="${REMOTE_SRC_WIN:-C:\\w\\azt}"
+REMOTE_SRC_WIN="C:\\w\\azt-$TIMESTAMP"
 
 REMOTE_TAR_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-src.tar.gz"
 REMOTE_PS_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-vm-client-test.ps1"
@@ -128,17 +123,17 @@ vbox() {
 
 matches_fixed() {
   if command -v rg >/dev/null 2>&1; then
-    rg -F "$1" >/dev/null
+    rg -F "$1" -q
   else
-    grep -F "$1" >/dev/null
+    grep -F "$1" -q
   fi
 }
 
 matches_regex() {
   if command -v rg >/dev/null 2>&1; then
-    rg "$1" >/dev/null
+    rg -q "$1"
   else
-    grep -- "$1" >/dev/null
+    grep -q -- "$1"
   fi
 }
 
@@ -155,173 +150,14 @@ snapshot_exists() {
   vbox snapshot "$VM_NAME" list --machinereadable | matches_fixed "=\"$SNAPSHOT_NAME\""
 }
 
-host_path_for_vbox() {
-  local path="$1"
-  if [[ "$path" == /* ]] && command -v wslpath >/dev/null 2>&1; then
-    wslpath -w "$path"
-  else
-    printf '%s\n' "$path"
-  fi
-}
-
-machine_cfg_file() {
-  vbox showvminfo "$VM_NAME" --machinereadable |
-    awk -F= '$1 == "CfgFile" { value=$2 } END { gsub(/"/, "", value); print value }'
-}
-
-machine_snapshot_dir() {
-  vbox showvminfo "$VM_NAME" --machinereadable |
-    awk -F= '$1 == "SnapFldr" { value=$2 } END { gsub(/"/, "", value); print value }'
-}
-
-ensure_vm_cache_disk() {
-  if [[ -z "$VM_CACHE_DISK_PATH" ]]; then
-    return 0
-  fi
-
-  if [[ "$VM_CACHE_DISK_PATH" == /* ]]; then
-    mkdir -p "$(dirname "$VM_CACHE_DISK_PATH")"
-  fi
-
-  local cache_disk
-  cache_disk="$(host_path_for_vbox "$VM_CACHE_DISK_PATH")"
-  cache_disk="${cache_disk//$'\r'/}"
-
-  local info vm_state current_key current_medium cache_disk_cmp current_medium_cmp required_port_count current_port_count
-  info="$(vbox showvminfo "$VM_NAME" --machinereadable)"
-  vm_state="$(printf '%s\n' "$info" | awk -F= '$1 == "VMState" { gsub(/"/, "", $2); print $2 }')"
-  vm_state="${vm_state//$'\r'/}"
-  current_key="\"${VM_CACHE_STORAGE_CONTROLLER}-${VM_CACHE_DISK_PORT}-0\""
-  current_medium="$(printf '%s\n' "$info" |
-    awk -F= -v key="$current_key" '$1 == key { gsub(/^"/, "", $2); gsub(/"$/, "", $2); print $2; exit }')"
-  current_medium="${current_medium//$'\r'/}"
-  current_medium="${current_medium//\"/}"
-  current_medium="${current_medium//\\\\/\\}"
-  cache_disk_cmp="$(printf '%s' "$cache_disk" | tr '[:upper:]' '[:lower:]')"
-  current_medium_cmp="$(printf '%s' "$current_medium" | tr '[:upper:]' '[:lower:]')"
-
-  if [[ "$current_medium_cmp" == "$cache_disk_cmp" ]]; then
-    return 0
-  fi
-
-  if [[ "$vm_state" == "saved" ]]; then
-    log "保存状態の VM には cache disk を後付けできないため、この実行では cache disk をスキップします: $cache_disk"
-    if [[ "$VM_CACHE_DISK_REQUIRED" == "1" ]]; then
-      exit 1
-    fi
-    return 0
-  fi
-
-  if ! vbox showmediuminfo disk "$cache_disk" >/dev/null 2>&1; then
-    if [[ "$VM_CACHE_DISK_PATH" == /* && -f "$VM_CACHE_DISK_PATH" ]]; then
-      log "既存の cache disk を登録します: $cache_disk"
-      vbox openmedium disk "$cache_disk" >/dev/null
-    else
-      log "cache disk を作成します: $cache_disk (${VM_CACHE_DISK_SIZE_MB}MB)"
-      vbox createmedium disk --filename "$cache_disk" --size "$VM_CACHE_DISK_SIZE_MB" --format VDI >/dev/null
-    fi
-    vbox modifymedium disk "$cache_disk" --type writethrough >/dev/null
-  fi
-
-  if [[ -n "$current_medium" && "$current_medium" != "none" ]]; then
-    log "cache disk 用 port が使用中です: ${VM_CACHE_STORAGE_CONTROLLER}-${VM_CACHE_DISK_PORT}-0 -> $current_medium"
-    exit 1
-  fi
-
-  required_port_count=$((VM_CACHE_DISK_PORT + 1))
-  current_port_count="$(printf '%s\n' "$info" |
-    awk -F= -v controller="$VM_CACHE_STORAGE_CONTROLLER" '
-      {
-        key=$1; value=$2;
-        gsub(/^"/, "", value); gsub(/"$/, "", value);
-        if (key ~ /^storagecontrollername[0-9]+$/ && value == controller) {
-          idx=key; sub(/^storagecontrollername/, "", idx); controller_idx=idx;
-        }
-        if (key ~ /^storagecontrollerportcount[0-9]+$/) {
-          idx=key; sub(/^storagecontrollerportcount/, "", idx); port_count[idx]=value;
-        }
-      }
-      END {
-        if (controller_idx != "") print port_count[controller_idx];
-      }')"
-  current_port_count="${current_port_count//$'\r'/}"
-  if [[ ! "$current_port_count" =~ ^[0-9]+$ ]]; then
-    log "storage controller の port count が取得できません: $VM_CACHE_STORAGE_CONTROLLER"
-    exit 1
-  fi
-  if (( current_port_count < required_port_count )); then
-    vbox storagectl "$VM_NAME" --name "$VM_CACHE_STORAGE_CONTROLLER" --portcount "$required_port_count" >/dev/null
-  fi
-  log "cache disk を VM に接続します: $cache_disk"
-  vbox storageattach "$VM_NAME" \
-    --storagectl "$VM_CACHE_STORAGE_CONTROLLER" \
-    --port "$VM_CACHE_DISK_PORT" \
-    --device 0 \
-    --type hdd \
-    --medium "$cache_disk" >/dev/null
-}
-
-prune_orphan_leaf_media() {
+prune_orphan_media_after_restore() {
   if [[ "$PRUNE_ORPHAN_MEDIA_AFTER_RESTORE" != "1" ]]; then
     return 0
   fi
 
-  local cfg_file vm_dir snapshot_dir
-  cfg_file="$(machine_cfg_file)"
-  cfg_file="${cfg_file//\\\\/\\}"
-  if [[ -z "$cfg_file" ]]; then
-    log "VM 設定ファイルが取得できないため orphan media prune をスキップします"
-    return 0
+  if ! "$REPO_ROOT/scripts/vm_prune_orphan_media.sh" "$VM_NAME"; then
+    log "orphan media prune に失敗しました。処理を続行します"
   fi
-  vm_dir="${cfg_file%\\*}"
-  snapshot_dir="$(machine_snapshot_dir)"
-  snapshot_dir="${snapshot_dir//\\\\/\\}"
-  if [[ -z "$snapshot_dir" ]]; then
-    snapshot_dir="$vm_dir\\Snapshots"
-  fi
-
-  local candidates=()
-  mapfile -t candidates < <(
-    vbox list hdds --long | tr -d '\r' |
-      SNAPSHOT_DIR="$snapshot_dir" awk '
-        BEGIN {
-          RS="\n\n"; FS="\n";
-          snapshot_dir = ENVIRON["SNAPSHOT_DIR"];
-          gsub(/\\/, "/", snapshot_dir);
-          gsub(/\/+$/, "", snapshot_dir);
-          snapshot_dir = tolower(snapshot_dir "/");
-        }
-        {
-          uuid=""; loc=""; size=""; use="no"; child="no";
-          for (i=1; i<=NF; i++) {
-            line=$i;
-            if (line ~ /^UUID:/) { sub(/^UUID:[[:space:]]*/, "", line); uuid=line }
-            if (line ~ /^Location:/) { sub(/^Location:[[:space:]]*/, "", line); loc=line }
-            if (line ~ /^Size on disk:/) { sub(/^Size on disk:[[:space:]]*/, "", line); size=line }
-            if (line ~ /^In use by VMs:/) { use="yes" }
-            if (line ~ /^Child UUIDs:/) { child="yes" }
-          }
-          loc_norm = loc;
-          gsub(/\\/, "/", loc_norm);
-          loc_norm_lc = tolower(loc_norm);
-          in_scope = (index(loc_norm_lc, snapshot_dir) == 1);
-          if (uuid != "" && use == "no" && child == "no" && in_scope && loc_norm ~ /\.vdi$/) {
-            print uuid "\t" size "\t" loc
-          }
-        }'
-  )
-
-  if (( ${#candidates[@]} == 0 )); then
-    log "未接続 leaf VDI はありません"
-    return 0
-  fi
-
-  local entry uuid size loc
-  for entry in "${candidates[@]}"; do
-    IFS=$'\t' read -r uuid size loc <<<"$entry"
-    log "未接続 leaf VDI を削除します: $uuid ($size) $loc"
-    vbox closemedium disk "$uuid" --delete </dev/null
-  done
 }
 
 ssh_run() {
@@ -441,8 +277,7 @@ cleanup() {
       if [[ "$DISCARD_SAVED_STATE_BEFORE_TEST" == "1" ]]; then
         vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
       fi
-      ensure_vm_cache_disk || true
-      prune_orphan_leaf_media || true
+      prune_orphan_media_after_restore
       FINAL_RESTORE_DONE=1
     fi
   fi
@@ -981,12 +816,9 @@ main() {
       if [[ "$DISCARD_SAVED_STATE_BEFORE_TEST" == "1" ]]; then
         vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
       fi
-      ensure_vm_cache_disk
-      prune_orphan_leaf_media
+      prune_orphan_media_after_restore
     fi
   fi
-
-  ensure_vm_cache_disk
 
   if ! is_vm_running; then
     VM_TOUCHED=1
@@ -1031,8 +863,7 @@ main() {
       if [[ "$DISCARD_SAVED_STATE_BEFORE_TEST" == "1" ]]; then
         vbox discardstate "$VM_NAME" >/dev/null 2>&1 || true
       fi
-      ensure_vm_cache_disk
-      prune_orphan_leaf_media
+      prune_orphan_media_after_restore
       FINAL_RESTORE_DONE=1
     fi
   fi


### PR DESCRIPTION
## Summary
- PR #101 の follow-up として、CapsLock / Shift+CapsLock の入力切り替え判定を現在のキーボード種別に合わせて補正しました。
- 初回インストール時は、CAPS での日本語入力トグル設定を default OFF にしました。
- PR #102 の follow-up として、VM build 失敗につながった cache disk / stable source dir / fast installer / `CARGO_TARGET_DIR` 変更を戻し、VM サイズ増大対策の orphan VDI prune だけを残しました。

Related: #97, #101, #102

## Background
- #101 で CapsLock による英数/かな切り替えを追加しましたが、実機検証で「英語キーボード接続時にも CapsLock 単体で IME toggle と CapsLock toggle の両方が起き、Shift+CapsLock では何も起きない」パターンが確認されました。
- 想定動作は、日本語配列では CapsLock 単体、英語配列では Shift+CapsLock が入力切り替えで、それぞれ逆側の操作が大文字固定です。
- #102 では VM build / test の肥大化対策と高速化を入れましたが、VM build 時の失敗要因になったため、ビルド経路への影響が大きい変更を戻す必要がありました。
- saved-state discard を default ON にする案は Windows Update が入って build に進めないケースがあったため、今回は採用していません。

## Changes
- CapsLock / Eisu shortcut follow-up
  - `GetKeyboardType(0)` の現在値を優先して CapsLock 用の日本語/英語キーボード種別を判定
  - unknown keyboard type の場合だけ、従来の hardware registry 判定へ fallback
  - TSF preserved key は layout ごとの入力切り替え操作だけを登録
    - 日本語配列: CapsLock 単体
    - 英語配列: Shift+CapsLock
  - 古い preserved key と layout 逆側の preserved key は unregister
  - current keyboard type が registry 判定を上書きすること、unknown type では fallback することの回帰 test を追加
- Default setting
  - `ShortcutConfig::default().eisu_toggle` を `false` に変更
  - missing `eisu_toggle` の serde default も `false` に変更
  - 設定画面の初期表示 / config 読み込み fallback も `false` に変更
- VM build / test follow-up
  - PR #102 の optional cache disk、stable source dir、cache root、fast installer、Tauri/frontend build 分離、timing log 変更を戻しました
  - `DISCARD_SAVED_STATE_BEFORE_BUILD` / `DISCARD_SAVED_STATE_BEFORE_TEST` の default は `0` のまま維持
  - snapshot restore 後の orphan leaf VDI prune は `scripts/vm_prune_orphan_media.sh` に分離して残しました
  - prune 対象は VM の snapshot directory 配下、未接続、child なし、`.vdi` の leaf media に限定しています

## Verification
- [x] format / 差分チェック
  - `cargo fmt --check`
  - `git diff --check`
  - `git diff --cached --check`
- [x] shared tests
  - `PROTOC=/home/batao9/workspaces/azooKey-Windows/.local/tmp/protoc/bin/protoc cargo test -p shared`
  - `PROTOC=/home/batao9/workspaces/azooKey-Windows/.local/tmp/protoc/bin/protoc cargo test -p shared shortcut_toggles_default_to_expected_values`
- [x] frontend build
  - `node ../scripts/sync-version.mjs && node node_modules/typescript/bin/tsc && node node_modules/vite/bin/vite.js build`
- [x] script syntax / config parse
  - `bash -n scripts/vm_build.sh scripts/vm_test_client_composition.sh scripts/vm_prune_orphan_media.sh .local/vm_build_master.sh .local/vm_test_client_composition.sh`
  - `python3` / `tomllib` で `Makefile.toml` parse
- [x] ローカル Windows VM composition test
  - `.local/vm_test_client_composition.sh fix/97-capslock-preserve-layout composition skip`
  - result: 108 tests passed, 0 failed, 47 filtered
  - log: `.local/logs/vm-client-test-20260616-215904.log`
- [x] ローカル Windows VM build
  - `.local/vm_build_master.sh fix/97-capslock-preserve-layout`
  - artifact: `.local/artifacts/azookey-setup-fix_97-capslock-preserve-layout-20260616-220408.exe` (208M)
  - sha256: `10ded2ab6a59ec4d1bed28f476f940b31d8943d66f4c727f3e6d12c6b4bbaf41`
- [x] 実機 install / CapsLock behavior check
  - 上記 installer で動作問題なしを確認済み

## Notes
- `.local/` 側の VM script にも同じ restore / prune 方針を反映済みですが、`.local/` は repository 管理外のため PR 差分には含めていません。
- `npm --prefix frontend run build` は WSL 上で `frontend/node_modules/.bin/tsc` / `vite` の executable bit がなく失敗したため、同等の `node .../typescript/bin/tsc` と `node .../vite/bin/vite.js build` で確認しています。
