### PR TITLE
fix(updater): prevent mojibake update notices

### DIFF
--- a/frontend/src-tauri/src/updater.rs
+++ b/frontend/src-tauri/src/updater.rs
@@ -18,6 +18,7 @@ const INSTALLER_ASSET_NAME: &str = "azookey-setup.exe";
 const SHA256SUMS_ASSET_NAME: &str = "SHA256SUMS.txt";
 const UPDATE_RESULT_FILENAME: &str = "update-result.json";
 const APP_VERSION_JSON: &str = include_str!("../../../app-version.json");
+const UTF8_BOM: &[u8] = b"\xEF\xBB\xBF";
 
 #[derive(Debug, Deserialize)]
 struct AppVersionConfig {
@@ -140,11 +141,34 @@ pub fn take_update_install_result() -> Result<Option<UpdateInstallResult>> {
 
     let data = fs::read_to_string(&path)
         .with_context(|| format!("failed to read update result: {}", path.display()))?;
-    let result = serde_json::from_str(&data)
+    let mut result: UpdateInstallResult = serde_json::from_str(&data)
         .with_context(|| format!("failed to parse update result: {}", path.display()))?;
+    normalize_update_install_result(&mut result);
     fs::remove_file(&path)
         .with_context(|| format!("failed to remove update result: {}", path.display()))?;
     Ok(Some(result))
+}
+
+fn normalize_update_install_result(result: &mut UpdateInstallResult) {
+    if result.exit_code == Some(3010) {
+        result.status = "success".to_string();
+        result.needs_restart = true;
+    }
+
+    if result.status == "success" {
+        result.message = if result.needs_restart {
+            "更新が完了しました。Windows の再起動が必要です。".to_string()
+        } else {
+            "更新が完了しました。".to_string()
+        };
+        return;
+    }
+
+    if result.status == "failed" {
+        if let Some(exit_code) = result.exit_code {
+            result.message = format!("更新に失敗しました。終了コード: {exit_code}");
+        }
+    }
 }
 
 async fn fetch_latest_release() -> Result<GithubRelease> {
@@ -399,27 +423,24 @@ fn launch_installer_helper(
 }
 
 fn write_installer_helper_script(script_path: &Path) -> Result<()> {
-    let mut file = fs::File::create(script_path)
-        .with_context(|| format!("failed to create updater helper: {}", script_path.display()))?;
-    file.write_all(INSTALLER_HELPER_PS1.as_bytes())
-        .with_context(|| format!("failed to write updater helper: {}", script_path.display()))?;
-    Ok(())
+    write_powershell_script(script_path, INSTALLER_HELPER_PS1, "updater helper")
 }
 
 fn write_installer_launcher_script(script_path: &Path) -> Result<()> {
-    let mut file = fs::File::create(script_path).with_context(|| {
-        format!(
-            "failed to create updater helper launcher: {}",
-            script_path.display()
-        )
-    })?;
-    file.write_all(INSTALLER_LAUNCHER_PS1.as_bytes())
-        .with_context(|| {
-            format!(
-                "failed to write updater helper launcher: {}",
-                script_path.display()
-            )
-        })?;
+    write_powershell_script(
+        script_path,
+        INSTALLER_LAUNCHER_PS1,
+        "updater helper launcher",
+    )
+}
+
+fn write_powershell_script(script_path: &Path, contents: &str, label: &str) -> Result<()> {
+    let mut file = fs::File::create(script_path)
+        .with_context(|| format!("failed to create {label}: {}", script_path.display()))?;
+    file.write_all(UTF8_BOM)
+        .with_context(|| format!("failed to write {label}: {}", script_path.display()))?;
+    file.write_all(contents.as_bytes())
+        .with_context(|| format!("failed to write {label}: {}", script_path.display()))?;
     Ok(())
 }
 
@@ -750,6 +771,21 @@ mod tests {
     }
 
     #[test]
+    fn helper_scripts_are_written_with_utf8_bom() {
+        let temp = tempfile::tempdir().unwrap();
+        let helper = temp.path().join("azookey-update-helper.ps1");
+        let launcher = temp.path().join("azookey-update-launcher.ps1");
+
+        write_installer_helper_script(&helper).unwrap();
+        write_installer_launcher_script(&launcher).unwrap();
+
+        for path in [helper, launcher] {
+            let data = fs::read(path).unwrap();
+            assert!(data.starts_with(UTF8_BOM));
+        }
+    }
+
+    #[test]
     fn env_overrides_are_used() {
         let _env = EnvGuard::new();
         unsafe {
@@ -787,7 +823,74 @@ mod tests {
 
         assert_eq!(result.exit_code, Some(3010));
         assert!(result.needs_restart);
+        assert_eq!(
+            result.message,
+            "更新が完了しました。Windows の再起動が必要です。"
+        );
         assert!(take_update_install_result().unwrap().is_none());
+    }
+
+    #[test]
+    fn update_result_recovers_legacy_failed_restart_exit_code() {
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().unwrap();
+        unsafe {
+            env::set_var("APPDATA", temp.path());
+        }
+        let path = update_result_path().unwrap();
+        fs::write(
+            &path,
+            r#"{
+  "status": "failed",
+  "exit_code": 3010,
+  "needs_restart": false,
+  "message": "譖ｴ譁ｰ縺ｫ螟ｱ謨励＠縺ｾ縺励◆縲らｵゆｺ�繧ｳ繝ｼ繝�: 3010",
+  "completed_at": "2026-05-27T00:00:00Z",
+  "installer_path": "installer.exe",
+  "install_log_path": "install.log"
+}"#,
+        )
+        .unwrap();
+
+        let result = take_update_install_result().unwrap().unwrap();
+
+        assert_eq!(result.status, "success");
+        assert_eq!(result.exit_code, Some(3010));
+        assert!(result.needs_restart);
+        assert_eq!(
+            result.message,
+            "更新が完了しました。Windows の再起動が必要です。"
+        );
+    }
+
+    #[test]
+    fn update_result_replaces_failed_exit_code_message() {
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().unwrap();
+        unsafe {
+            env::set_var("APPDATA", temp.path());
+        }
+        let path = update_result_path().unwrap();
+        fs::write(
+            &path,
+            r#"{
+  "status": "failed",
+  "exit_code": 42,
+  "needs_restart": false,
+  "message": "譖ｴ譁ｰ縺ｫ螟ｱ謨励＠縺ｾ縺励◆縲らｵゆｺ�繧ｳ繝ｼ繝�: 42",
+  "completed_at": "2026-05-27T00:00:00Z",
+  "installer_path": "installer.exe",
+  "install_log_path": "install.log"
+}"#,
+        )
+        .unwrap();
+
+        let result = take_update_install_result().unwrap().unwrap();
+
+        assert_eq!(result.status, "failed");
+        assert_eq!(result.exit_code, Some(42));
+        assert!(!result.needs_restart);
+        assert_eq!(result.message, "更新に失敗しました。終了コード: 42");
     }
 
     #[test]

--- a/scripts/vm_test_updater.sh
+++ b/scripts/vm_test_updater.sh
@@ -282,12 +282,15 @@ function Start-LocalPseudoRelease {
 
   $job = Start-Job -ArgumentList $pseudoDir, $Port -ScriptBlock {
     param([string]$Root, [int]$ListenPort)
+    $maxRequests = 4
+    $servedRequests = 0
     $listener = [System.Net.HttpListener]::new()
     $listener.Prefixes.Add("http://127.0.0.1:$ListenPort/")
     $listener.Start()
     try {
-      while ($true) {
+      while ($servedRequests -lt $maxRequests) {
         $context = $listener.GetContext()
+        $servedRequests++
         $name = [System.IO.Path]::GetFileName($context.Request.Url.AbsolutePath)
         if ([string]::IsNullOrWhiteSpace($name)) {
           $name = "latest.json"
@@ -308,7 +311,24 @@ function Start-LocalPseudoRelease {
     }
   }
 
-  Start-Sleep -Seconds 2
+  $readyUrl = "$baseUrl/latest.json"
+  for ($i = 1; $i -le 30; $i++) {
+    if ($job.State -ne "Running") {
+      $jobOutput = Receive-Job -Job $job -Keep -ErrorAction Continue | Out-String
+      throw "pseudo release server stopped before becoming ready: state=$($job.State) output=$jobOutput"
+    }
+
+    & curl.exe -fsSL -H "User-Agent: azookey-updater-smoke" -o NUL $readyUrl
+    if ($LASTEXITCODE -eq 0) {
+      break
+    }
+
+    if ($i -eq 30) {
+      throw "pseudo release server did not become ready: $readyUrl"
+    }
+    Start-Sleep -Seconds 1
+  }
+
   [PSCustomObject]@{
     Job = $job
     ApiUrl = "$baseUrl/latest.json"
@@ -320,7 +340,6 @@ $pseudo = Start-LocalPseudoRelease -InstallerPath $LocalInstallerPath -Port $Pse
 try {
   Test-ReleaseDownload -ReleaseApiUrl $pseudo.ApiUrl -Prefix "pseudo" -RunInstaller
 } finally {
-  Stop-Job -Job $pseudo.Job -ErrorAction SilentlyContinue
   Remove-Job -Job $pseudo.Job -Force -ErrorAction SilentlyContinue
 }
 PS1


### PR DESCRIPTION
## Summary
- Fix updater notification mojibake by writing generated PowerShell helper scripts with a UTF-8 BOM.
- Normalize update install result messages from structured fields before showing them, including legacy mojibake `3010` results.
- Stabilize updater VM smoke pseudo-release server readiness and cleanup.

Closes #105

## Verification
- `git diff --check`
- `cargo fmt --check --manifest-path frontend/src-tauri/Cargo.toml`
- `bash -n scripts/vm_test_updater.sh`
- VM build: `.local/vm_build_master.sh fix/105-notification-mojibake`
  - Artifact: `.local/artifacts/azookey-setup-fix_105-notification-mojibake-20260619-212522.exe`
- VM updater smoke: `VM_NAME=Win11 SNAPSHOT_NAME='SSH IME Install Ready + VC++ AutoLogin' SSH_USER=vboxuser SSH_PORT=2223 SSH_KEY="$HOME/.ssh/id_rsa" VBOX_MANAGE='/mnt/c/Program Files/Oracle/VirtualBox/VBoxManage.exe' bash scripts/vm_test_updater.sh .local/artifacts/azookey-setup-fix_105-notification-mojibake-20260619-212522.exe`
  - Log: `.local/logs/vm-updater-20260619-224942.log`

## Notes
- Direct Linux-side `cargo test --manifest-path frontend/src-tauri/Cargo.toml updater::tests` could not run because the host is missing `pkg-config`/OpenSSL discovery for `openssl-sys`; Windows VM build covered the Tauri updater crate successfully.
