### PR TITLE
fix(client): keep TSF activation alive without IPC

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -13,7 +13,7 @@ use super::{
     input_mode::InputMode,
     ipc_service::{
         client_performance_log_enabled, current_input_trace_request_id, Candidates,
-        ClientInputTraceGuard, IPCService,
+        ClientInputTraceGuard, IPCService, WindowRpcDelivery,
     },
     romaji_lookup::RomajiLookup,
     state::{keyboard_disabled_from_context, AppConfigSnapshot, IMEState},
@@ -1644,7 +1644,7 @@ impl TextServiceFactory {
                 }
                 None
             };
-            ipc_service.update_candidate_window_with_reading(
+            let delivery = ipc_service.update_candidate_window_with_reading(
                 visible,
                 position,
                 Some(candidates.texts.clone()),
@@ -1654,7 +1654,7 @@ impl TextServiceFactory {
                 candidate_list_visible,
                 reading_vertical_adjustment,
             )?;
-            self.remember_candidate_window_visibility(visible);
+            self.remember_candidate_window_visibility_if_sent(delivery, visible);
             Ok(())
         })();
 
@@ -1700,6 +1700,25 @@ impl TextServiceFactory {
                 update_pos && visible != Some(false)
             }
         }
+    }
+
+    #[inline]
+    fn delivered_candidate_window_visibility(
+        delivery: WindowRpcDelivery,
+        visible: Option<bool>,
+    ) -> Option<bool> {
+        delivery.was_sent().then_some(visible).flatten()
+    }
+
+    #[inline]
+    pub(crate) fn remember_candidate_window_visibility_if_sent(
+        &self,
+        delivery: WindowRpcDelivery,
+        visible: Option<bool>,
+    ) {
+        self.remember_candidate_window_visibility(Self::delivered_candidate_window_visibility(
+            delivery, visible,
+        ));
     }
 
     #[inline]
@@ -3847,12 +3866,11 @@ impl TextServiceFactory {
         let ipc_service = IMEState::ipc_service().ok().flatten();
 
         if let Some(mut ipc_service) = ipc_service {
-            let update_result =
-                ipc_service.update_candidate_window(Some(false), None, Some(vec![]), Some(0), None);
-            if update_result.is_ok() {
-                self.remember_candidate_window_visibility(Some(false));
+            if let Ok(delivery) =
+                ipc_service.update_candidate_window(Some(false), None, Some(vec![]), Some(0), None)
+            {
+                self.remember_candidate_window_visibility_if_sent(delivery, Some(false));
             }
-            let _ = update_result;
             let _ = ipc_service.clear_text();
 
             let _ = IMEState::set_ipc_service(ipc_service);
@@ -3961,14 +3979,14 @@ impl TextServiceFactory {
                     next_split_group_id = 0;
 
                     self.discard_composition_text()?;
-                    ipc_service.update_candidate_window(
+                    let delivery = ipc_service.update_candidate_window(
                         Some(false),
                         None,
                         Some(vec![]),
                         Some(0),
                         None,
                     )?;
-                    self.remember_candidate_window_visibility(Some(false));
+                    self.remember_candidate_window_visibility_if_sent(delivery, Some(false));
                     ipc_service.clear_text()?;
                 }};
             }
@@ -4015,19 +4033,22 @@ impl TextServiceFactory {
                     ClientAction::StartComposition => {
                         self.start_composition()?;
                         if app_config.general.show_candidate_window_after_space {
-                            ipc_service.update_candidate_window(
+                            let delivery = ipc_service.update_candidate_window(
                                 Some(false),
                                 None,
                                 None,
                                 None,
                                 None,
                             )?;
-                            self.remember_candidate_window_visibility(Some(false));
+                            self.remember_candidate_window_visibility_if_sent(
+                                delivery,
+                                Some(false),
+                            );
                         }
                     }
                     ClientAction::ShowCandidateWindow => {
                         let position = self.candidate_window_position()?;
-                        ipc_service.update_candidate_window_with_reading(
+                        let delivery = ipc_service.update_candidate_window_with_reading(
                             Some(true),
                             position,
                             None,
@@ -4045,7 +4066,7 @@ impl TextServiceFactory {
                                 &transition,
                             ),
                         )?;
-                        self.remember_candidate_window_visibility(Some(true));
+                        self.remember_candidate_window_visibility_if_sent(delivery, Some(true));
                     }
                     ClientAction::EndComposition => {
                         self.end_composition()?;
@@ -4065,14 +4086,14 @@ impl TextServiceFactory {
                         current_clause_has_split_left_neighbor = false;
                         current_clause_split_group_id = None;
                         next_split_group_id = 0;
-                        ipc_service.update_candidate_window(
+                        let delivery = ipc_service.update_candidate_window(
                             Some(false),
                             None,
                             Some(vec![]),
                             Some(0),
                             None,
                         )?;
-                        self.remember_candidate_window_visibility(Some(false));
+                        self.remember_candidate_window_visibility_if_sent(delivery, Some(false));
                         ipc_service.clear_text()?;
                     }
                     ClientAction::AppendText(text) => {
@@ -4369,14 +4390,17 @@ impl TextServiceFactory {
                                 self.set_text(&committed_prefix, "")?;
                             }
                             self.end_composition()?;
-                            ipc_service.update_candidate_window(
+                            let delivery = ipc_service.update_candidate_window(
                                 Some(false),
                                 None,
                                 Some(vec![]),
                                 Some(0),
                                 None,
                             )?;
-                            self.remember_candidate_window_visibility(Some(false));
+                            self.remember_candidate_window_visibility_if_sent(
+                                delivery,
+                                Some(false),
+                            );
                             ipc_service.clear_text()?;
 
                             preview.clear();

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -208,6 +208,24 @@ impl TextServiceFactory {
         }
     }
 
+    fn ensure_ipc_service_for_key_event(operation: &str) -> bool {
+        match IMEState::ensure_ipc_service() {
+            Ok(true) => {
+                tracing::debug!(operation, "Initialized IPC service during key event");
+                true
+            }
+            Ok(false) => true,
+            Err(error) => {
+                tracing::debug!(
+                    ?error,
+                    operation,
+                    "IPC service is unavailable during key event"
+                );
+                false
+            }
+        }
+    }
+
     #[inline]
     pub(crate) fn is_ctrl_pressed() -> bool {
         VK_CONTROL.is_pressed() || VK_LCONTROL.is_pressed() || VK_RCONTROL.is_pressed()
@@ -3537,6 +3555,10 @@ impl TextServiceFactory {
                 actions.insert(0, ClientAction::SetTemporaryLatinShiftPending(false));
             }
 
+            if !Self::ensure_ipc_service_for_key_event("process_key") {
+                return Ok(None);
+            }
+
             Ok(Some((actions, transition, config_snapshot)))
         })();
 
@@ -3596,6 +3618,10 @@ impl TextServiceFactory {
         let mut actions = vec![ClientAction::SetTemporaryLatinShiftPending(false)];
         if composition.temporary_latin {
             actions.insert(0, ClientAction::SetTemporaryLatin(false));
+        }
+
+        if !Self::ensure_ipc_service_for_key_event("process_key_up") {
+            return Ok(None);
         }
 
         Ok(Some((actions, composition.state.clone())))
@@ -3785,6 +3811,10 @@ impl TextServiceFactory {
                     .any(|action| matches!(action, ClientAction::SetTemporaryLatin(false)))
             {
                 actions.insert(0, ClientAction::SetTemporaryLatin(false));
+            }
+
+            if !Self::ensure_ipc_service_for_key_event("handle_preserved_eisu_shortcut") {
+                return Ok(false);
             }
 
             self.handle_action_with_config_snapshot(&actions, transition, config_snapshot)?;

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -6,6 +6,7 @@ use super::{
 use crate::engine::{
     client_action::{ClientAction, SetSelectionType, SetTextType},
     input_mode::InputMode,
+    ipc_service::WindowRpcDelivery,
     user_action::{Function, Navigation, UserAction},
 };
 use shared::{get_default_romaji_rows, AppConfig, PunctuationStyle, RomajiRule, WidthMode};
@@ -194,6 +195,35 @@ fn delayed_candidate_window_shows_when_space_opens_preview() {
             ClientAction::ShowCandidateWindow,
             ClientAction::SetSelection(SetSelectionType::Down)
         ]
+    );
+}
+
+#[test]
+fn skipped_candidate_window_update_does_not_remember_visibility() {
+    assert_eq!(
+        TextServiceFactory::delivered_candidate_window_visibility(
+            WindowRpcDelivery::SkippedUnavailable,
+            Some(true),
+        ),
+        None
+    );
+    assert_eq!(
+        TextServiceFactory::delivered_candidate_window_visibility(
+            WindowRpcDelivery::SkippedUnavailable,
+            Some(false),
+        ),
+        None
+    );
+    assert_eq!(
+        TextServiceFactory::delivered_candidate_window_visibility(WindowRpcDelivery::Sent, None),
+        None
+    );
+    assert_eq!(
+        TextServiceFactory::delivered_candidate_window_visibility(
+            WindowRpcDelivery::Sent,
+            Some(true),
+        ),
+        Some(true)
     );
 }
 

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -95,6 +95,25 @@ impl NonIdempotentEditRecovery {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WindowRpcDelivery {
+    Sent,
+    SkippedUnavailable,
+}
+
+impl WindowRpcDelivery {
+    pub(crate) fn was_sent(self) -> bool {
+        matches!(self, Self::Sent)
+    }
+
+    fn log_status(self) -> &'static str {
+        match self {
+            Self::Sent => "success",
+            Self::SkippedUnavailable => "skipped_unavailable",
+        }
+    }
+}
+
 fn next_request_id() -> u64 {
     let counter = CLIENT_REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     (u64::from(std::process::id()) << 32) | (counter & 0xffff_ffff)
@@ -1025,6 +1044,26 @@ impl IPCService {
         self.window_client.as_mut()
     }
 
+    fn with_window_client_delivery(
+        &mut self,
+        operation: &str,
+        send: impl FnOnce(
+            &tokio::runtime::Runtime,
+            &mut WindowServiceClient<Channel>,
+        ) -> anyhow::Result<()>,
+    ) -> anyhow::Result<WindowRpcDelivery> {
+        let runtime = self.runtime.clone();
+        let Some(window_client) = self.ensure_window_client(operation) else {
+            return Ok(WindowRpcDelivery::SkippedUnavailable);
+        };
+
+        let result = send(runtime.as_ref(), window_client);
+        if result.is_err() {
+            self.window_client = None;
+        }
+        result.map(|()| WindowRpcDelivery::Sent)
+    }
+
     fn with_window_client(
         &mut self,
         operation: &str,
@@ -1033,16 +1072,8 @@ impl IPCService {
             &mut WindowServiceClient<Channel>,
         ) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
-        let runtime = self.runtime.clone();
-        let Some(window_client) = self.ensure_window_client(operation) else {
-            return Ok(());
-        };
-
-        let result = send(runtime.as_ref(), window_client);
-        if result.is_err() {
-            self.window_client = None;
-        }
-        result
+        self.with_window_client_delivery(operation, send)
+            .map(|_| ())
     }
 
     fn ignore_window_rpc_error(operation: &str, result: anyhow::Result<()>) -> anyhow::Result<()> {
@@ -1055,6 +1086,23 @@ impl IPCService {
         }
 
         Ok(())
+    }
+
+    fn ignore_window_rpc_delivery_error(
+        operation: &str,
+        result: anyhow::Result<WindowRpcDelivery>,
+    ) -> anyhow::Result<WindowRpcDelivery> {
+        match result {
+            Ok(delivery) => Ok(delivery),
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    operation,
+                    "Candidate window IPC request failed; continuing without UI connection"
+                );
+                Ok(WindowRpcDelivery::SkippedUnavailable)
+            }
+        }
     }
 
     #[tracing::instrument]
@@ -1227,14 +1275,14 @@ impl IPCService {
     }
 
     #[tracing::instrument(skip(candidates))]
-    pub fn update_candidate_window(
+    pub(crate) fn update_candidate_window(
         &mut self,
         visible: Option<bool>,
         position: Option<shared::proto::WindowPosition>,
         candidates: Option<Vec<String>>,
         selected_index: Option<i32>,
         input_mode: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<WindowRpcDelivery> {
         let clear_reading = visible == Some(false);
         self.update_candidate_window_with_reading(
             visible,
@@ -1249,7 +1297,7 @@ impl IPCService {
     }
 
     #[tracing::instrument(skip(candidates))]
-    pub fn update_candidate_window_with_reading(
+    pub(crate) fn update_candidate_window_with_reading(
         &mut self,
         visible: Option<bool>,
         position: Option<shared::proto::WindowPosition>,
@@ -1259,7 +1307,7 @@ impl IPCService {
         reading: Option<&str>,
         candidate_list_visible: Option<bool>,
         reading_vertical_adjustment: Option<i32>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<WindowRpcDelivery> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
         let position_present = performance_start.map(|_| position.is_some());
@@ -1267,7 +1315,7 @@ impl IPCService {
         let input_mode_present = performance_start.map(|_| input_mode.is_some());
         let reading_present =
             performance_start.map(|_| reading.is_some_and(|value| !value.is_empty()));
-        let result: anyhow::Result<()> = (|| {
+        let result: anyhow::Result<WindowRpcDelivery> = (|| {
             let request = tonic::Request::new(shared::proto::UpdateCandidateWindowRequest {
                 visible,
                 position,
@@ -1279,10 +1327,13 @@ impl IPCService {
                 candidate_list_visible,
                 reading_vertical_adjustment,
             });
-            self.with_window_client("ui_update_candidate_window", |runtime, window_client| {
-                runtime.block_on(window_client.update_candidate_window(request))?;
-                Ok(())
-            })
+            self.with_window_client_delivery(
+                "ui_update_candidate_window",
+                |runtime, window_client| {
+                    runtime.block_on(window_client.update_candidate_window(request))?;
+                    Ok(())
+                },
+            )
         })();
         self.log_client_performance_from_start(
             performance_start,
@@ -1295,8 +1346,9 @@ impl IPCService {
                 let input_mode_present = input_mode_present.unwrap_or_default();
                 let reading_present = reading_present.unwrap_or_default();
                 match &result {
-                    Ok(()) => format!(
-                        "status=success;visible={visible:?};position_present={position_present};candidate_count={candidate_count:?};selected_index={selected_index:?};input_mode_present={input_mode_present};reading_present={reading_present};candidate_list_visible={candidate_list_visible:?};reading_vertical_adjustment={reading_vertical_adjustment:?}"
+                    Ok(delivery) => format!(
+                        "status={};visible={visible:?};position_present={position_present};candidate_count={candidate_count:?};selected_index={selected_index:?};input_mode_present={input_mode_present};reading_present={reading_present};candidate_list_visible={candidate_list_visible:?};reading_vertical_adjustment={reading_vertical_adjustment:?}",
+                        delivery.log_status()
                     ),
                     Err(error) => format!(
                         "status=error;visible={visible:?};position_present={position_present};candidate_count={candidate_count:?};selected_index={selected_index:?};input_mode_present={input_mode_present};reading_present={reading_present};candidate_list_visible={candidate_list_visible:?};reading_vertical_adjustment={reading_vertical_adjustment:?};error={error:?}"
@@ -1304,7 +1356,7 @@ impl IPCService {
                 }
             },
         );
-        Self::ignore_window_rpc_error("ui_update_candidate_window", result)
+        Self::ignore_window_rpc_delivery_error("ui_update_candidate_window", result)
     }
 }
 

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -16,13 +16,16 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::{net::windows::named_pipe::ClientOptions, time};
-use tonic::transport::Endpoint;
+use tonic::transport::{channel::Channel, Endpoint};
 use tower::service_fn;
 use windows::Win32::Foundation::ERROR_PIPE_BUSY;
 
 const INPUT_STYLE_ROMAN2KANA: i32 = 0;
 const INPUT_STYLE_DIRECT: i32 = 1;
 const CLIENT_LOG_CONFIG_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const PIPE_BUSY_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+const SERVER_PIPE_BUSY_TIMEOUT: Duration = Duration::from_millis(250);
+const UI_PIPE_BUSY_TIMEOUT: Duration = Duration::ZERO;
 
 static CLIENT_REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 static IPC_CONNECTION_SEQUENCE: AtomicU64 = AtomicU64::new(1);
@@ -43,9 +46,9 @@ struct ClientLogConfigCache {
 pub struct IPCService {
     connection_id: u64,
     // kkc server client
-    azookey_client: AzookeyServiceClient<tonic::transport::channel::Channel>,
+    azookey_client: AzookeyServiceClient<Channel>,
     // candidate window server client
-    window_client: WindowServiceClient<tonic::transport::channel::Channel>,
+    window_client: Option<WindowServiceClient<Channel>>,
     runtime: Arc<tokio::runtime::Runtime>,
     performance_log_tx: tokio::sync::mpsc::UnboundedSender<PerformanceLogRequest>,
     server_session_id: Option<u64>,
@@ -174,44 +177,29 @@ impl IPCService {
         let runtime = Arc::new(tokio::runtime::Runtime::new()?);
         let connection_id = IPC_CONNECTION_SEQUENCE.fetch_add(1, Ordering::Relaxed);
 
-        let server_channel = runtime.block_on(
-            Endpoint::try_from("http://[::]:50051")?.connect_with_connector(service_fn(
-                |_| async {
-                    let client = loop {
-                        match ClientOptions::new().open(r"\\.\pipe\azookey_server") {
-                            Ok(client) => break client,
-                            Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY.0 as i32) => (),
-                            Err(e) => return Err(e),
-                        }
-
-                        time::sleep(Duration::from_millis(50)).await;
-                    };
-
-                    Ok::<_, std::io::Error>(TokioIo::new(client))
-                },
-            )),
+        let server_channel = Self::connect_named_pipe_channel(
+            &runtime,
+            "http://[::]:50051",
+            r"\\.\pipe\azookey_server",
+            SERVER_PIPE_BUSY_TIMEOUT,
         )?;
-
-        let ui_channel = runtime.block_on(
-            Endpoint::try_from("http://[::]:50052")?.connect_with_connector(service_fn(
-                |_| async {
-                    let client = loop {
-                        match ClientOptions::new().open(r"\\.\pipe\azookey_ui") {
-                            Ok(client) => break client,
-                            Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY.0 as i32) => (),
-                            Err(e) => return Err(e),
-                        }
-
-                        time::sleep(Duration::from_millis(50)).await;
-                    };
-
-                    Ok::<_, std::io::Error>(TokioIo::new(client))
-                },
-            )),
-        )?;
+        let window_client = match Self::connect_named_pipe_channel(
+            &runtime,
+            "http://[::]:50052",
+            r"\\.\pipe\azookey_ui",
+            UI_PIPE_BUSY_TIMEOUT,
+        ) {
+            Ok(ui_channel) => Some(WindowServiceClient::new(ui_channel)),
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    "Candidate window IPC is unavailable; continuing without UI connection"
+                );
+                None
+            }
+        };
 
         let azookey_client = AzookeyServiceClient::new(server_channel);
-        let window_client = WindowServiceClient::new(ui_channel);
         let (performance_log_tx, mut performance_log_rx) =
             tokio::sync::mpsc::unbounded_channel::<PerformanceLogRequest>();
         let mut performance_log_client = azookey_client.clone();
@@ -236,6 +224,41 @@ impl IPCService {
             server_session_id: None,
             server_reset_recovered: false,
         })
+    }
+
+    fn connect_named_pipe_channel(
+        runtime: &tokio::runtime::Runtime,
+        endpoint: &'static str,
+        pipe_name: &'static str,
+        busy_timeout: Duration,
+    ) -> Result<Channel> {
+        let channel = runtime.block_on(Endpoint::try_from(endpoint)?.connect_with_connector(
+            service_fn(move |_| async move {
+                let busy_started_at = Instant::now();
+                let client = loop {
+                    match ClientOptions::new().open(pipe_name) {
+                        Ok(client) => break client,
+                        Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY.0 as i32) => {
+                            if busy_started_at.elapsed() >= busy_timeout {
+                                return Err(std::io::Error::new(
+                                    std::io::ErrorKind::TimedOut,
+                                    format!(
+                                        "{pipe_name} remained busy for at least {busy_timeout:?}"
+                                    ),
+                                ));
+                            }
+                        }
+                        Err(e) => return Err(e),
+                    }
+
+                    time::sleep(PIPE_BUSY_RETRY_INTERVAL).await;
+                };
+
+                Ok::<_, std::io::Error>(TokioIo::new(client))
+            }),
+        ))?;
+
+        Ok(channel)
     }
 }
 
@@ -970,17 +993,80 @@ impl IPCService {
 
 // implement methods to interact with candidate window server
 impl IPCService {
+    fn ensure_window_client(
+        &mut self,
+        operation: &str,
+    ) -> Option<&mut WindowServiceClient<Channel>> {
+        if self.window_client.is_none() {
+            match Self::connect_named_pipe_channel(
+                self.runtime.as_ref(),
+                "http://[::]:50052",
+                r"\\.\pipe\azookey_ui",
+                UI_PIPE_BUSY_TIMEOUT,
+            ) {
+                Ok(ui_channel) => {
+                    tracing::info!(
+                        operation,
+                        "Candidate window IPC connected after deferred retry"
+                    );
+                    self.window_client = Some(WindowServiceClient::new(ui_channel));
+                }
+                Err(error) => {
+                    tracing::debug!(
+                        ?error,
+                        operation,
+                        "Candidate window IPC remains unavailable"
+                    );
+                    return None;
+                }
+            }
+        }
+
+        self.window_client.as_mut()
+    }
+
+    fn with_window_client(
+        &mut self,
+        operation: &str,
+        send: impl FnOnce(
+            &tokio::runtime::Runtime,
+            &mut WindowServiceClient<Channel>,
+        ) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        let runtime = self.runtime.clone();
+        let Some(window_client) = self.ensure_window_client(operation) else {
+            return Ok(());
+        };
+
+        let result = send(runtime.as_ref(), window_client);
+        if result.is_err() {
+            self.window_client = None;
+        }
+        result
+    }
+
+    fn ignore_window_rpc_error(operation: &str, result: anyhow::Result<()>) -> anyhow::Result<()> {
+        if let Err(error) = result {
+            tracing::warn!(
+                ?error,
+                operation,
+                "Candidate window IPC request failed; continuing without UI connection"
+            );
+        }
+
+        Ok(())
+    }
+
     #[tracing::instrument]
     pub fn show_window(&mut self) -> anyhow::Result<()> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
         let result: anyhow::Result<()> = (|| {
             let request = tonic::Request::new(shared::proto::EmptyResponse {});
-            self.runtime
-                .clone()
-                .block_on(self.window_client.show_window(request))?;
-
-            Ok(())
+            self.with_window_client("ui_show_window", |runtime, window_client| {
+                runtime.block_on(window_client.show_window(request))?;
+                Ok(())
+            })
         })();
         self.log_client_performance_from_start(
             performance_start,
@@ -992,7 +1078,7 @@ impl IPCService {
                 Err(error) => format!("status=error;error={error:?}"),
             },
         );
-        result
+        Self::ignore_window_rpc_error("ui_show_window", result)
     }
 
     #[tracing::instrument]
@@ -1001,11 +1087,10 @@ impl IPCService {
         let performance_start = client_performance_start();
         let result: anyhow::Result<()> = (|| {
             let request = tonic::Request::new(shared::proto::EmptyResponse {});
-            self.runtime
-                .clone()
-                .block_on(self.window_client.hide_window(request))?;
-
-            Ok(())
+            self.with_window_client("ui_hide_window", |runtime, window_client| {
+                runtime.block_on(window_client.hide_window(request))?;
+                Ok(())
+            })
         })();
         self.log_client_performance_from_start(
             performance_start,
@@ -1017,7 +1102,7 @@ impl IPCService {
                 Err(error) => format!("status=error;error={error:?}"),
             },
         );
-        result
+        Self::ignore_window_rpc_error("ui_hide_window", result)
     }
 
     #[tracing::instrument]
@@ -1039,11 +1124,10 @@ impl IPCService {
                     right,
                 }),
             });
-            self.runtime
-                .clone()
-                .block_on(self.window_client.set_window_position(request))?;
-
-            Ok(())
+            self.with_window_client("ui_set_window_position", |runtime, window_client| {
+                runtime.block_on(window_client.set_window_position(request))?;
+                Ok(())
+            })
         })();
         self.log_client_performance_from_start(
             performance_start,
@@ -1059,7 +1143,7 @@ impl IPCService {
                 ),
             },
         );
-        result
+        Self::ignore_window_rpc_error("ui_set_window_position", result)
     }
 
     #[tracing::instrument]
@@ -1069,11 +1153,10 @@ impl IPCService {
         let candidate_count = performance_start.map(|_| candidates.len());
         let result: anyhow::Result<()> = (|| {
             let request = tonic::Request::new(shared::proto::SetCandidateRequest { candidates });
-            self.runtime
-                .clone()
-                .block_on(self.window_client.set_candidate(request))?;
-
-            Ok(())
+            self.with_window_client("ui_set_candidates", |runtime, window_client| {
+                runtime.block_on(window_client.set_candidate(request))?;
+                Ok(())
+            })
         })();
         self.log_client_performance_from_start(
             performance_start,
@@ -1090,7 +1173,7 @@ impl IPCService {
                 }
             },
         );
-        result
+        Self::ignore_window_rpc_error("ui_set_candidates", result)
     }
 
     #[tracing::instrument]
@@ -1099,11 +1182,10 @@ impl IPCService {
         let performance_start = client_performance_start();
         let result: anyhow::Result<()> = (|| {
             let request = tonic::Request::new(shared::proto::SetSelectionRequest { index });
-            self.runtime
-                .clone()
-                .block_on(self.window_client.set_selection(request))?;
-
-            Ok(())
+            self.with_window_client("ui_set_selection", |runtime, window_client| {
+                runtime.block_on(window_client.set_selection(request))?;
+                Ok(())
+            })
         })();
         self.log_client_performance_from_start(
             performance_start,
@@ -1115,7 +1197,7 @@ impl IPCService {
                 Err(error) => format!("status=error;index={index};error={error:?}"),
             },
         );
-        result
+        Self::ignore_window_rpc_error("ui_set_selection", result)
     }
 
     #[tracing::instrument]
@@ -1126,11 +1208,10 @@ impl IPCService {
             let request = tonic::Request::new(shared::proto::SetInputModeRequest {
                 mode: mode.to_string(),
             });
-            self.runtime
-                .clone()
-                .block_on(self.window_client.set_input_mode(request))?;
-
-            Ok(())
+            self.with_window_client("ui_set_input_mode", |runtime, window_client| {
+                runtime.block_on(window_client.set_input_mode(request))?;
+                Ok(())
+            })
         })();
         self.log_client_performance_from_start(
             performance_start,
@@ -1142,7 +1223,7 @@ impl IPCService {
                 Err(error) => format!("status=error;mode={mode};error={error:?}"),
             },
         );
-        result
+        Self::ignore_window_rpc_error("ui_set_input_mode", result)
     }
 
     #[tracing::instrument(skip(candidates))]
@@ -1198,11 +1279,10 @@ impl IPCService {
                 candidate_list_visible,
                 reading_vertical_adjustment,
             });
-            self.runtime
-                .clone()
-                .block_on(self.window_client.update_candidate_window(request))?;
-
-            Ok(())
+            self.with_window_client("ui_update_candidate_window", |runtime, window_client| {
+                runtime.block_on(window_client.update_candidate_window(request))?;
+                Ok(())
+            })
         })();
         self.log_client_performance_from_start(
             performance_start,
@@ -1224,7 +1304,7 @@ impl IPCService {
                 }
             },
         );
-        result
+        Self::ignore_window_rpc_error("ui_update_candidate_window", result)
     }
 }
 

--- a/crates/client/src/engine/state.rs
+++ b/crates/client/src/engine/state.rs
@@ -248,6 +248,18 @@ impl IMEState {
         Ok(())
     }
 
+    pub fn ensure_ipc_service() -> anyhow::Result<bool> {
+        if Self::ipc_service()?.is_some() {
+            return Ok(false);
+        }
+
+        let mut ipc_service = IPCService::new()?;
+        ipc_service.append_text(String::new())?;
+        Self::set_ipc_service(ipc_service)?;
+
+        Ok(true)
+    }
+
     pub fn input_mode() -> anyhow::Result<InputMode> {
         Ok(Self::get()?.input_mode.clone())
     }

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -88,7 +88,29 @@ static MENU_OWNER_WINDOW_CLASS_SEQUENCE: AtomicU32 = AtomicU32::new(0);
 // if not, you will get E_FAIL error in ITfLangBarItemMgr::AddItem
 
 impl TextServiceFactory_Impl {
+    fn ensure_ipc_service_for_language_bar_event(event: &str) -> bool {
+        match IMEState::ensure_ipc_service() {
+            Ok(true) => {
+                tracing::debug!(event, "Initialized IPC service during language bar event");
+                true
+            }
+            Ok(false) => true,
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    event,
+                    "IPC service is unavailable during language bar event"
+                );
+                false
+            }
+        }
+    }
+
     fn toggle_input_mode(&self) -> Result<()> {
+        if !Self::ensure_ipc_service_for_language_bar_event("toggle_input_mode") {
+            return Ok(());
+        }
+
         let mode = match IMEState::input_mode()? {
             InputMode::Latin => InputMode::Kana,
             InputMode::Kana => InputMode::Latin,

--- a/crates/client/src/tsf/text_input_proccesor.rs
+++ b/crates/client/src/tsf/text_input_proccesor.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    engine::{composition::CapsLockKeyboardLayout, ipc_service, state::IMEState},
+    engine::{composition::CapsLockKeyboardLayout, state::IMEState},
     globals::{DllModule, GUID_DISPLAY_ATTRIBUTE, GUID_PRESERVED_KEY_EISU_CAPSLOCK_ANY_MODIFIER},
 };
 
@@ -31,17 +31,6 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
         // add reference to the dll instance to prevent it from being unloaded
         let mut dll_instance = DllModule::get()?;
         dll_instance.add_ref();
-
-        // initialize ipc_service
-        if let Ok(mut ipc_service) = ipc_service::IPCService::new() {
-            ipc_service.append_text("".to_string())?;
-            IMEState::set_ipc_service(ipc_service)?;
-        } else {
-            // Activate() should not return an error
-            // if Activate() returns an error, the icon of the previously activated TextService will be displayed, which may confuse the user
-            tracing::error!("Failed to initialize IPC service");
-            return Ok(());
-        }
 
         let mut text_service = self.borrow_mut()?;
 
@@ -115,6 +104,19 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
         };
         drop(text_service);
         self.set_keyboard_disabled_for_document_mgr(doc_mgr.as_ref())?;
+        match IMEState::ensure_ipc_service() {
+            Ok(true) => tracing::debug!("Initialized IPC service during Activate"),
+            Ok(false) => {}
+            Err(error) => {
+                // Activate() should not return an error for a transient IPC startup race:
+                // Windows may keep showing the previously active IME icon even though TSF
+                // considers this text service activated.
+                tracing::warn!(
+                    ?error,
+                    "Failed to initialize IPC service during Activate; continuing TSF activation"
+                );
+            }
+        }
 
         tracing::debug!("Activate success");
 

--- a/crates/client/src/tsf/thread_mgr_event_sink.rs
+++ b/crates/client/src/tsf/thread_mgr_event_sink.rs
@@ -25,12 +25,11 @@ impl TextServiceFactory {
         let (changed, ipc_service) = IMEState::set_keyboard_disabled_and_clone_ipc(disabled)?;
 
         if let Some(mut ipc_service) = ipc_service {
-            let update_result =
-                ipc_service.update_candidate_window(Some(false), None, Some(vec![]), Some(0), None);
-            if update_result.is_ok() {
-                self.remember_candidate_window_visibility(Some(false));
+            if let Ok(delivery) =
+                ipc_service.update_candidate_window(Some(false), None, Some(vec![]), Some(0), None)
+            {
+                self.remember_candidate_window_visibility_if_sent(delivery, Some(false));
             }
-            let _ = update_result;
 
             IMEState::set_ipc_service(ipc_service)?;
         }

--- a/crates/client/src/tsf/thread_mgr_event_sink.rs
+++ b/crates/client/src/tsf/thread_mgr_event_sink.rs
@@ -12,6 +12,14 @@ use crate::engine::{
 
 use super::factory::{TextServiceFactory, TextServiceFactory_Impl};
 
+fn ensure_ipc_service_for_tsf_event(event: &str) {
+    match IMEState::ensure_ipc_service() {
+        Ok(true) => tracing::debug!(event, "Initialized IPC service during TSF event"),
+        Ok(false) => {}
+        Err(error) => tracing::warn!(?error, event, "IPC service is unavailable during TSF event"),
+    }
+}
+
 impl TextServiceFactory {
     pub fn set_keyboard_disabled_state(&self, disabled: bool) -> Result<()> {
         let (changed, ipc_service) = IMEState::set_keyboard_disabled_and_clone_ipc(disabled)?;
@@ -74,9 +82,16 @@ impl ITfThreadMgrEventSink_Impl for TextServiceFactory_Impl {
             self.borrow_mut()?.advise_text_layout_sink(focus.clone())?;
         }
         self.set_keyboard_disabled_for_document_mgr(focus)?;
+        ensure_ipc_service_for_tsf_event("OnSetFocus");
 
         let actions = vec![ClientAction::EndComposition];
-        self.handle_action(&actions, CompositionState::None)?;
+        if IMEState::ipc_service()?.is_some() {
+            self.handle_action(&actions, CompositionState::None)?;
+        } else {
+            tracing::debug!(
+                "Skipping focus composition cleanup because IPC service is unavailable"
+            );
+        }
 
         if focus.is_none() {
             let mut text_service = self.borrow_mut()?;
@@ -106,6 +121,7 @@ impl ITfThreadFocusSink_Impl for TextServiceFactory_Impl {
             let thread_mgr = text_service.thread_mgr()?;
             unsafe { thread_mgr.GetFocus().ok() }
         };
+        ensure_ipc_service_for_tsf_event("OnSetThreadFocus");
         self.set_keyboard_disabled_for_document_mgr(focus.as_ref())?;
 
         Ok(())


### PR DESCRIPTION
## Summary
- IPC の準備前に TSF が Activate されても、キーイベント・フォーカス通知・言語バーの登録を継続するようにしました。
- azookey_server / azookey_ui への接続をフォーカス・キー処理時に再試行し、UI IPC の失敗で入力機能全体が無効にならないようにしました。
- candidate window UI RPC が送信されなかった場合は、表示状態を送信済みとして記録しないようにしました。
- 言語バーの入力モード切り替えでも IPC を再試行し、deferred-start 状態で安全に扱うようにしました。

## Background
- Issue: Closes #109
- Windows 検索バーでは SearchHost.exe が早い段階で起動し、azookey_server または azookey_ui の準備前に TSF Activate が走る場合があります。
- 従来は IPC 接続に失敗すると Activate が早期 return し、キーイベント sink やフォーカス通知、言語バー項目が未登録のままになる可能性がありました。

## Changes
- client/TSF: `Activate` で TSF の基本登録を IPC 初期化より先に実行し、IPC 失敗時も TSF activation を継続
- client/state: `IMEState::ensure_ipc_service` を追加し、必要時に IPC を再接続
- client/key-focus: フォーカス通知とキー処理時に IPC 接続を再試行し、未接続時は安全に処理をスキップ
- client/langbar: 入力モード切り替え前に IPC 接続を再試行し、未接続時はクリック処理だけ安全にスキップ
- client/IPC: candidate window UI IPC を optional / best-effort 化し、UI pipe busy/失敗時に server-backed input を止めないように変更
- client/candidate-window: UI RPC の送信有無を区別し、未送信の show/hide 更新で visibility cache を更新しないように変更

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/28163093434
- [x] Windows VM 確認
  - `.local/vm_test_client_composition.sh fix/109-searchhost-ime-activation '' skip`: 115 passed（latest `07ab64c` 含む）
  - log: `.local/logs/vm-client-test-20260625-190943.log`
  - `.local/vm_build_master.sh fix/109-searchhost-ime-activation`: 成功
  - artifact: `.local/artifacts/azookey-setup-fix_109-searchhost-ime-activation-20260624-224804.exe`
- [x] ローカル確認
  - `git diff --check`: pass
  - `cargo fmt --all --check`: pass
  - `cargo check -p azookey-windows --target x86_64-pc-windows-msvc`: pass（既存 warning のみ）
  - `cargo check -p azookey-windows --tests --target x86_64-pc-windows-msvc`: pass（既存 warning のみ）
- [x] Read-only review
  - 指摘された busy pipe の無限 wait リスクを修正済み
- [x] Codex review follow-up
  - P2 指摘の「未送信 window RPC を送信済みとして扱う」問題を `5636944` で修正
  - P2 指摘の「言語バー toggle 前に IPC を retry しない」問題を `07ab64c` で修正
  - latest `07ab64c` の再レビューで major issues なし

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した