### PR TITLE
fix(client): commit conversion before new input

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1741,18 +1741,16 @@ impl TextServiceFactory {
     }
 
     #[inline]
-    fn actions_need_context_update(actions: &[ClientAction]) -> bool {
-        actions.iter().any(|action| {
-            matches!(
-                action,
-                ClientAction::AppendText(_)
-                    | ClientAction::AppendTextRaw(_)
-                    | ClientAction::AppendTextDirect(_)
-                    | ClientAction::ShrinkText(_)
-                    | ClientAction::ShrinkTextRaw(_)
-                    | ClientAction::ShrinkTextDirect(_)
-            )
-        })
+    fn action_needs_context_update(action: &ClientAction) -> bool {
+        matches!(
+            action,
+            ClientAction::AppendText(_)
+                | ClientAction::AppendTextRaw(_)
+                | ClientAction::AppendTextDirect(_)
+                | ClientAction::ShrinkText(_)
+                | ClientAction::ShrinkTextRaw(_)
+                | ClientAction::ShrinkTextDirect(_)
+        )
     }
 
     #[inline]
@@ -2853,6 +2851,21 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn commit_preview_then_append_actions(
+        append_action: ClientAction,
+        start_temporary_latin: bool,
+    ) -> (CompositionState, Vec<ClientAction>) {
+        let mut actions = Vec::with_capacity(4);
+        actions.push(ClientAction::EndComposition);
+        actions.push(ClientAction::StartComposition);
+        if start_temporary_latin {
+            actions.push(ClientAction::SetTemporaryLatin(true));
+        }
+        actions.push(append_action);
+        (CompositionState::Composing, actions)
+    }
+
+    #[inline]
     fn clause_navigation_actions(composition: &Composition, direction: i32) -> Vec<ClientAction> {
         if ClauseState::is_active_for_composition(composition) || !composition.suffix.is_empty() {
             return vec![
@@ -3201,27 +3214,23 @@ impl TextServiceFactory {
                     && Self::direct_text_for_action(action).is_some() =>
                 {
                     let text = Self::direct_text_for_action(action)?;
-                    let mut actions = vec![];
-                    if start_temporary_latin {
-                        actions.push(ClientAction::SetTemporaryLatin(true));
-                    }
-                    actions.push(ClientAction::ShrinkTextDirect(text));
-                    Some((CompositionState::Composing, actions))
+                    Some(Self::commit_preview_then_append_actions(
+                        ClientAction::AppendTextDirect(text),
+                        start_temporary_latin,
+                    ))
                 }
                 UserAction::NumpadSymbol(symbol) if *mode == InputMode::Kana => {
                     let text =
                         Self::numpad_text_for_mode(*symbol, app_config.general.numpad_input, false)
                             .unwrap_or_else(|| symbol.to_string());
-                    Some((
-                        CompositionState::Composing,
-                        vec![ClientAction::ShrinkTextRaw(text)],
+                    Some(Self::commit_preview_then_append_actions(
+                        ClientAction::AppendTextRaw(text),
+                        false,
                     ))
                 }
-                UserAction::Input(char) => Some((
-                    CompositionState::Composing,
-                    vec![ClientAction::ShrinkText(Self::input_text_for_mode(
-                        *char, mode,
-                    ))],
+                UserAction::Input(char) => Some(Self::commit_preview_then_append_actions(
+                    ClientAction::AppendText(Self::input_text_for_mode(*char, mode)),
+                    false,
                 )),
                 UserAction::Number {
                     value,
@@ -3231,14 +3240,14 @@ impl TextServiceFactory {
                     let text =
                         Self::numpad_text_for_mode(digit, app_config.general.numpad_input, false)
                             .unwrap_or_else(|| digit.to_string());
-                    Some((
-                        CompositionState::Composing,
-                        vec![ClientAction::ShrinkTextRaw(text)],
+                    Some(Self::commit_preview_then_append_actions(
+                        ClientAction::AppendTextRaw(text),
+                        false,
                     ))
                 }
-                UserAction::Number { value, .. } => Some((
-                    CompositionState::Composing,
-                    vec![ClientAction::ShrinkText(value.to_string())],
+                UserAction::Number { value, .. } => Some(Self::commit_preview_then_append_actions(
+                    ClientAction::AppendText(value.to_string()),
+                    false,
                 )),
                 UserAction::Backspace | UserAction::Delete => {
                     if composition.raw_input.chars().count() <= 1 {
@@ -3963,12 +3972,15 @@ impl TextServiceFactory {
                 }};
             }
 
-            if Self::actions_need_context_update(actions) {
-                self.update_context(&preview)?;
-            }
             ipc_service = IMEState::ipc_service()?.context("ipc_service is None")?;
 
             for (action_index, action) in actions.iter().enumerate() {
+                if Self::action_needs_context_update(action) {
+                    IMEState::set_ipc_service(ipc_service.clone())?;
+                    self.update_context(&preview)?;
+                    ipc_service = IMEState::ipc_service()?.context("ipc_service is None")?;
+                }
+
                 match action {
                     ClientAction::StartComposition => {
                         self.start_composition()?;

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -3216,7 +3216,7 @@ impl TextServiceFactory {
                     let text = Self::direct_text_for_action(action)?;
                     Some(Self::commit_preview_then_append_actions(
                         ClientAction::AppendTextDirect(text),
-                        start_temporary_latin,
+                        composition.temporary_latin || start_temporary_latin,
                     ))
                 }
                 UserAction::NumpadSymbol(symbol) if *mode == InputMode::Kana => {

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -263,6 +263,40 @@ fn temporary_latin_after_space_conversion_starts_new_direct_composition() {
 }
 
 #[test]
+fn existing_temporary_latin_after_space_conversion_preserves_direct_composition() {
+    let composition = Composition {
+        state: CompositionState::Previewing,
+        temporary_latin: true,
+        preview: "AB".to_string(),
+        raw_input: "AB".to_string(),
+        raw_hiragana: "AB".to_string(),
+        corresponding_count: 2,
+        ..Composition::default()
+    };
+
+    let (transition, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Input('c'),
+        &InputMode::Kana,
+        false,
+        &AppConfig::default(),
+        false,
+    )
+    .expect("existing temporary latin should stay direct after committing preview");
+
+    assert_eq!(transition, CompositionState::Composing);
+    assert_eq!(
+        actions,
+        vec![
+            ClientAction::EndComposition,
+            ClientAction::StartComposition,
+            ClientAction::SetTemporaryLatin(true),
+            ClientAction::AppendTextDirect("c".to_string())
+        ]
+    );
+}
+
+#[test]
 fn delete_uses_remove_text_path_while_composing() {
     let composition = Composition {
         state: CompositionState::Composing,

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -198,6 +198,71 @@ fn delayed_candidate_window_shows_when_space_opens_preview() {
 }
 
 #[test]
+fn input_after_space_conversion_commits_preview_before_starting_new_composition() {
+    let composition = Composition {
+        state: CompositionState::Previewing,
+        preview: "今日は".to_string(),
+        raw_input: "kyouha".to_string(),
+        raw_hiragana: "きょうは".to_string(),
+        corresponding_count: 6,
+        ..Composition::default()
+    };
+
+    let (transition, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Input('a'),
+        &InputMode::Kana,
+        false,
+        &AppConfig::default(),
+        false,
+    )
+    .expect("input should commit preview and start new composition");
+
+    assert_eq!(transition, CompositionState::Composing);
+    assert_eq!(
+        actions,
+        vec![
+            ClientAction::EndComposition,
+            ClientAction::StartComposition,
+            ClientAction::AppendText("a".to_string())
+        ]
+    );
+}
+
+#[test]
+fn temporary_latin_after_space_conversion_starts_new_direct_composition() {
+    let composition = Composition {
+        state: CompositionState::Previewing,
+        preview: "今日は".to_string(),
+        raw_input: "kyouha".to_string(),
+        raw_hiragana: "きょうは".to_string(),
+        corresponding_count: 6,
+        ..Composition::default()
+    };
+
+    let (transition, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Input('Ａ'),
+        &InputMode::Kana,
+        true,
+        &AppConfig::default(),
+        true,
+    )
+    .expect("temporary latin should commit preview and start direct composition");
+
+    assert_eq!(transition, CompositionState::Composing);
+    assert_eq!(
+        actions,
+        vec![
+            ClientAction::EndComposition,
+            ClientAction::StartComposition,
+            ClientAction::SetTemporaryLatin(true),
+            ClientAction::AppendTextDirect("A".to_string())
+        ]
+    );
+}
+
+#[test]
 fn delete_uses_remove_text_path_while_composing() {
     let composition = Composition {
         state: CompositionState::Composing,


### PR DESCRIPTION
## Summary
- Space 変換プレビュー中に新しい入力が来たとき、現在の変換候補を先に確定してから新しい composition を開始するようにしました。
- 通常入力 / 数字 / numpad symbol / temporary latin direct input の Previewing 経路を `EndComposition -> StartComposition -> Append*` に揃えました。
- 新しい append 前の context 更新を action 直前へ移し、確定済みテキストを含む文脈で次の入力を開始できるようにしました。

Closes #114

## Background
- Issue #114 では、Space で変換中の状態で次の入力を始めると、変換中の文字が上書きされることが報告されていました。
- 期待する挙動は、既存の変換結果を確定したうえで、新しい入力を別の未確定文字列として開始することです。
- 従来の Previewing 経路では `ShrinkText*` で同じ composition を縮めながら次の入力へ移るため、変換結果の確定順序が期待とずれていました。

## Changes
- Previewing input handling
  - Previewing 中の通常入力 / 数字 / numpad symbol / temporary latin direct input を `EndComposition -> StartComposition -> Append*` の action 列に変更
  - temporary latin direct input では `SetTemporaryLatin(true)` を新 composition 開始後に適用
  - 既に temporary Latin の preview 中だった場合も、新 composition に direct-input mode を引き継ぐように変更
- Context update ordering
  - append / shrink が必要な action の直前で `update_context` するように変更
  - `EndComposition -> StartComposition -> Append*` の場合、確定後の preview が空になった状態で context を取り直すようにしました
  - `IPCService` は context 更新後に `IMEState` から取り直す既存設計に合わせています
- Tests
  - Space 変換後の通常入力が preview を確定してから新 composition を開始することを確認
  - temporary latin 入力でも preview 確定後に direct append が始まることを確認
  - 既存 temporary Latin preview からの入力でも direct-input mode が維持されることを確認

## Verification
- [x] GitHub Actions build 成功
  - latest run: https://github.com/batao9/azooKey-Windows/actions/runs/28096836292
  - previous run: https://github.com/batao9/azooKey-Windows/actions/runs/28095932759
- [x] Codex subagent review
  - 初回 review で context 更新順の指摘あり
  - action 直前で context を更新する形へ修正
  - re-review result: レビュー通過、指摘なし
- [x] GitHub Codex review follow-up
  - temporary Latin preview commit 後に direct-input mode が落ちる可能性の指摘あり
  - `composition.temporary_latin || start_temporary_latin` を新 composition へ引き継ぐように修正
  - regression test を追加
- [x] format / 差分チェック
  - `git diff --check`
  - `git diff --cached --check`
  - `cargo fmt --check`
- [x] Windows target cargo check
  - `PROTOC=/home/batao9/workspaces/azooKey-Windows/.local/tmp/protoc/bin/protoc cargo check -p azookey-windows --tests --target x86_64-pc-windows-msvc`
  - result: passed
  - warnings: 既存の unused / lifetime 系のみ
- [x] Windows VM build
  - `.local/vm_build_master.sh fix/114-confirm-conversion-before-new-input`
  - artifact: `.local/artifacts/azookey-setup-fix_114-confirm-conversion-before-new-input-20260624-183334.exe`
- [x] Windows VM install
  - `SHUTDOWN_AFTER_INSTALL=0 .local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-fix_114-confirm-conversion-before-new-input-20260624-183334.exe`
  - installer exit code: 0
  - log: `.local/logs/win11-install-20260624-191755.log`
- [x] Windows VM real input test
  - Notepad に azooKey DLL がロードされていることを確認
  - `watashi` -> Space -> `a` で、`私` が上書きされず `私あ` になることを確認
  - evidence: `.local/vm-debug/issue114-06-after-type-a.png`
  - Enter 確定後も `私あ` が残ることを確認
  - evidence: `.local/vm-debug/issue114-07-after-enter.png`

## Notes
- Linux host 側の native `cargo test -p azookey-windows composition --lib` は Windows-specific API / crate のため実行できませんでした。Windows target の `cargo check --tests` と VM 実入力で確認しています。
- VM build は installer 生成と artifact 回収まで完了しました。後片付けの VM 停止処理では、VM が既に停止済みだったため cleanup 側が非 0 になりましたが、回収した installer での install / real input verification は成功しています。

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した