### PR TITLE
feat(server): enrich Zenzai n-best candidates

### DIFF
--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -19,6 +19,10 @@ private let fallbackDictionaryURL =
     dictionaryURL: fallbackDictionaryURL,
     preloadDictionary: false
 )
+@MainActor var normalNBestSupplementConverter = KanaKanjiConverter(
+    dictionaryURL: fallbackDictionaryURL,
+    preloadDictionary: false
+)
 @MainActor var composingText = ComposingText()
 @MainActor var composingTextSnapshots: [ComposingText] = []
 @MainActor var currentInputStyle: InputStyle = .roman2kana
@@ -349,6 +353,10 @@ private func readAppSettings(at path: URL) throws -> AppSettings {
         dictionaryURL: converterDictionaryURL,
         preloadDictionary: converterPreloadDictionary
     )
+    normalNBestSupplementConverter = KanaKanjiConverter(
+        dictionaryURL: converterDictionaryURL,
+        preloadDictionary: converterPreloadDictionary
+    )
 }
 
 @MainActor private func converterRuntimeDirectoryURL() -> URL {
@@ -398,7 +406,7 @@ private func makeConvertRequestOptions(
         zenzaiMode: zenzaiEnabled ? .on(
             weight: zenzaiWeightURL,
             inferenceLimit: 1,
-            requestRichCandidates: false,
+            requestRichCandidates: true,
             personalizationMode: nil,
             versionDependentMode: .v3(
                 .init(
@@ -1441,6 +1449,65 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     return result
 }
 
+func mergeZenzaiMainResultsWithNormalNBest(
+    zenzaiResults: [Candidate],
+    normalNBestResults: [Candidate],
+    hiragana: String
+) -> [Candidate] {
+    var seenTexts = Set<String>()
+    var results: [Candidate] = []
+
+    func appendIfNeeded(_ candidate: Candidate) {
+        let text = constructCandidateString(candidate: candidate, hiragana: hiragana)
+        guard seenTexts.insert(text).inserted else {
+            return
+        }
+        results.append(candidate)
+    }
+
+    for candidate in zenzaiResults {
+        appendIfNeeded(candidate)
+    }
+    for candidate in normalNBestResults {
+        appendIfNeeded(candidate)
+    }
+
+    return results
+}
+
+func cursorPrefixBoundaryFirstClauseResults(
+    zenzaiFirstClauseResults: [Candidate],
+    mergedFirstClauseResults: [Candidate]
+) -> [Candidate] {
+    zenzaiFirstClauseResults.isEmpty ? mergedFirstClauseResults : zenzaiFirstClauseResults
+}
+
+@MainActor private func requestNormalNBestSupplementCandidates(
+    inputData: ComposingText,
+    options: ConvertRequestOptions,
+    operation: String,
+    diagnosticDetails: String
+) -> ConversionResult {
+    var normalOptions = options
+    normalOptions.zenzaiMode = .off
+
+    let requestStart = performanceNow()
+    let converted = normalNBestSupplementConverter.requestCandidates(inputData, options: normalOptions)
+    let requestMs = elapsedPerformanceMilliseconds(since: requestStart)
+    performanceLog(
+        operation: operation,
+        stage: "request_normal_nbest_supplement",
+        elapsedMs: requestMs,
+        details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
+    )
+    serverLog(
+        "DEBUG",
+        "\(operation): normal N-best supplement returned candidateCount=\(converted.mainResults.count) \(diagnosticDetails)"
+    )
+
+    return converted
+}
+
 @_silgen_name("LoadConfig")
 @MainActor public func load_config() {
     let loadedSettingsPath = settingsPath()
@@ -1468,6 +1535,7 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     var dynamicUserDictionary: [DicdataElement] = []
     defer {
         converter.importDynamicUserDictionary(dynamicUserDictionary)
+        normalNBestSupplementConverter.importDynamicUserDictionary(dynamicUserDictionary)
     }
 
     config["enable"] = false
@@ -1558,6 +1626,7 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
             rebuildConverter()
         } else {
             converter.stopComposition()
+            normalNBestSupplementConverter.stopComposition()
         }
         composingText = ComposingText()
         composingTextSnapshots.removeAll()
@@ -1863,6 +1932,17 @@ public func free_candidate_list(
             details: diagnosticDetails
         )
     }
+    let normalNBestConverted: ConversionResult?
+    if useZenzai {
+        normalNBestConverted = requestNormalNBestSupplementCandidates(
+            inputData: previewComposingText,
+            options: options,
+            operation: "get_composed_text",
+            diagnosticDetails: diagnosticDetails
+        )
+    } else {
+        normalNBestConverted = nil
+    }
     let requestStart = performanceNow()
     let converted = converter.requestCandidates(previewComposingText, options: options)
     let requestMs = elapsedPerformanceMilliseconds(since: requestStart)
@@ -1880,12 +1960,25 @@ public func free_candidate_list(
         details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
     )
     serverLog("DEBUG", "GetComposedText: requestCandidates returned candidateCount=\(converted.mainResults.count) \(diagnosticDetails)")
+    let mainResults = normalNBestConverted.map {
+        mergeZenzaiMainResultsWithNormalNBest(
+            zenzaiResults: converted.mainResults,
+            normalNBestResults: $0.mainResults,
+            hiragana: previewHiragana
+        )
+    } ?? converted.mainResults
+    if let normalNBestConverted {
+        serverLog(
+            "DEBUG",
+            "GetComposedText: merged Zenzai candidates candidateCount=\(mainResults.count) zenzaiCandidateCount=\(converted.mainResults.count) normalNBestCandidateCount=\(normalNBestConverted.mainResults.count) \(diagnosticDetails)"
+        )
+    }
     candidateCrashTrace(
         useZenzai: useZenzai,
         operation: "GetComposedText",
         stage: "postprocessCandidates",
         state: "begin",
-        details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
+        details: "candidate_count=\(mainResults.count);zenzai_candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
     )
     let buildStart = performanceEnabled ? performanceNow() : 0
     var constructCandidateStringMs = 0
@@ -1893,10 +1986,10 @@ public func free_candidate_list(
     var strdupCandidatesMs = 0
     var resolutionCache: [String: CandidateDisplayResolution] = [:]
     var result: [FFICandidate] = []
-    result.reserveCapacity(converted.mainResults.count)
+    result.reserveCapacity(mainResults.count)
 
-    for i in 0..<converted.mainResults.count {
-        let candidate = converted.mainResults[i]
+    for i in 0..<mainResults.count {
+        let candidate = mainResults[i]
 
         let constructStart = performanceEnabled ? performanceNow() : 0
         let candidateText = constructCandidateString(candidate: candidate, hiragana: previewHiragana)
@@ -1935,7 +2028,7 @@ public func free_candidate_list(
             operation: "get_composed_text",
             stage: "construct_candidate_string",
             elapsedMs: constructCandidateStringMs,
-            details: "candidate_count=\(result.count);main_candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
+            details: "candidate_count=\(result.count);main_candidate_count=\(mainResults.count);zenzai_candidate_count=\(converted.mainResults.count);normal_nbest_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);\(diagnosticDetails)"
         )
         performanceLog(
             operation: "get_composed_text",
@@ -1953,7 +2046,7 @@ public func free_candidate_list(
             operation: "get_composed_text",
             stage: "build_ffi_candidates_total",
             elapsedMs: elapsedPerformanceMilliseconds(since: buildStart),
-            details: "candidate_count=\(result.count);main_candidate_count=\(converted.mainResults.count);cache_entries=\(resolutionCache.count);string_allocations=\(stringAllocationCount);\(diagnosticDetails)"
+            details: "candidate_count=\(result.count);main_candidate_count=\(mainResults.count);zenzai_candidate_count=\(converted.mainResults.count);normal_nbest_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);cache_entries=\(resolutionCache.count);string_allocations=\(stringAllocationCount);\(diagnosticDetails)"
         )
     }
     candidateCrashTrace(
@@ -1961,9 +2054,9 @@ public func free_candidate_list(
         operation: "GetComposedText",
         stage: "postprocessCandidates",
         state: "completed",
-        details: "candidate_count=\(result.count);main_candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
+        details: "candidate_count=\(result.count);main_candidate_count=\(mainResults.count);zenzai_candidate_count=\(converted.mainResults.count);normal_nbest_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);\(diagnosticDetails)"
     )
-    serverLog("DEBUG", "GetComposedText: postprocessCandidates completed candidateCount=\(result.count) mainCandidateCount=\(converted.mainResults.count) \(diagnosticDetails)")
+    serverLog("DEBUG", "GetComposedText: postprocessCandidates completed candidateCount=\(result.count) mainCandidateCount=\(mainResults.count) zenzaiCandidateCount=\(converted.mainResults.count) normalNBestCandidateCount=\(normalNBestConverted?.mainResults.count ?? 0) \(diagnosticDetails)")
     serverLog("DEBUG", "GetComposedText: completed candidateCount=\(result.count) \(diagnosticDetails)")
 
     return listPointer
@@ -2022,6 +2115,17 @@ public func free_candidate_list(
         )
     }
     let totalStart = performanceNow()
+    let normalNBestConverted: ConversionResult?
+    if useZenzai {
+        normalNBestConverted = requestNormalNBestSupplementCandidates(
+            inputData: previewPrefixComposingText,
+            options: options,
+            operation: "get_composed_text_for_cursor_prefix",
+            diagnosticDetails: "suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+        )
+    } else {
+        normalNBestConverted = nil
+    }
     let requestStart = performanceNow()
     let converted = converter.requestCandidates(previewPrefixComposingText, options: options)
     let requestMs = elapsedPerformanceMilliseconds(since: requestStart)
@@ -2039,23 +2143,47 @@ public func free_candidate_list(
         details: "first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
     serverLog("DEBUG", "GetComposedTextForCursorPrefix: requestCandidates returned firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)")
+    let cursorPrefixMainResults = normalNBestConverted.map {
+        mergeZenzaiMainResultsWithNormalNBest(
+            zenzaiResults: converted.mainResults,
+            normalNBestResults: $0.mainResults,
+            hiragana: previewPrefixHiragana
+        )
+    } ?? converted.mainResults
+    let cursorPrefixFirstClauseResults = normalNBestConverted.map {
+        mergeZenzaiMainResultsWithNormalNBest(
+            zenzaiResults: converted.firstClauseResults,
+            normalNBestResults: $0.firstClauseResults,
+            hiragana: previewPrefixHiragana
+        )
+    } ?? converted.firstClauseResults
+    if let normalNBestConverted {
+        serverLog(
+            "DEBUG",
+            "GetComposedTextForCursorPrefix: merged Zenzai candidates firstClauseCandidateCount=\(cursorPrefixFirstClauseResults.count) mainCandidateCount=\(cursorPrefixMainResults.count) zenzaiFirstClauseCandidateCount=\(converted.firstClauseResults.count) zenzaiMainCandidateCount=\(converted.mainResults.count) normalNBestFirstClauseCandidateCount=\(normalNBestConverted.firstClauseResults.count) normalNBestMainCandidateCount=\(normalNBestConverted.mainResults.count) suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+        )
+    }
     candidateCrashTrace(
         useZenzai: useZenzai,
         operation: "GetComposedTextForCursorPrefix",
         stage: "postprocessCandidates",
         state: "begin",
-        details: "phase=first_clause;first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+        details: "phase=first_clause;first_clause_candidate_count=\(cursorPrefixFirstClauseResults.count);main_candidate_count=\(cursorPrefixMainResults.count);zenzai_first_clause_candidate_count=\(converted.firstClauseResults.count);zenzai_main_candidate_count=\(converted.mainResults.count);normal_nbest_first_clause_candidate_count=\(normalNBestConverted?.firstClauseResults.count ?? 0);normal_nbest_main_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
     var cursorPrefixResolutionCache: [String: CandidateDisplayResolution] = [:]
+    let boundaryFirstClauseResults = cursorPrefixBoundaryFirstClauseResults(
+        zenzaiFirstClauseResults: converted.firstClauseResults,
+        mergedFirstClauseResults: cursorPrefixFirstClauseResults
+    )
     let firstClauseCorrespondingCount = cursorPrefixFirstClauseCorrespondingCount(
-        firstClauseResults: converted.firstClauseResults,
+        firstClauseResults: boundaryFirstClauseResults,
         originalComposingText: prefixComposingText,
         previewComposingText: previewPrefixComposingText,
         resolutionCache: &cursorPrefixResolutionCache
     )
     let preliminaryCursorPrefixResults = cursorPrefixCandidateDisplayResults(
-        mainResults: converted.mainResults,
-        firstClauseResults: converted.firstClauseResults,
+        mainResults: cursorPrefixMainResults,
+        firstClauseResults: cursorPrefixFirstClauseResults,
         firstClauseCorrespondingCount: firstClauseCorrespondingCount,
         originalComposingText: prefixComposingText,
         previewComposingText: previewPrefixComposingText,
@@ -2092,29 +2220,52 @@ public func free_candidate_list(
             "DEBUG",
             "GetComposedTextForCursorPrefix: requestCandidates exactClause begin correspondingCount=\(firstClauseCorrespondingCount) \(exactClauseDiagnosticDetails)"
         )
+        let exactClauseNormalNBestConverted: ConversionResult?
+        if useZenzai {
+            exactClauseNormalNBestConverted = requestNormalNBestSupplementCandidates(
+                inputData: exactClausePreviewState.composingText,
+                options: options,
+                operation: "get_composed_text_for_cursor_prefix_exact_clause",
+                diagnosticDetails: "corresponding_count=\(firstClauseCorrespondingCount);\(exactClauseDiagnosticDetails)"
+            )
+        } else {
+            exactClauseNormalNBestConverted = nil
+        }
         let exactClauseRequestStart = performanceNow()
         let exactClauseConverted = converter.requestCandidates(
             exactClausePreviewState.composingText,
             options: options
         )
-        exactClauseResults = exactClauseConverted.mainResults
+        exactClauseResults = exactClauseNormalNBestConverted.map {
+            mergeZenzaiMainResultsWithNormalNBest(
+                zenzaiResults: exactClauseConverted.mainResults,
+                normalNBestResults: $0.mainResults,
+                hiragana: exactClausePreviewState.composingText.convertTarget
+            )
+        } ?? exactClauseConverted.mainResults
+        if let exactClauseNormalNBestConverted {
+            serverLog(
+                "DEBUG",
+                "GetComposedTextForCursorPrefix: merged exactClause Zenzai candidates candidateCount=\(exactClauseResults.count) zenzaiCandidateCount=\(exactClauseConverted.mainResults.count) normalNBestCandidateCount=\(exactClauseNormalNBestConverted.mainResults.count) correspondingCount=\(firstClauseCorrespondingCount) \(exactClauseDiagnosticDetails)"
+            )
+        }
         let exactClauseRequestMs = elapsedPerformanceMilliseconds(since: exactClauseRequestStart)
         performanceLog(
             operation: "get_composed_text_for_cursor_prefix",
             stage: "request_candidates_exact_clause",
             elapsedMs: exactClauseRequestMs,
-            details: "candidate_count=\(exactClauseResults.count);corresponding_count=\(firstClauseCorrespondingCount);\(exactClauseDiagnosticDetails)"
+            details: "candidate_count=\(exactClauseResults.count);zenzai_candidate_count=\(exactClauseConverted.mainResults.count);normal_nbest_candidate_count=\(exactClauseNormalNBestConverted?.mainResults.count ?? 0);corresponding_count=\(firstClauseCorrespondingCount);\(exactClauseDiagnosticDetails)"
         )
         candidateCrashTrace(
             useZenzai: useZenzai,
             operation: "GetComposedTextForCursorPrefix",
             stage: "requestCandidatesExactClause",
             state: "completed",
-            details: "candidate_count=\(exactClauseResults.count);corresponding_count=\(firstClauseCorrespondingCount);\(exactClauseDiagnosticDetails)"
+            details: "candidate_count=\(exactClauseResults.count);zenzai_candidate_count=\(exactClauseConverted.mainResults.count);normal_nbest_candidate_count=\(exactClauseNormalNBestConverted?.mainResults.count ?? 0);corresponding_count=\(firstClauseCorrespondingCount);\(exactClauseDiagnosticDetails)"
         )
         serverLog(
             "DEBUG",
-            "GetComposedTextForCursorPrefix: requestCandidates exactClause returned candidateCount=\(exactClauseResults.count) correspondingCount=\(firstClauseCorrespondingCount) \(exactClauseDiagnosticDetails)"
+            "GetComposedTextForCursorPrefix: requestCandidates exactClause returned candidateCount=\(exactClauseResults.count) zenzaiCandidateCount=\(exactClauseConverted.mainResults.count) normalNBestCandidateCount=\(exactClauseNormalNBestConverted?.mainResults.count ?? 0) correspondingCount=\(firstClauseCorrespondingCount) \(exactClauseDiagnosticDetails)"
         )
     }
     candidateCrashTrace(
@@ -2127,8 +2278,8 @@ public func free_candidate_list(
     let cursorPrefixResults = exactClauseResults.isEmpty
         ? preliminaryCursorPrefixResults
         : cursorPrefixCandidateDisplayResults(
-            mainResults: converted.mainResults,
-            firstClauseResults: converted.firstClauseResults,
+            mainResults: cursorPrefixMainResults,
+            firstClauseResults: cursorPrefixFirstClauseResults,
             exactClauseResults: exactClauseResults,
             firstClauseCorrespondingCount: firstClauseCorrespondingCount,
             originalComposingText: prefixComposingText,
@@ -2141,7 +2292,7 @@ public func free_candidate_list(
         operation: "get_composed_text_for_cursor_prefix",
         stage: "total_before_ffi_candidates",
         elapsedMs: totalMs,
-        details: "candidate_count=\(cursorPrefixResults.count);first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);exact_clause_candidate_count=\(exactClauseResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+        details: "candidate_count=\(cursorPrefixResults.count);first_clause_candidate_count=\(cursorPrefixFirstClauseResults.count);main_candidate_count=\(cursorPrefixMainResults.count);zenzai_first_clause_candidate_count=\(converted.firstClauseResults.count);zenzai_main_candidate_count=\(converted.mainResults.count);normal_nbest_first_clause_candidate_count=\(normalNBestConverted?.firstClauseResults.count ?? 0);normal_nbest_main_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);exact_clause_candidate_count=\(exactClauseResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
     let buildStart = performanceEnabled ? performanceNow() : 0
     var resolveCandidateCompositionMs = 0
@@ -2197,7 +2348,7 @@ public func free_candidate_list(
             operation: "get_composed_text_for_cursor_prefix",
             stage: "build_ffi_candidates_total",
             elapsedMs: elapsedPerformanceMilliseconds(since: buildStart),
-            details: "candidate_count=\(result.count);first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);exact_clause_candidate_count=\(exactClauseResults.count);cache_entries=\(cursorPrefixResolutionCache.count);string_allocations=\(stringAllocationCount);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+            details: "candidate_count=\(result.count);first_clause_candidate_count=\(cursorPrefixFirstClauseResults.count);main_candidate_count=\(cursorPrefixMainResults.count);zenzai_first_clause_candidate_count=\(converted.firstClauseResults.count);zenzai_main_candidate_count=\(converted.mainResults.count);normal_nbest_first_clause_candidate_count=\(normalNBestConverted?.firstClauseResults.count ?? 0);normal_nbest_main_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);exact_clause_candidate_count=\(exactClauseResults.count);cache_entries=\(cursorPrefixResolutionCache.count);string_allocations=\(stringAllocationCount);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
         )
     }
     candidateCrashTrace(
@@ -2205,9 +2356,9 @@ public func free_candidate_list(
         operation: "GetComposedTextForCursorPrefix",
         stage: "postprocessCandidates",
         state: "completed",
-        details: "candidate_count=\(result.count);first_clause_candidate_count=\(converted.firstClauseResults.count);main_candidate_count=\(converted.mainResults.count);exact_clause_candidate_count=\(exactClauseResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+        details: "candidate_count=\(result.count);first_clause_candidate_count=\(cursorPrefixFirstClauseResults.count);main_candidate_count=\(cursorPrefixMainResults.count);zenzai_first_clause_candidate_count=\(converted.firstClauseResults.count);zenzai_main_candidate_count=\(converted.mainResults.count);normal_nbest_first_clause_candidate_count=\(normalNBestConverted?.firstClauseResults.count ?? 0);normal_nbest_main_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);exact_clause_candidate_count=\(exactClauseResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
-    serverLog("DEBUG", "GetComposedTextForCursorPrefix: postprocessCandidates completed candidateCount=\(result.count) firstClauseCandidateCount=\(converted.firstClauseResults.count) mainCandidateCount=\(converted.mainResults.count) exactClauseCandidateCount=\(exactClauseResults.count) suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)")
+    serverLog("DEBUG", "GetComposedTextForCursorPrefix: postprocessCandidates completed candidateCount=\(result.count) firstClauseCandidateCount=\(cursorPrefixFirstClauseResults.count) mainCandidateCount=\(cursorPrefixMainResults.count) zenzaiFirstClauseCandidateCount=\(converted.firstClauseResults.count) zenzaiMainCandidateCount=\(converted.mainResults.count) normalNBestFirstClauseCandidateCount=\(normalNBestConverted?.firstClauseResults.count ?? 0) normalNBestMainCandidateCount=\(normalNBestConverted?.mainResults.count ?? 0) exactClauseCandidateCount=\(exactClauseResults.count) suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)")
     serverLog("DEBUG", "GetComposedTextForCursorPrefix: completed candidateCount=\(result.count) suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)")
 
     return listPointer

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -187,6 +187,110 @@ private func testCandidate(
     #expect(constructCandidateString(candidate: candidate, hiragana: "きょ") == "きょ")
 }
 
+@Test func zenzaiNormalNBestSupplementKeepsZenzaiFirstAndDeduplicates() async throws {
+    let hiragana = "ここではきものをぬいでください"
+    let zenzaiTop = testCandidate(
+        word: "ここでは着物を脱いでください",
+        ruby: hiragana,
+        composingCount: .inputCount(16)
+    )
+    let zenzaiRichSecond = testCandidate(
+        word: "ここで履物を脱いでください",
+        ruby: hiragana,
+        composingCount: .inputCount(16)
+    )
+    let duplicatedTop = testCandidate(
+        word: "ここでは着物を脱いでください",
+        ruby: hiragana,
+        composingCount: .inputCount(16)
+    )
+    let normalSecond = testCandidate(
+        word: "ここでは着物を脱いでくださ異",
+        ruby: hiragana,
+        composingCount: .inputCount(16)
+    )
+    let normalThird = testCandidate(
+        word: "ここでは着物を脱いでくださ偉",
+        ruby: hiragana,
+        composingCount: .inputCount(16)
+    )
+
+    let merged = mergeZenzaiMainResultsWithNormalNBest(
+        zenzaiResults: [zenzaiTop, zenzaiRichSecond],
+        normalNBestResults: [duplicatedTop, normalSecond, normalThird, zenzaiRichSecond],
+        hiragana: hiragana
+    )
+
+    #expect(
+        merged.map { constructCandidateString(candidate: $0, hiragana: hiragana) } == [
+            "ここでは着物を脱いでください",
+            "ここで履物を脱いでください",
+            "ここでは着物を脱いでくださ異",
+            "ここでは着物を脱いでくださ偉",
+        ]
+    )
+}
+
+@Test func zenzaiNormalNBestSupplementUsesNormalCandidatesWhenZenzaiResultsAreEmpty() async throws {
+    let hiragana = "あしたのてんきはあめです"
+    let normal = testCandidate(
+        word: "明日の天気は雨です",
+        ruby: hiragana,
+        composingCount: .inputCount(21)
+    )
+
+    let merged = mergeZenzaiMainResultsWithNormalNBest(
+        zenzaiResults: [],
+        normalNBestResults: [normal],
+        hiragana: hiragana
+    )
+
+    #expect(merged.map { constructCandidateString(candidate: $0, hiragana: hiragana) } == ["明日の天気は雨です"])
+}
+
+@Test func cursorPrefixBoundarySelectionUsesZenzaiFirstClauseBeforeNormalFallback() async throws {
+    let boundaryCounts = await MainActor.run {
+        var source = ComposingText()
+        source.insertAtCursorPosition("aruteidonagaibunsetsudemo", inputStyle: .roman2kana)
+        let preview = makeCandidatePreviewComposingText(from: source).composingText
+        let zenzaiFirstClause = testCandidate(
+            word: "ある程度",
+            ruby: "あるていど",
+            composingCount: .inputCount(8)
+        )
+        let normalLongerClause = testCandidate(
+            word: "ある程度長い",
+            ruby: "あるていどながい",
+            composingCount: .inputCount(13)
+        )
+        let mergedFirstClauseResults = mergeZenzaiMainResultsWithNormalNBest(
+            zenzaiResults: [zenzaiFirstClause],
+            normalNBestResults: [normalLongerClause],
+            hiragana: preview.convertTarget
+        )
+        let boundaryFirstClauseResults = cursorPrefixBoundaryFirstClauseResults(
+            zenzaiFirstClauseResults: [zenzaiFirstClause],
+            mergedFirstClauseResults: mergedFirstClauseResults
+        )
+
+        return (
+            selected: cursorPrefixFirstClauseCorrespondingCount(
+                firstClauseResults: boundaryFirstClauseResults,
+                originalComposingText: source,
+                previewComposingText: preview
+            ),
+            merged: cursorPrefixFirstClauseCorrespondingCount(
+                firstClauseResults: mergedFirstClauseResults,
+                originalComposingText: source,
+                previewComposingText: preview
+            )
+        )
+    }
+
+    #expect(boundaryCounts.selected == 8)
+    #expect(boundaryCounts.merged == 13)
+}
+
 @Test func supportsNextInputCarryForTsuRules() async throws {
     let map = tableMap([
         row("tt", "っ", "t"),


### PR DESCRIPTION
## Summary
- Zenzai 変換 request で rich candidate を有効化し、文全体の N-best 代替候補を候補一覧へ出せるようにしました。
- Zenzai の primary / rich candidates を先頭に維持しつつ、通常変換の N-best を重複除去して補助候補として後続に追加するようにしました。
- cursor-prefix 変換でも同じ補助候補 path を使い、境界判定では Zenzai の first-clause 結果を優先するようにしました。

Closes #111

## Background
- Issue #111 では、Zenzai 変換中の 2 位以下の候補精度を改善することが求められていました。
- これまでの 2 位以下の候補は、末尾の文字だけが変わるような候補に見えるケースがあり、文章全体に対する代替候補としては弱い状態でした。
- 期待する挙動は、単なる suffix 差分ではなく、文節区切りや語義の違いを含む文全体の候補が 2 位以下にも並ぶことです。

## Changes
- Zenzai rich candidates
  - server の conversion options で `requestRichCandidates: true` を設定
  - Zenzai が返す primary candidate と rich alternative の順序を維持
- 通常変換 N-best supplement
  - `zenzaiMode = .off` で補助候補を取得する secondary converter を追加
  - Zenzai 結果の後ろに通常変換 N-best を merge
  - 表示文字列単位で重複候補を除去
  - Zenzai が空結果だった場合は通常変換候補へ fallback
- cursor-prefix handling
  - cursor-prefix candidate request でも Zenzai + 通常 N-best の merge を適用
  - clause 境界判定では、利用可能な場合は Zenzai first-clause 結果を優先
- Tests
  - 文全体の rich candidate を含む merge order / deduplication test を追加
  - Zenzai 空結果時の fallback test を追加
  - cursor-prefix 境界判定の regression test を追加

## Verification
- [x] Codex subagent review
  - 初回 follow-up review で cursor-prefix 境界判定と Zenzai 空結果 fallback の指摘あり
  - 上記 2 点を修正済み
  - re-review result: scoped changes に remaining issue なし
- [x] format / 差分チェック
  - `git diff --check`
  - `git diff --cached --check`
- [x] Windows VM server-swift tests
  - `ALLOW_DIRTY_WORKTREE=1 .local/vm_test_client_composition.sh feature/111-zenzai-nbest-candidates skip all`
  - result: 44 tests passed
  - log: `.local/logs/vm-client-test-20260622-020227.log`
- [x] Windows VM build
  - `ALLOW_DIRTY_WORKTREE=1 .local/vm_build_master.sh feature/111-zenzai-nbest-candidates`
  - artifact: `.local/artifacts/azookey-setup-feature_111-zenzai-nbest-candidates-20260622-021544.exe`
- [x] Windows VM install
  - `.local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-feature_111-zenzai-nbest-candidates-20260622-021544.exe`
  - installer exit code: 0
  - log: `.local/logs/win11-install-20260622-030118.log`
- [x] Windows VM real input test
  - `kokodehakimonowonuidekudasai`
    - `ここでは着物を抜いてください`, `ここでは着物を抜いて下さい`, `ここでは着物を脱いでください`, `ここではきものを脱いでください`, `ここでは着物を脱いで下さい` が候補に出ることを確認
    - evidence: `.local/vm-debug/issue111-final-01-kokodehakimono.png`
  - `kaiginojunbiwoshiteimasu`
    - `会議の準備をしています`, `懐疑の準備をしています`, `カイギの準備をしています`, `会議の準備をして居ます`, `懐疑の準備をして居ます` が候補に出ることを確認
    - evidence: `.local/vm-debug/issue111-final-02-kaiginojunbi.png`
  - `watashihashinjukuekimadeikimasu`
    - `私は新宿駅まで行きます`, `私は新宿駅までいきます`, `わたしは新宿駅まで行きます`, `私は新宿駅まで生きます`, `私は新宿駅間でいきます` が候補に出ることを確認
    - evidence: `.local/vm-debug/issue111-final-03-shinjukueki.png`

## Notes
- `ここで履物を脱いでください` のような候補が実際に出るかは model output 依存です。Zenzai が返した場合は今回の実装で順序を維持して候補に反映できますが、今回確認した現在の model output では `抜いて` / `脱いで` 系の文全体候補が上位に出ました。
- VM 実入力では、2 位以下の候補が末尾 1 文字だけの差分ではなく、文全体の変換候補として構成されることを確認済みです。