### PR TITLE
fix(ui): measure ruby window size from DOM

### DIFF
--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -21,4 +21,5 @@ features = [
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Environment",
     "Win32_Graphics_Gdi",
+    "Win32_UI_HiDpi",
 ]

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -18,7 +18,8 @@ use tokio::task::JoinHandle;
 use tonic::transport::Server;
 use uiaccess::prepare_uiaccess_token;
 use utils::{
-    get_candidate_window_position, get_candidate_window_position_with_ruby_clearance, CandidateRect,
+    get_candidate_window_position, get_candidate_window_position_with_ruby_clearance,
+    get_ruby_window_size_for_rect, CandidateRect,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     SetWindowPos, HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SW_HIDE,
@@ -36,11 +37,18 @@ pub mod uiaccess;
 pub mod utils;
 
 const INDICATOR_WINDOW_LEFT_OFFSET: i32 = 45;
-const RUBY_WINDOW_MIN_WIDTH: u32 = 58;
-const RUBY_WINDOW_MAX_WIDTH: u32 = 640;
-const RUBY_WINDOW_HEIGHT: u32 = 42;
-const RUBY_WINDOW_TEXT_WIDTH_PER_CHAR: u32 = 16;
-const RUBY_WINDOW_HORIZONTAL_CHROME: u32 = 40;
+
+#[derive(Clone, Copy, Debug)]
+struct RubyMeasuredSize {
+    width: f64,
+    height: f64,
+}
+
+impl RubyMeasuredSize {
+    fn new(width: f64, height: f64) -> Self {
+        Self { width, height }
+    }
+}
 
 fn place_candidate_windows(
     candidate_window: &tao::window::Window,
@@ -90,13 +98,51 @@ fn place_ruby_window(
     ruby_window.set_outer_position(PhysicalPosition::new(x, y));
 }
 
+fn set_ruby_window_measured_size(
+    ruby_window: &tao::window::Window,
+    rect: Option<CandidateRect>,
+    measured_size: RubyMeasuredSize,
+) {
+    let size = if let Some(rect) = rect {
+        get_ruby_window_size_for_rect(rect, measured_size.width, measured_size.height)
+    } else {
+        utils::RubyWindowSize::new(
+            measured_logical_dimension(measured_size.width),
+            measured_logical_dimension(measured_size.height),
+        )
+    };
+    ruby_window.set_inner_size(LogicalSize::new(size.width, size.height));
+}
+
+fn measured_logical_dimension(value: f64) -> f64 {
+    if value.is_finite() {
+        value.ceil().max(1.0)
+    } else {
+        1.0
+    }
+}
+
+fn set_and_place_ruby_window(
+    ruby_window: &tao::window::Window,
+    rect: CandidateRect,
+    measured_size: RubyMeasuredSize,
+    vertical_adjustment: i32,
+) {
+    set_ruby_window_measured_size(ruby_window, Some(rect), measured_size);
+    place_ruby_window(ruby_window, rect, vertical_adjustment);
+    set_ruby_window_measured_size(ruby_window, Some(rect), measured_size);
+    place_ruby_window(ruby_window, rect, vertical_adjustment);
+}
+
 fn ruby_clearance<'a>(
     ruby_window: &'a tao::window::Window,
     reading: &str,
     candidate_list_visible: bool,
+    ruby_size_ready: bool,
     vertical_adjustment: i32,
 ) -> Option<(&'a tao::window::Window, i32)> {
-    (candidate_list_visible && !reading.is_empty()).then_some((ruby_window, vertical_adjustment))
+    (candidate_list_visible && ruby_size_ready && !reading.is_empty())
+        .then_some((ruby_window, vertical_adjustment))
 }
 
 fn send_user_event(proxy: &EventLoopProxy<UserEvent>, event: UserEvent) {
@@ -125,17 +171,6 @@ fn set_candidate_window_width(candidate_window: &tao::window::Window, candidates
     ));
 }
 
-fn set_ruby_window_width(ruby_window: &tao::window::Window, reading: &str) {
-    let len = reading.chars().count() as u32;
-    let width = max(
-        RUBY_WINDOW_MIN_WIDTH,
-        RUBY_WINDOW_HORIZONTAL_CHROME
-            .saturating_add(len.saturating_mul(RUBY_WINDOW_TEXT_WIDTH_PER_CHAR)),
-    )
-    .min(RUBY_WINDOW_MAX_WIDTH);
-    ruby_window.set_inner_size(PhysicalSize::new(width, RUBY_WINDOW_HEIGHT));
-}
-
 fn update_candidate_list(candidate_webview: &wry::WebView, candidates: &[String]) {
     match serde_json::to_string(candidates) {
         Ok(candidates) => {
@@ -150,14 +185,38 @@ fn update_candidate_list(candidate_webview: &wry::WebView, candidates: &[String]
     }
 }
 
-fn update_ruby_reading(ruby_webview: &wry::WebView, reading: &str) {
+fn update_ruby_reading(ruby_webview: &wry::WebView, reading: &str, request_id: u32) {
     match serde_json::to_string(reading) {
         Ok(reading) => {
-            evaluate_script(ruby_webview, &format!("updateReading({})", reading));
+            evaluate_script(
+                ruby_webview,
+                &format!("updateReading({}, {})", reading, request_id),
+            );
         }
         Err(error) => {
             eprintln!("Warning: Failed to serialize reading: {error:?}");
         }
+    }
+}
+
+fn next_ruby_size_request_id(current_request_id: &mut u32) -> u32 {
+    *current_request_id = (*current_request_id).wrapping_add(1);
+    if *current_request_id == 0 {
+        *current_request_id = 1;
+    }
+
+    *current_request_id
+}
+
+fn show_ruby_window_if_ready(
+    ruby_window: &tao::window::Window,
+    window_visible: bool,
+    reading: &str,
+    ruby_size_ready: bool,
+    has_candidate_rect: bool,
+) {
+    if window_visible && ruby_size_ready && has_candidate_rect && !reading.is_empty() {
+        show_window_no_activate(ruby_window);
     }
 }
 
@@ -234,6 +293,11 @@ fn keep_windows_topmost(
 #[derive(Debug)]
 pub enum UserEvent {
     UpdateHeight(i32),
+    UpdateRubySize {
+        request_id: u32,
+        width: f64,
+        height: f64,
+    },
     UpdateCandidates(String),
     UpdateSelection(i32),
     UpdateInputMethod(String),
@@ -291,7 +355,35 @@ async fn main() -> anyhow::Result<()> {
     let indicator_window = indicator::create_indicator_window(&event_loop)?;
     let indicator_webview = indicator::create_indicator_webview(&indicator_window)?;
     let ruby_window = ruby::create_ruby_window(&event_loop)?;
-    let ruby_webview = ruby::create_ruby_webview(&ruby_window)?;
+    let proxy_clone = event_loop_proxy.clone();
+    let ruby_webview_builder = ruby::create_ruby_webview()?;
+    let ruby_webview = ruby_webview_builder
+        .with_devtools(cfg!(debug_assertions))
+        .with_ipc_handler(move |message| {
+            if let Ok(message) = serde_json::from_str::<serde_json::Value>(message.body()) {
+                if message.get("type").and_then(|value| value.as_str()) == Some("ruby-resize") {
+                    let request_id = message
+                        .get("requestId")
+                        .and_then(|value| value.as_u64())
+                        .and_then(|value| u32::try_from(value).ok());
+                    let width = message.get("width").and_then(|value| value.as_f64());
+                    let height = message.get("height").and_then(|value| value.as_f64());
+                    if let (Some(request_id), Some(width), Some(height)) =
+                        (request_id, width, height)
+                    {
+                        send_user_event(
+                            &proxy_clone,
+                            UserEvent::UpdateRubySize {
+                                request_id,
+                                width,
+                                height,
+                            },
+                        );
+                    }
+                }
+            }
+        })
+        .build(&ruby_window)?;
 
     // handle window actions
     let proxy_clone = event_loop_proxy.clone();
@@ -304,6 +396,10 @@ async fn main() -> anyhow::Result<()> {
     let mut last_candidate_rect: Option<CandidateRect> = None;
     let mut current_reading = String::new();
     let mut current_candidate_list_visible = true;
+    let mut current_window_visible = false;
+    let mut current_ruby_size_request_id = 0_u32;
+    let mut current_ruby_size_ready = false;
+    let mut current_ruby_measured_size: Option<RubyMeasuredSize> = None;
     let mut current_reading_vertical_adjustment =
         LIVE_CONVERSION_READING_VERTICAL_ADJUSTMENT_DEFAULT;
 
@@ -343,10 +439,11 @@ async fn main() -> anyhow::Result<()> {
                                 &ruby_window,
                                 &current_reading,
                                 current_candidate_list_visible,
+                                current_ruby_size_ready,
                                 current_reading_vertical_adjustment,
                             ),
                         );
-                        if !current_reading.is_empty() {
+                        if current_ruby_size_ready && !current_reading.is_empty() {
                             place_ruby_window(
                                 &ruby_window,
                                 rect,
@@ -354,6 +451,51 @@ async fn main() -> anyhow::Result<()> {
                             );
                         }
                     }
+                }
+                UserEvent::UpdateRubySize {
+                    request_id,
+                    width,
+                    height,
+                } => {
+                    if request_id != current_ruby_size_request_id || current_reading.is_empty() {
+                        return;
+                    }
+
+                    let measured_size = RubyMeasuredSize::new(width, height);
+                    current_ruby_measured_size = Some(measured_size);
+                    current_ruby_size_ready = true;
+
+                    if let Some(rect) = last_candidate_rect {
+                        set_and_place_ruby_window(
+                            &ruby_window,
+                            rect,
+                            measured_size,
+                            current_reading_vertical_adjustment,
+                        );
+                        place_candidate_windows(
+                            &candidate_window,
+                            &indicator_window,
+                            rect,
+                            ruby_clearance(
+                                &ruby_window,
+                                &current_reading,
+                                current_candidate_list_visible,
+                                current_ruby_size_ready,
+                                current_reading_vertical_adjustment,
+                            ),
+                        );
+                        place_ruby_window(&ruby_window, rect, current_reading_vertical_adjustment);
+                    } else {
+                        set_ruby_window_measured_size(&ruby_window, None, measured_size);
+                    }
+
+                    show_ruby_window_if_ready(
+                        &ruby_window,
+                        current_window_visible,
+                        &current_reading,
+                        current_ruby_size_ready,
+                        last_candidate_rect.is_some(),
+                    );
                 }
                 UserEvent::WindowAction(action) => {
                     match action {
@@ -378,14 +520,24 @@ async fn main() -> anyhow::Result<()> {
                                 };
                             }
 
+                            current_window_visible = true;
                             show_window_no_activate(&candidate_window);
-                            if !current_reading.is_empty() {
-                                show_window_no_activate(&ruby_window);
-                            }
+                            show_ruby_window_if_ready(
+                                &ruby_window,
+                                current_window_visible,
+                                &current_reading,
+                                current_ruby_size_ready,
+                                last_candidate_rect.is_some(),
+                            );
                         }
                         WindowAction::Hide => {
+                            current_window_visible = false;
                             current_reading.clear();
-                            update_ruby_reading(&ruby_webview, "");
+                            current_ruby_size_ready = false;
+                            current_ruby_measured_size = None;
+                            let request_id =
+                                next_ruby_size_request_id(&mut current_ruby_size_request_id);
+                            update_ruby_reading(&ruby_webview, "", request_id);
                             hide_window(&candidate_window);
                             hide_window(&ruby_window);
                         }
@@ -399,6 +551,16 @@ async fn main() -> anyhow::Result<()> {
                             last_candidate_rect = Some(rect);
 
                             keep_windows_topmost(&candidate_window, &ruby_window, indicator_hwnd);
+                            if current_ruby_size_ready && !current_reading.is_empty() {
+                                if let Some(measured_size) = current_ruby_measured_size {
+                                    set_and_place_ruby_window(
+                                        &ruby_window,
+                                        rect,
+                                        measured_size,
+                                        current_reading_vertical_adjustment,
+                                    );
+                                }
+                            }
                             place_candidate_windows(
                                 &candidate_window,
                                 &indicator_window,
@@ -407,16 +569,24 @@ async fn main() -> anyhow::Result<()> {
                                     &ruby_window,
                                     &current_reading,
                                     current_candidate_list_visible,
+                                    current_ruby_size_ready,
                                     current_reading_vertical_adjustment,
                                 ),
                             );
-                            if !current_reading.is_empty() {
+                            if current_ruby_size_ready && !current_reading.is_empty() {
                                 place_ruby_window(
                                     &ruby_window,
                                     rect,
                                     current_reading_vertical_adjustment,
                                 );
                             }
+                            show_ruby_window_if_ready(
+                                &ruby_window,
+                                current_window_visible,
+                                &current_reading,
+                                current_ruby_size_ready,
+                                last_candidate_rect.is_some(),
+                            );
                         }
                         WindowAction::SetCandidate { candidates } => {
                             current_candidate_list_visible = true;
@@ -432,10 +602,11 @@ async fn main() -> anyhow::Result<()> {
                                         &ruby_window,
                                         &current_reading,
                                         current_candidate_list_visible,
+                                        current_ruby_size_ready,
                                         current_reading_vertical_adjustment,
                                     ),
                                 );
-                                if !current_reading.is_empty() {
+                                if current_ruby_size_ready && !current_reading.is_empty() {
                                     place_ruby_window(
                                         &ruby_window,
                                         rect,
@@ -500,12 +671,16 @@ async fn main() -> anyhow::Result<()> {
                             }
 
                             if let Some(ref reading) = reading {
+                                let keep_current_ruby_size =
+                                    !reading.is_empty() && current_ruby_measured_size.is_some();
                                 current_reading = reading.clone();
-                                update_ruby_reading(&ruby_webview, reading);
-                                if reading.is_empty() {
+                                let request_id =
+                                    next_ruby_size_request_id(&mut current_ruby_size_request_id);
+                                update_ruby_reading(&ruby_webview, reading, request_id);
+                                current_ruby_size_ready = keep_current_ruby_size;
+                                if !keep_current_ruby_size {
+                                    current_ruby_measured_size = None;
                                     hide_window(&ruby_window);
-                                } else {
-                                    set_ruby_window_width(&ruby_window, reading);
                                 }
                             }
 
@@ -530,6 +705,16 @@ async fn main() -> anyhow::Result<()> {
                                 );
                                 last_candidate_rect = Some(rect);
                                 keep_windows_topmost(&candidate_window, &ruby_window, indicator_hwnd);
+                                if current_ruby_size_ready && !current_reading.is_empty() {
+                                    if let Some(measured_size) = current_ruby_measured_size {
+                                        set_and_place_ruby_window(
+                                            &ruby_window,
+                                            rect,
+                                            measured_size,
+                                            current_reading_vertical_adjustment,
+                                        );
+                                    }
+                                }
                                 place_candidate_windows(
                                     &candidate_window,
                                     &indicator_window,
@@ -538,16 +723,24 @@ async fn main() -> anyhow::Result<()> {
                                         &ruby_window,
                                         &current_reading,
                                         current_candidate_list_visible,
+                                        current_ruby_size_ready,
                                         current_reading_vertical_adjustment,
                                     ),
                                 );
-                                if !current_reading.is_empty() {
+                                if current_ruby_size_ready && !current_reading.is_empty() {
                                     place_ruby_window(
                                         &ruby_window,
                                         rect,
                                         current_reading_vertical_adjustment,
                                     );
                                 }
+                                show_ruby_window_if_ready(
+                                    &ruby_window,
+                                    current_window_visible,
+                                    &current_reading,
+                                    current_ruby_size_ready,
+                                    last_candidate_rect.is_some(),
+                                );
                             } else if candidates.is_some() || reading.is_some() {
                                 if let Some(rect) = last_candidate_rect {
                                     place_candidate_windows(
@@ -558,10 +751,11 @@ async fn main() -> anyhow::Result<()> {
                                             &ruby_window,
                                             &current_reading,
                                             current_candidate_list_visible,
+                                            current_ruby_size_ready,
                                             current_reading_vertical_adjustment,
                                         ),
                                     );
-                                    if !current_reading.is_empty() {
+                                    if current_ruby_size_ready && !current_reading.is_empty() {
                                         place_ruby_window(
                                             &ruby_window,
                                             rect,
@@ -602,6 +796,7 @@ async fn main() -> anyhow::Result<()> {
 
                             if let Some(visible) = visible {
                                 if visible {
+                                    current_window_visible = true;
                                     let mut task_guard = match task_guard.try_lock() {
                                         Ok(guard) => guard,
                                         Err(_) => {
@@ -627,17 +822,32 @@ async fn main() -> anyhow::Result<()> {
                                         hide_window(&candidate_window);
                                     }
 
-                                    if !current_reading.is_empty() {
-                                        show_window_no_activate(&ruby_window);
-                                    }
+                                    show_ruby_window_if_ready(
+                                        &ruby_window,
+                                        current_window_visible,
+                                        &current_reading,
+                                        current_ruby_size_ready,
+                                        last_candidate_rect.is_some(),
+                                    );
                                 } else {
+                                    current_window_visible = false;
                                     current_reading.clear();
-                                    update_ruby_reading(&ruby_webview, "");
+                                    current_ruby_size_ready = false;
+                                    current_ruby_measured_size = None;
+                                    let request_id =
+                                        next_ruby_size_request_id(&mut current_ruby_size_request_id);
+                                    update_ruby_reading(&ruby_webview, "", request_id);
                                     hide_window(&candidate_window);
                                     hide_window(&ruby_window);
                                 }
                             } else if reading.is_some() && !current_reading.is_empty() {
-                                show_window_no_activate(&ruby_window);
+                                show_ruby_window_if_ready(
+                                    &ruby_window,
+                                    current_window_visible,
+                                    &current_reading,
+                                    current_ruby_size_ready,
+                                    last_candidate_rect.is_some(),
+                                );
                             }
                         }
                     }

--- a/crates/ui/src/ruby.rs
+++ b/crates/ui/src/ruby.rs
@@ -11,7 +11,7 @@ use windows::Win32::{
         WS_POPUP,
     },
 };
-use wry::{WebView, WebViewBuilder};
+use wry::WebViewBuilder;
 
 use crate::UserEvent;
 
@@ -39,16 +39,15 @@ pub fn create_ruby_window(event_loop: &EventLoop<UserEvent>) -> Result<Window> {
     Ok(window)
 }
 
-pub fn create_ruby_webview(window: &Window) -> Result<WebView> {
-    WebViewBuilder::new()
-        .with_transparent(true)
-        .with_html(
-            r##"
+pub fn create_ruby_webview<'a>() -> Result<WebViewBuilder<'a>> {
+    let webview_builder = WebViewBuilder::new().with_transparent(true).with_html(
+        r##"
         <html>
             <head>
                 <style>
                     body, html {
                         overscroll-behavior: none;
+                        width: 100%;
                         height: 100%;
                     }
                     body {
@@ -84,8 +83,20 @@ pub fn create_ruby_webview(window: &Window) -> Result<WebView> {
                     }
                     #reading {
                         display: block;
+                        max-width: 100%;
                         overflow: hidden;
                         text-overflow: ellipsis;
+                    }
+                    #measurement {
+                        position: absolute;
+                        left: 0;
+                        top: 0;
+                        display: inline-block;
+                        max-width: none;
+                        overflow: visible;
+                        white-space: nowrap;
+                        visibility: hidden;
+                        pointer-events: none;
                     }
                     main::after {
                         content: "";
@@ -110,21 +121,117 @@ pub fn create_ruby_webview(window: &Window) -> Result<WebView> {
                     }
                 </style>
                 <script>
-	                    function updateReading(reading) {
-	                        const readingElement = document.getElementById('reading');
-	                        if (!readingElement) {
-	                            return;
-	                        }
+                    let currentRequestId = 0;
+                    let measureFrame = null;
+                    let resizeObserver = null;
 
-	                        readingElement.textContent = typeof reading === 'string' ? reading : '';
-	                    }
-	                </script>
-	            </head>
-	            <body>
-	                <main><span id="reading"></span></main>
-	            </body>
-	        </html>"##,
-        )
-        .build(window)
-        .context("Failed to create ruby webview")
+                    function cssPixels(style, property) {
+                        const value = Number.parseFloat(style.getPropertyValue(property));
+                        return Number.isFinite(value) ? value : 0;
+                    }
+
+                    function horizontalBox(style) {
+                        return cssPixels(style, 'padding-left')
+                            + cssPixels(style, 'padding-right')
+                            + cssPixels(style, 'border-left-width')
+                            + cssPixels(style, 'border-right-width');
+                    }
+
+                    function verticalBox(style) {
+                        return cssPixels(style, 'padding-top')
+                            + cssPixels(style, 'padding-bottom')
+                            + cssPixels(style, 'border-top-width')
+                            + cssPixels(style, 'border-bottom-width');
+                    }
+
+                    function scheduleMeasureRuby() {
+                        if (measureFrame !== null) {
+                            return;
+                        }
+
+                        measureFrame = window.requestAnimationFrame(() => {
+                            measureFrame = null;
+                            measureRuby();
+                        });
+                    }
+
+                    function measureRuby() {
+                        const readingElement = document.getElementById('reading');
+                        const measurementElement = document.getElementById('measurement');
+                        const main = document.querySelector('main');
+                        const body = document.body;
+                        if (!readingElement || !measurementElement || !main || !body) {
+                            return;
+                        }
+
+                        const mainStyle = window.getComputedStyle(main);
+                        const bodyStyle = window.getComputedStyle(body);
+                        const measurementRect = measurementElement.getBoundingClientRect();
+                        const bodyHorizontal = horizontalBox(bodyStyle);
+                        const bodyVertical = verticalBox(bodyStyle);
+                        const measurementWidth = Math.max(
+                            measurementElement.scrollWidth,
+                            measurementRect.width
+                        );
+                        const desiredMainWidth = Math.max(
+                            measurementWidth + horizontalBox(mainStyle),
+                            cssPixels(mainStyle, 'min-width')
+                        );
+                        const desiredMainHeight = Math.max(
+                            measurementRect.height + verticalBox(mainStyle),
+                            cssPixels(mainStyle, 'min-height')
+                        );
+                        const width = Math.ceil(desiredMainWidth + bodyHorizontal);
+                        const height = Math.ceil(desiredMainHeight + bodyVertical);
+
+                        if (!Number.isFinite(width) || !Number.isFinite(height)) {
+                            return;
+                        }
+
+                        window.ipc.postMessage(JSON.stringify({
+                            type: 'ruby-resize',
+                            requestId: currentRequestId,
+                            width,
+                            height
+                        }));
+                    }
+
+                    function updateReading(reading, requestId) {
+                        const readingElement = document.getElementById('reading');
+                        const measurementElement = document.getElementById('measurement');
+                        if (!readingElement || !measurementElement) {
+                            return;
+                        }
+
+                        const numericRequestId = Number(requestId);
+                        currentRequestId = Number.isFinite(numericRequestId)
+                            ? numericRequestId
+                            : currentRequestId + 1;
+                        const text = typeof reading === 'string' ? reading : '';
+                        readingElement.textContent = text;
+                        measurementElement.textContent = text;
+                        scheduleMeasureRuby();
+                    }
+
+                    window.addEventListener('DOMContentLoaded', () => {
+                        const main = document.querySelector('main');
+                        if (window.ResizeObserver && main) {
+                            resizeObserver = new ResizeObserver(scheduleMeasureRuby);
+                            resizeObserver.observe(main);
+                        }
+
+                        scheduleMeasureRuby();
+                    });
+                </script>
+            </head>
+            <body>
+                <main>
+                    <span id="reading"></span>
+                    <span id="measurement" aria-hidden="true"></span>
+                </main>
+            </body>
+        </html>"##,
+    );
+
+    Ok(webview_builder)
 }

--- a/crates/ui/src/utils.rs
+++ b/crates/ui/src/utils.rs
@@ -6,6 +6,7 @@ use tao::window::Window;
 use windows::Win32::{
     Foundation::RECT,
     Graphics::Gdi::{GetMonitorInfoW, MonitorFromRect, MONITORINFO, MONITOR_DEFAULTTONEAREST},
+    UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -35,6 +36,18 @@ pub struct CandidateWindowSize {
 
 impl CandidateWindowSize {
     pub fn new(width: i32, height: i32) -> Self {
+        Self { width, height }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RubyWindowSize {
+    pub width: f64,
+    pub height: f64,
+}
+
+impl RubyWindowSize {
+    pub fn new(width: f64, height: f64) -> Self {
         Self { width, height }
     }
 }
@@ -163,6 +176,83 @@ pub fn get_ruby_window_position(
     let (x, y) = ruby_window_position(target_rect, size, monitor_info.rcWork, vertical_adjustment);
 
     (x as f64, y as f64)
+}
+
+pub fn get_ruby_window_size_for_rect(
+    rect: CandidateRect,
+    measured_width: f64,
+    measured_height: f64,
+) -> RubyWindowSize {
+    let monitor = unsafe {
+        MonitorFromRect(
+            &RECT {
+                left: rect.left,
+                top: rect.top,
+                right: rect.right,
+                bottom: rect.bottom,
+            } as *const _,
+            MONITOR_DEFAULTTONEAREST,
+        )
+    };
+
+    let mut monitor_info = MONITORINFO::default();
+    monitor_info.cbSize = std::mem::size_of::<MONITORINFO>() as u32;
+
+    unsafe {
+        let _ = GetMonitorInfoW(monitor, &mut monitor_info);
+    }
+
+    ruby_window_size_for_work_area(
+        measured_width,
+        measured_height,
+        monitor_info.rcWork,
+        monitor_scale_factor(monitor),
+    )
+}
+
+fn monitor_scale_factor(monitor: windows::Win32::Graphics::Gdi::HMONITOR) -> f64 {
+    let mut dpi_x = 96_u32;
+    let mut dpi_y = 96_u32;
+
+    if unsafe { GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) }.is_ok()
+        && dpi_x > 0
+    {
+        dpi_x as f64 / 96.0
+    } else {
+        1.0
+    }
+}
+
+pub fn ruby_window_size_for_work_area(
+    measured_width: f64,
+    measured_height: f64,
+    work_area: RECT,
+    scale_factor: f64,
+) -> RubyWindowSize {
+    let scale_factor = if scale_factor.is_finite() && scale_factor > 0.0 {
+        scale_factor
+    } else {
+        1.0
+    };
+    let width = if measured_width.is_finite() {
+        measured_width.ceil().max(1.0)
+    } else {
+        1.0
+    };
+    let height = if measured_height.is_finite() {
+        measured_height.ceil().max(1.0)
+    } else {
+        1.0
+    };
+
+    let work_area_width = work_area.right.saturating_sub(work_area.left);
+    let max_width = if work_area_width > 0 {
+        (work_area_width as f64 / scale_factor).max(1.0)
+    } else {
+        width
+    };
+
+    RubyWindowSize::new(width.min(max_width), height)
 }
 
 pub fn candidate_window_position(
@@ -314,7 +404,8 @@ fn clamp_start(preferred: i32, length: i32, min: i32, max: i32) -> i32 {
 mod tests {
     use super::{
         candidate_window_position, candidate_window_position_with_ruby_clearance,
-        ruby_window_position, CandidateRect, CandidateWindowSize,
+        ruby_window_position, ruby_window_size_for_work_area, CandidateRect, CandidateWindowSize,
+        RubyWindowSize,
     };
     use windows::Win32::Foundation::RECT;
 
@@ -480,5 +571,26 @@ mod tests {
         );
 
         assert_eq!(pos, (85, 394));
+    }
+
+    #[test]
+    fn keeps_measured_ruby_width_when_it_fits_work_area() {
+        let size = ruby_window_size_for_work_area(320.2, 39.1, work_area(), 1.0);
+
+        assert_eq!(size, RubyWindowSize::new(321.0, 40.0));
+    }
+
+    #[test]
+    fn clamps_ruby_width_to_work_area_logical_width() {
+        let size = ruby_window_size_for_work_area(1000.0, 39.0, work_area(), 1.0);
+
+        assert_eq!(size, RubyWindowSize::new(800.0, 39.0));
+    }
+
+    #[test]
+    fn clamps_ruby_width_using_monitor_scale_factor() {
+        let size = ruby_window_size_for_work_area(1000.0, 39.0, work_area(), 2.0);
+
+        assert_eq!(size, RubyWindowSize::new(400.0, 39.0));
     }
 }


### PR DESCRIPTION
## Summary
- PR #110 の follow-up として、ライブ変換ルビウィンドウの幅・高さを固定推定から WebView DOM 実測へ変更しました。
- WQHD / DPI scaling / Chrome 入力欄で短中文の読みが省略されたり、入力中の幅変化で横ずれしたりしないようにしました。
- 実測サイズを反映した後に ruby / candidate window を再配置し、長すぎる場合だけ monitor work area に合わせて clamp するようにしました。

Related: #107, #110

## Background
- PR #110 では、入力中文字の上に読みを小さなルビウィンドウとして表示する UI を追加しました。
- その後の実機確認で、Chrome / Twitch などの入力欄を WQHD monitor で使うと、短中文の読みが `...` 省略されるケースがありました。
- 原因は Rust 側で `文字数 * 固定幅` によって ruby window size を推定していたことで、DPI / monitor / WebView layout / font rendering の差を吸収できていなかったことです。

## Changes
- Ruby WebView DOM measurement
  - `updateReading(reading, requestId)` で Rust 側から measurement request id を渡すように変更
  - WebView 内 JS が `#reading` / hidden measurement span / computed padding / border を使って必要な width / height を実測
  - `requestAnimationFrame` 後に `ruby-resize` IPC を送り、`ResizeObserver` でも再測定できるように変更
- Rust side size handling
  - `RUBY_WINDOW_TEXT_WIDTH_PER_CHAR` / `RUBY_WINDOW_HORIZONTAL_CHROME` / fixed ruby height 依存を削除
  - DOM 実測値を logical size として `set_inner_size` に反映
  - stale request id の measurement result は破棄
  - 初回は有効な measurement が返るまで ruby window を表示しないように変更
  - 既存 measurement がある入力更新では前回サイズを維持し、新 measurement 反映時に再配置して flicker を抑制
- Clamp / placement
  - candidate rect がある monitor work area と monitor DPI から logical max width を算出
  - 実測幅が画面内に収まる場合はそのまま維持し、画面幅を超える場合だけ clamp
  - ruby size 反映後に `place_ruby_window` と `place_candidate_windows` を再実行
- Tests
  - ruby size clamp helper tests を追加
  - work area 内では実測幅を維持すること、work area 超過時だけ clamp されることを確認
  - 既存の ruby / candidate overlap 回避 tests は維持

## Verification
- [x] Codex subagent review
  - 初回 review で、読み更新ごとに ruby window を非表示化することによる flicker / candidate jump risk の指摘あり
  - 既存 measurement がある更新では前回サイズで表示を維持するように修正
  - re-review result: レビュー通過
- [x] format / 差分チェック
  - `cargo fmt --all`
  - `git diff --check`
  - `git diff --cached --check`
- [x] frontend type check
  - `cd frontend && node node_modules/typescript/bin/tsc --noEmit`
- [x] Windows target UI check
  - `PROTOC=/home/batao9/workspaces/azooKey-Windows/.local/tmp/protoc/bin/protoc cargo check -p ui --target x86_64-pc-windows-msvc --release`
- [x] Windows VM build
  - `.local/vm_build_master.sh fix/110-ruby-dom-measured-resize`
  - artifact: `.local/artifacts/azookey-setup-fix_110-ruby-dom-measured-resize-20260623-001107.exe`
  - sha256: `3d5392d546570b5bf0c45ceb29c3be8a9811d5dd9655e3a8e00745107d8ef4ae`
- [x] Windows VM install
  - `.local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-fix_110-ruby-dom-measured-resize-20260623-001107.exe`
  - installer exit code: 0
  - log: `.local/logs/win11-install-20260623-200428.log`
- [x] Windows VM real input test
  - Notepad: `ちゃっとがいちぶ` が省略なしで表示されることを確認
    - evidence: `.local/vm-debug/final-chatto-dom-measured-slow.png`
  - Notepad: 長い `あああ...` 入力中も ruby width が伸び、入力中文字の上から横ずれしないことを確認
    - evidence: `.local/vm-debug/final-long-growth-mid.png`
    - evidence: `.local/vm-debug/final-long-growth-extended.png`
  - Notepad: Backspace 後に ruby width が縮み、左右余白が残らないことを確認
    - evidence: `.local/vm-debug/final-after-backspace-shrink.png`
  - Notepad: Space 変換 / Enter 確定で ruby / candidate window が追従し、確定後に消えることを確認
    - evidence: `.local/vm-debug/final-after-space-conversion.png`
    - evidence: `.local/vm-debug/final-after-enter-commit.png`
  - Chrome contenteditable / WQHD 相当: `ちゃっとがいちぶ` が省略なしで表示されることを確認
    - evidence: `.local/vm-debug/final-chrome-wqhd-chatto-complete.png`
  - Chrome contenteditable / WQHD 相当: 長い `あああ...` 入力でも ruby が追従することを確認
    - evidence: `.local/vm-debug/final-chrome-wqhd-long-growth.png`
  - Chrome contenteditable / FHD 相当: 長い `あああ...` 入力でも ruby が追従することを確認
    - evidence: `.local/vm-debug/final-fhd-mode-check-chrome.png`

## Notes
- Chrome は VM の追加確認用に `winget` で導入しました。repository 差分や installer には含まれていません。
- 外部 gRPC / proto interface は変更せず、追加 IPC は ruby WebView と UI process 間に限定しています。
- 極端に長い読みは、画面外にはみ出さないよう monitor work area に合わせて clamp し、その場合のみ CSS ellipsis が効く設計です。