### PR TITLE
fix(server): filter weak Zenzai alternatives

### DIFF
--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -1449,10 +1449,41 @@ func constructCandidateString(candidate: Candidate, hiragana: String) -> String 
     return result
 }
 
+func hiraganaToKatakana(_ text: String) -> String {
+    var scalars = String.UnicodeScalarView()
+    scalars.reserveCapacity(text.unicodeScalars.count)
+
+    for scalar in text.unicodeScalars {
+        let value = scalar.value
+        if (0x3041...0x3096).contains(value), let converted = UnicodeScalar(value + 0x60) {
+            scalars.append(converted)
+        } else {
+            scalars.append(scalar)
+        }
+    }
+
+    return String(scalars)
+}
+
+func shouldKeepZenzaiAlternativeCandidate(candidate: Candidate, hiragana: String) -> Bool {
+    guard candidate.rubyCount >= hiragana.count else {
+        return false
+    }
+
+    let text = constructCandidateString(candidate: candidate, hiragana: hiragana)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !text.isEmpty else {
+        return false
+    }
+
+    return text != hiragana && text != hiraganaToKatakana(hiragana)
+}
+
 func mergeZenzaiMainResultsWithNormalNBest(
     zenzaiResults: [Candidate],
     normalNBestResults: [Candidate],
-    hiragana: String
+    hiragana: String,
+    filterZenzaiAlternatives: Bool = true
 ) -> [Candidate] {
     var seenTexts = Set<String>()
     var results: [Candidate] = []
@@ -1465,7 +1496,13 @@ func mergeZenzaiMainResultsWithNormalNBest(
         results.append(candidate)
     }
 
-    for candidate in zenzaiResults {
+    if let topCandidate = zenzaiResults.first {
+        appendIfNeeded(topCandidate)
+    }
+    for candidate in zenzaiResults.dropFirst() {
+        if filterZenzaiAlternatives && !shouldKeepZenzaiAlternativeCandidate(candidate: candidate, hiragana: hiragana) {
+            continue
+        }
         appendIfNeeded(candidate)
     }
     for candidate in normalNBestResults {
@@ -2154,7 +2191,8 @@ public func free_candidate_list(
         mergeZenzaiMainResultsWithNormalNBest(
             zenzaiResults: converted.firstClauseResults,
             normalNBestResults: $0.firstClauseResults,
-            hiragana: previewPrefixHiragana
+            hiragana: previewPrefixHiragana,
+            filterZenzaiAlternatives: false
         )
     } ?? converted.firstClauseResults
     if let normalNBestConverted {

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -231,6 +231,88 @@ private func testCandidate(
     )
 }
 
+@Test func zenzaiNormalNBestSupplementFiltersWeakRichCandidates() async throws {
+    let hiragana = "ここではきものをぬいでください"
+    let zenzaiTop = testCandidate(
+        word: "ここでは着物を脱いでください",
+        ruby: hiragana,
+        composingCount: .inputCount(16)
+    )
+    let partialRich = testCandidate(
+        word: "ここでは",
+        ruby: "ここでは",
+        composingCount: .inputCount(4)
+    )
+    let katakanaEchoRich = testCandidate(
+        word: "ココデハキモノヲヌイデクダサイ",
+        ruby: hiragana,
+        composingCount: .inputCount(16)
+    )
+    let hiraganaEchoRich = testCandidate(
+        word: hiragana,
+        ruby: hiragana,
+        composingCount: .inputCount(16)
+    )
+    let usefulRich = testCandidate(
+        word: "ここで履物を脱いでください",
+        ruby: hiragana,
+        composingCount: .inputCount(16)
+    )
+    let normalSecond = testCandidate(
+        word: "ここでは着物を抜いてください",
+        ruby: hiragana,
+        composingCount: .inputCount(16)
+    )
+
+    let merged = mergeZenzaiMainResultsWithNormalNBest(
+        zenzaiResults: [zenzaiTop, partialRich, katakanaEchoRich, hiraganaEchoRich, usefulRich],
+        normalNBestResults: [normalSecond],
+        hiragana: hiragana
+    )
+
+    #expect(
+        merged.map { constructCandidateString(candidate: $0, hiragana: hiragana) } == [
+            "ここでは着物を脱いでください",
+            "ここで履物を脱いでください",
+            "ここでは着物を抜いてください",
+        ]
+    )
+}
+
+@Test func zenzaiNormalNBestSupplementCanKeepFirstClauseRichCandidates() async throws {
+    let hiragana = "ここではきものをぬいでください"
+    let firstClause = testCandidate(
+        word: "ここでは",
+        ruby: "ここでは",
+        composingCount: .inputCount(4)
+    )
+    let alternativeFirstClause = testCandidate(
+        word: "ここで",
+        ruby: "ここで",
+        composingCount: .inputCount(3)
+    )
+    let normalFirstClause = testCandidate(
+        word: "此処では",
+        ruby: "ここでは",
+        composingCount: .inputCount(4)
+    )
+
+    let merged = mergeZenzaiMainResultsWithNormalNBest(
+        zenzaiResults: [firstClause, alternativeFirstClause],
+        normalNBestResults: [normalFirstClause],
+        hiragana: hiragana,
+        filterZenzaiAlternatives: false
+    )
+
+    #expect(
+        merged.map { constructCandidateString(candidate: $0, hiragana: hiragana) } == [
+            "ここでは",
+            "ここで",
+            "此処では",
+        ]
+    )
+}
+
 @Test func zenzaiNormalNBestSupplementUsesNormalCandidatesWhenZenzaiResultsAreEmpty() async throws {
     let hiragana = "あしたのてんきはあめです"
     let normal = testCandidate(


### PR DESCRIPTION
## Summary
- PR #112 の follow-up として、Zenzai ON 時に 2 位以下へ混ざっていた短い候補や読みそのままの候補を除外しました。
- Zenzai の top candidate は維持しつつ、2 位以下は全文をカバーする有用な rich candidate と通常変換 N-best を merge するようにしました。
- cursor-prefix の first-clause 候補は文節境界に関わるため、今回の filter 対象外として既存挙動を維持しました。

Related: #111, #112

## Background
- PR #112 では Zenzai の rich candidates と通常変換 N-best を使い、文全体の代替候補を 2 位以下へ出すようにしました。
- その後の実入力確認で、以前の良好な top 5 は Zenzai OFF の状態であり、Zenzai ON では `ここでは` / `ここで` のような partial candidate や `ココデハキモノヲヌイデクダサイ` のような phonetic echo が上位に混ざることを確認しました。
- 期待する挙動は、Zenzai ON でも 2 位以下に文全体として自然な候補を配置することです。

## Changes
- Zenzai rich candidate filtering
  - Zenzai の top candidate は常に維持
  - 2 位以下の rich candidate は入力全体を cover しないものを除外
  - 入力 hiragana そのもの、または単純な katakana 変換だけの候補を除外
  - 有用な全文 rich candidate は維持
- Normal N-best supplement
  - filter 後に通常変換 N-best を追加し、Zenzai ON でも全文候補が 2 位以下へ並ぶように変更
  - 表示文字列単位の重複除去は維持
- Cursor-prefix handling
  - first-clause 結果の merge では `filterZenzaiAlternatives: false` を指定
  - clause boundary candidate が短いこと自体を理由に落とさないようにしました
- Tests
  - `ここではきものをぬいでください` 相当の bad rich candidates を filter し、有用な全文候補と通常 N-best が残ることを確認
  - first-clause rich candidates は filter されず保持されることを確認

## Verification
- [x] Codex subagent review
  - result: blocking finding なし
  - residual risk として mixed-script の phonetic echo が将来すり抜ける可能性はあるが、今回の issue の blocker ではないと確認
- [x] format / 差分チェック
  - `git diff --check`
  - `git diff --cached --check`
- [x] Windows VM server-swift tests
  - `ALLOW_DIRTY_WORKTREE=1 .local/vm_test_client_composition.sh fix/111-zenzai-on-candidate-ranking skip all`
  - result: 46 tests passed
  - log: `.local/logs/vm-client-test-20260623-215447.log`
- [x] Windows VM build
  - `ALLOW_DIRTY_WORKTREE=1 .local/vm_build_master.sh fix/111-zenzai-on-candidate-ranking`
  - artifact: `.local/artifacts/azookey-setup-fix_111-zenzai-on-candidate-ranking-20260623-220646.exe`
- [x] Windows VM install
  - `.local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-fix_111-zenzai-on-candidate-ranking-20260623-220646.exe`
  - installer exit code: 0
  - log: `.local/logs/win11-install-20260623-232337.log`
- [x] Windows VM real input test
  - 修正前 / Zenzai ON
    - `configured_zenzai=true;runtime_zenzai=true;use_zenzai=true` の状態で、2 位以下に `ここでは`, `ココデハキモノヲヌイデクダサイ`, `ここで` が混ざることを確認
    - evidence: `.local/vm-debug/issue111-regression-before-zenzai-on-kokodehakimono.png`
  - 修正前 / Zenzai OFF
    - `configured_zenzai=false;runtime_zenzai=false;use_zenzai=false` の状態で、全文候補中心の top 5 になることを確認
    - evidence: `.local/vm-debug/issue111-regression-before-zenzai-off-kokodehakimono-valid.png`
  - 修正後 / Zenzai ON
    - `configured_zenzai=true;runtime_zenzai=true;use_zenzai=true` の状態で、`ここでは着物を脱いでください`, `ここでは着物を抜いてください`, `ここでは着物を抜いて下さい`, `ここではきものを脱いでください`, `ここでは着物を脱いで下さい` が候補に出ることを確認
    - evidence: `.local/vm-debug/issue111-zenzai-on-valid-kokodehakimono.png`
  - 修正後 / Zenzai OFF
    - `configured_zenzai=false;runtime_zenzai=false;use_zenzai=false` の状態で、従来通り全文候補中心の top 5 になることを確認
    - evidence: `.local/vm-debug/issue111-zenzai-off-valid-kokodehakimono.png`

## Notes
- Windows PowerShell 5 の `Set-Content -Encoding UTF8` は BOM 付き JSON を書き、設定 parser が fallback して Zenzai OFF 相当になることがあったため、VM 検証では no-BOM UTF-8 で `settings.json` を更新して Zenzai ON/OFF を確認しました。
- Host 側では `swift` command が見つからないため `swift test` は実行できませんでした。server-swift tests は Windows VM 上で通しています。
