### PR TITLE
feat: add conversion learning history

### DIFF
--- a/crates/client/src/engine/client_action.rs
+++ b/crates/client/src/engine/client_action.rs
@@ -25,6 +25,7 @@ pub enum ClientAction {
     CommitLearning {
         scope: LearningCommitScope,
         kind: LearningCommitKind,
+        was_temporary_latin: bool,
     },
     SetTemporaryLatin(bool),
     SetTemporaryLatinShiftPending(bool),

--- a/crates/client/src/engine/client_action.rs
+++ b/crates/client/src/engine/client_action.rs
@@ -22,6 +22,10 @@ pub enum ClientAction {
     MoveClause(i32),
     AdjustBoundary(i32),
     SetSelection(SetSelectionType),
+    CommitLearning {
+        scope: LearningCommitScope,
+        kind: LearningCommitKind,
+    },
     SetTemporaryLatin(bool),
     SetTemporaryLatinShiftPending(bool),
 
@@ -33,6 +37,27 @@ pub enum SetSelectionType {
     Up,
     Down,
     Number(i32),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum LearningCommitKind {
+    Normal,
+    Partial,
+}
+
+impl LearningCommitKind {
+    pub(crate) fn proto_value(self) -> i32 {
+        match self {
+            Self::Normal => 1,
+            Self::Partial => 3,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum LearningCommitScope {
+    CurrentClause,
+    Composition,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1,5 +1,10 @@
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashSet,
+    rc::Rc,
+    time::{Duration, Instant},
+};
 
+use crate::tsf::edit_session::edit_session;
 use crate::{
     engine::user_action::UserAction,
     extension::VKeyExt as _,
@@ -8,7 +13,9 @@ use crate::{
 };
 
 use super::{
-    client_action::{ClientAction, SetSelectionType, SetTextType},
+    client_action::{
+        ClientAction, LearningCommitKind, LearningCommitScope, SetSelectionType, SetTextType,
+    },
     full_width::{convert_kana_symbol, to_fullwidth, to_halfwidth},
     input_mode::InputMode,
     ipc_service::{
@@ -27,16 +34,21 @@ use shared::{
     LIVE_CONVERSION_READING_VERTICAL_ADJUSTMENT_MAX,
     LIVE_CONVERSION_READING_VERTICAL_ADJUSTMENT_MIN,
 };
-use windows::core::{w, PCWSTR};
+use windows::core::{w, IUnknown, Interface as _, PCWSTR};
 use windows::Win32::{
     Foundation::{LPARAM, WPARAM},
+    System::Com::CoTaskMemFree,
     System::Registry::{RegGetValueW, HKEY, HKEY_LOCAL_MACHINE, RRF_RT_REG_SZ},
     UI::{
         Input::KeyboardAndMouse::{
             GetAsyncKeyState, GetKeyboardType, VK_CONTROL, VK_LCONTROL, VK_LMENU, VK_LSHIFT,
             VK_MENU, VK_RCONTROL, VK_RMENU, VK_RSHIFT, VK_SHIFT,
         },
-        TextServices::{ITfComposition, ITfCompositionSink_Impl, ITfContext},
+        TextServices::{
+            ITfComposition, ITfCompositionSink_Impl, ITfContext, ITfInputScope, InputScope,
+            GUID_PROP_INPUTSCOPE, IS_NUMERIC_PASSWORD, IS_PASSWORD, IS_PRIVATE,
+            TF_DEFAULT_SELECTION, TF_SELECTION,
+        },
     },
 };
 
@@ -155,6 +167,12 @@ pub struct FutureClauseSnapshot {
     selected_text: String,
     selected_sub_text: String,
     candidates: Candidates,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct PendingLearningCommit {
+    candidate_id: u64,
+    kind: LearningCommitKind,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -774,6 +792,7 @@ impl TextServiceFactory {
                 .get(index)
                 .copied()
                 .unwrap_or(0),
+            candidate_id: candidates.candidate_ids.get(index).copied().unwrap_or(0),
         })
     }
 
@@ -996,6 +1015,7 @@ impl TextServiceFactory {
                 sub_text: suffix.to_string(),
                 hiragana: raw_hiragana.to_string(),
                 corresponding_count,
+                candidate_id: 0,
             });
 
         FutureClauseSnapshot {
@@ -1029,6 +1049,7 @@ impl TextServiceFactory {
             sub_texts: vec![suffix.to_string()],
             hiragana: raw_hiragana.to_string(),
             corresponding_count: vec![corresponding_count],
+            candidate_ids: vec![0],
         };
         FutureClauseSnapshot {
             clause_preview: clause_preview.to_string(),
@@ -1352,6 +1373,7 @@ impl TextServiceFactory {
             ClientAction::AdjustBoundary(_) => "AdjustBoundary",
             ClientAction::SetIMEMode(_) => "SetIMEMode",
             ClientAction::SetSelection(_) => "SetSelection",
+            ClientAction::CommitLearning { .. } => "CommitLearning",
             ClientAction::ShrinkText(_) => "ShrinkText",
             ClientAction::ShrinkTextRaw(_) => "ShrinkTextRaw",
             ClientAction::ShrinkTextDirect(_) => "ShrinkTextDirect",
@@ -2706,6 +2728,215 @@ impl TextServiceFactory {
     }
 
     #[inline]
+    fn selected_learning_candidate_from_snapshot(
+        snapshot: &ClauseSnapshot,
+    ) -> Option<CandidateSelection> {
+        Self::select_candidate(&snapshot.candidates, snapshot.selection_index)
+    }
+
+    #[inline]
+    fn selected_learning_candidate_from_future_snapshot(
+        snapshot: &FutureClauseSnapshot,
+    ) -> Option<CandidateSelection> {
+        Self::select_candidate(&snapshot.candidates, snapshot.selection_index)
+    }
+
+    #[inline]
+    fn learning_candidate_reading(selection: &CandidateSelection) -> String {
+        selection
+            .hiragana
+            .chars()
+            .take(selection.corresponding_count.max(0) as usize)
+            .collect()
+    }
+
+    #[inline]
+    fn reading_has_japanese_kana(reading: &str) -> bool {
+        reading
+            .chars()
+            .any(|ch| matches!(ch, '\u{3040}'..='\u{30ff}' | '\u{31f0}'..='\u{31ff}'))
+    }
+
+    #[inline]
+    fn should_commit_learning_candidate(
+        selection: &CandidateSelection,
+        temporary_latin: bool,
+    ) -> bool {
+        if temporary_latin || selection.candidate_id == 0 || selection.text.is_empty() {
+            return false;
+        }
+
+        let reading = Self::learning_candidate_reading(selection);
+        reading.chars().count() >= 2 && Self::reading_has_japanese_kana(&reading)
+    }
+
+    #[inline]
+    fn clear_current_learning_candidate_ids(candidates: &mut Candidates) {
+        for candidate_id in &mut candidates.candidate_ids {
+            *candidate_id = 0;
+        }
+    }
+
+    fn collect_learning_candidate_ids(
+        scope: LearningCommitScope,
+        selection_index: i32,
+        candidates: &Candidates,
+        clause_snapshots: &[ClauseSnapshot],
+        future_clause_snapshots: &[FutureClauseSnapshot],
+        temporary_latin: bool,
+    ) -> Vec<u64> {
+        let mut candidate_ids = Vec::new();
+        let mut seen = HashSet::new();
+
+        let mut push_candidate = |selection: Option<CandidateSelection>| {
+            let Some(selection) = selection else {
+                return;
+            };
+            if !Self::should_commit_learning_candidate(&selection, temporary_latin) {
+                return;
+            }
+            if seen.insert(selection.candidate_id) {
+                candidate_ids.push(selection.candidate_id);
+            }
+        };
+
+        match scope {
+            LearningCommitScope::CurrentClause => {
+                push_candidate(Self::select_candidate(candidates, selection_index));
+            }
+            LearningCommitScope::Composition => {
+                for snapshot in clause_snapshots {
+                    push_candidate(Self::selected_learning_candidate_from_snapshot(snapshot));
+                }
+                push_candidate(Self::select_candidate(candidates, selection_index));
+                for snapshot in future_clause_snapshots.iter().rev() {
+                    push_candidate(Self::selected_learning_candidate_from_future_snapshot(
+                        snapshot,
+                    ));
+                }
+            }
+        }
+
+        candidate_ids
+    }
+
+    fn flush_pending_learning_commits(
+        ipc_service: &mut IPCService,
+        pending_learning_commits: &mut Vec<PendingLearningCommit>,
+    ) {
+        for commit in pending_learning_commits.drain(..) {
+            if let Err(error) = ipc_service
+                .commit_learning_candidate(commit.candidate_id, commit.kind.proto_value())
+            {
+                tracing::warn!(
+                    ?error,
+                    candidate_id = commit.candidate_id,
+                    kind = ?commit.kind,
+                    "Failed to commit conversion learning candidate"
+                );
+            }
+        }
+    }
+
+    #[inline]
+    fn is_sensitive_input_scope(scope: InputScope) -> bool {
+        scope == IS_PASSWORD || scope == IS_NUMERIC_PASSWORD || scope == IS_PRIVATE
+    }
+
+    fn input_scope_list_contains_sensitive(input_scope: &ITfInputScope) -> bool {
+        unsafe {
+            let mut scopes_ptr: *mut InputScope = std::ptr::null_mut();
+            let mut scope_count = 0;
+            if input_scope
+                .GetInputScopes(&mut scopes_ptr, &mut scope_count)
+                .is_err()
+            {
+                return false;
+            }
+            if scopes_ptr.is_null() {
+                return false;
+            }
+
+            let scopes = std::slice::from_raw_parts(scopes_ptr, scope_count as usize);
+            let sensitive = scopes.iter().copied().any(Self::is_sensitive_input_scope);
+            CoTaskMemFree(Some(scopes_ptr.cast()));
+            sensitive
+        }
+    }
+
+    fn context_has_sensitive_input_scope(tid: u32, context: ITfContext) -> Result<bool> {
+        Ok(edit_session::<bool>(
+            tid,
+            context.clone(),
+            Rc::new({
+                move |cookie| {
+                    let mut selection: [TF_SELECTION; 1] = [TF_SELECTION::default()];
+                    let mut fetched = 0;
+                    unsafe {
+                        context.GetSelection(
+                            cookie,
+                            TF_DEFAULT_SELECTION,
+                            &mut selection,
+                            &mut fetched,
+                        )?;
+                    }
+                    if fetched == 0 {
+                        return Ok(false);
+                    }
+
+                    let range = match selection[0].range.as_ref() {
+                        Some(range) => unsafe { range.Clone()? },
+                        None => return Ok(false),
+                    };
+                    let input_scope_property =
+                        unsafe { context.GetAppProperty(&GUID_PROP_INPUTSCOPE)? };
+                    let value = unsafe { input_scope_property.GetValue(cookie, &range)? };
+                    let unknown = IUnknown::try_from(&value)?;
+                    let input_scope = unknown.cast::<ITfInputScope>()?;
+                    Ok(Self::input_scope_list_contains_sensitive(&input_scope))
+                }
+            }),
+        )?
+        .unwrap_or(false))
+    }
+
+    fn current_context_has_sensitive_input_scope(&self) -> bool {
+        let (tid, context) = match self.borrow() {
+            Ok(text_service) => {
+                let tid = text_service.tid;
+                match text_service.context::<ITfContext>() {
+                    Ok(context) => (tid, context),
+                    Err(error) => {
+                        tracing::debug!(
+                            ?error,
+                            "Skip learning input scope check because context is unavailable"
+                        );
+                        return false;
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::debug!(
+                    ?error,
+                    "Skip learning input scope check because text service borrow failed"
+                );
+                return false;
+            }
+        };
+
+        match Self::context_has_sensitive_input_scope(tid, context) {
+            Ok(value) => value,
+            Err(error) => {
+                tracing::debug!(
+                    ?error,
+                    "Skip learning input scope check because input scope could not be read"
+                );
+                false
+            }
+        }
+    }
+
+    #[inline]
     fn commit_current_clause_actions(
         composition: &Composition,
     ) -> (CompositionState, Vec<ClientAction>) {
@@ -2722,9 +2953,35 @@ impl TextServiceFactory {
     #[inline]
     fn commit_enter_actions(composition: &Composition) -> (CompositionState, Vec<ClientAction>) {
         if ClauseState::is_active_for_composition(composition) {
-            (CompositionState::None, vec![ClientAction::EndComposition])
+            (
+                CompositionState::None,
+                vec![
+                    ClientAction::CommitLearning {
+                        scope: LearningCommitScope::Composition,
+                        kind: LearningCommitKind::Normal,
+                    },
+                    ClientAction::EndComposition,
+                ],
+            )
         } else {
-            Self::commit_current_clause_actions(composition)
+            let (state, mut actions) = Self::commit_current_clause_actions(composition);
+            let kind = if composition.suffix.is_empty() {
+                LearningCommitKind::Normal
+            } else {
+                LearningCommitKind::Partial
+            };
+            actions.insert(
+                0,
+                ClientAction::CommitLearning {
+                    scope: if composition.suffix.is_empty() {
+                        LearningCommitScope::Composition
+                    } else {
+                        LearningCommitScope::CurrentClause
+                    },
+                    kind,
+                },
+            );
+            (state, actions)
         }
     }
 
@@ -3951,6 +4208,13 @@ impl TextServiceFactory {
             let mut ipc_service;
             let mut transition = transition;
             let mut deferred_clause_navigation_ready_ui_sync = None;
+            let mut pending_learning_commits = Vec::new();
+            let has_learning_action = actions
+                .iter()
+                .any(|action| matches!(action, ClientAction::CommitLearning { .. }));
+            let learning_blocked = has_learning_action
+                && (IMEState::keyboard_disabled().unwrap_or(true)
+                    || self.current_context_has_sensitive_input_scope());
 
             macro_rules! reset_after_empty_server_composition {
                 ($reason:expr) => {{
@@ -4068,6 +4332,33 @@ impl TextServiceFactory {
                         )?;
                         self.remember_candidate_window_visibility_if_sent(delivery, Some(true));
                     }
+                    ClientAction::CommitLearning { scope, kind } => {
+                        if learning_blocked {
+                            tracing::debug!(
+                                ?scope,
+                                ?kind,
+                                "Skip conversion learning in disabled or sensitive context"
+                            );
+                            continue;
+                        }
+                        pending_learning_commits.extend(
+                            Self::collect_learning_candidate_ids(
+                                *scope,
+                                selection_index,
+                                &candidates,
+                                &clause_snapshots,
+                                &future_clause_snapshots,
+                                temporary_latin,
+                            )
+                            .into_iter()
+                            .map(|candidate_id| {
+                                PendingLearningCommit {
+                                    candidate_id,
+                                    kind: *kind,
+                                }
+                            }),
+                        );
+                    }
                     ClientAction::EndComposition => {
                         self.end_composition()?;
                         selection_index = 0;
@@ -4094,6 +4385,10 @@ impl TextServiceFactory {
                             None,
                         )?;
                         self.remember_candidate_window_visibility_if_sent(delivery, Some(false));
+                        Self::flush_pending_learning_commits(
+                            &mut ipc_service,
+                            &mut pending_learning_commits,
+                        );
                         ipc_service.clear_text()?;
                     }
                     ClientAction::AppendText(text) => {
@@ -5142,6 +5437,10 @@ impl TextServiceFactory {
                         };
 
                         if recovered {
+                            Self::flush_pending_learning_commits(
+                                &mut ipc_service,
+                                &mut pending_learning_commits,
+                            );
                             transition = CompositionState::Composing;
                         }
                     }
@@ -5247,6 +5546,10 @@ impl TextServiceFactory {
                         };
 
                         if recovered {
+                            Self::flush_pending_learning_commits(
+                                &mut ipc_service,
+                                &mut pending_learning_commits,
+                            );
                             transition = CompositionState::Composing;
                         }
                     }
@@ -5352,6 +5655,10 @@ impl TextServiceFactory {
                         };
 
                         if recovered {
+                            Self::flush_pending_learning_commits(
+                                &mut ipc_service,
+                                &mut pending_learning_commits,
+                            );
                             transition = CompositionState::Composing;
                         }
                     }
@@ -5382,6 +5689,7 @@ impl TextServiceFactory {
                         );
 
                         preview = Self::merge_preview_with_prefix(&fixed_prefix, &converted_clause);
+                        Self::clear_current_learning_candidate_ids(&mut candidates);
                         Self::sync_clause_snapshot_suffixes(
                             &mut clause_snapshots,
                             &preview,

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -2959,6 +2959,7 @@ impl TextServiceFactory {
                     ClientAction::CommitLearning {
                         scope: LearningCommitScope::Composition,
                         kind: LearningCommitKind::Normal,
+                        was_temporary_latin: composition.temporary_latin,
                     },
                     ClientAction::EndComposition,
                 ],
@@ -2979,6 +2980,7 @@ impl TextServiceFactory {
                         LearningCommitScope::CurrentClause
                     },
                     kind,
+                    was_temporary_latin: composition.temporary_latin,
                 },
             );
             (state, actions)
@@ -4332,7 +4334,11 @@ impl TextServiceFactory {
                         )?;
                         self.remember_candidate_window_visibility_if_sent(delivery, Some(true));
                     }
-                    ClientAction::CommitLearning { scope, kind } => {
+                    ClientAction::CommitLearning {
+                        scope,
+                        kind,
+                        was_temporary_latin,
+                    } => {
                         if learning_blocked {
                             tracing::debug!(
                                 ?scope,
@@ -4348,7 +4354,7 @@ impl TextServiceFactory {
                                 &candidates,
                                 &clause_snapshots,
                                 &future_clause_snapshots,
-                                temporary_latin,
+                                *was_temporary_latin,
                             )
                             .into_iter()
                             .map(|candidate_id| {

--- a/crates/client/src/engine/composition/clause_state.rs
+++ b/crates/client/src/engine/composition/clause_state.rs
@@ -17,6 +17,7 @@ pub(crate) struct CandidateSelection {
     pub(crate) sub_text: String,
     pub(crate) hiragana: String,
     pub(crate) corresponding_count: i32,
+    pub(crate) candidate_id: u64,
 }
 
 pub(crate) trait ClauseActionBackend {

--- a/crates/client/src/engine/composition/clause_state.rs
+++ b/crates/client/src/engine/composition/clause_state.rs
@@ -394,6 +394,10 @@ impl ClauseState {
             }
             *state.preview =
                 TextServiceFactory::merge_preview_with_prefix(state.fixed_prefix, &selected.text);
+            TextServiceFactory::clear_current_learning_candidate_ids(state.candidates);
+            for snapshot in state.future_clause_snapshots.iter_mut() {
+                TextServiceFactory::clear_current_learning_candidate_ids(&mut snapshot.candidates);
+            }
         }
         *state.suffix = TextServiceFactory::sync_current_clause_future_suffix(
             state.candidates,

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -38,7 +38,11 @@ pub(super) fn candidates(
 }
 
 fn learning_action(scope: LearningCommitScope, kind: LearningCommitKind) -> ClientAction {
-    ClientAction::CommitLearning { scope, kind }
+    ClientAction::CommitLearning {
+        scope,
+        kind,
+        was_temporary_latin: false,
+    }
 }
 
 pub(super) fn actual_future_snapshot(
@@ -829,10 +833,42 @@ fn enter_commits_all_when_clause_navigation_is_active() {
             ClientAction::CommitLearning {
                 scope: LearningCommitScope::Composition,
                 kind: LearningCommitKind::Normal,
+                was_temporary_latin: false,
             },
             ClientAction::EndComposition,
         ]
     );
+}
+
+#[test]
+fn enter_learning_preserves_temporary_latin_state() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        preview: "私A".to_string(),
+        raw_input: "watasiA".to_string(),
+        raw_hiragana: "わたしA".to_string(),
+        corresponding_count: 4,
+        temporary_latin: true,
+        ..Composition::default()
+    };
+
+    let (_, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Enter,
+        &InputMode::Kana,
+        false,
+        &AppConfig::default(),
+        false,
+    )
+    .expect("enter should commit temporary latin composition");
+
+    assert!(matches!(
+        actions.first(),
+        Some(ClientAction::CommitLearning {
+            was_temporary_latin: true,
+            ..
+        })
+    ));
 }
 
 #[test]
@@ -1262,6 +1298,15 @@ fn ensure_clause_navigation_preserves_fkey_display_preview() {
     assert_eq!(corresponding_count, 5);
     assert_eq!(current_candidates.texts[0], "カゲン");
     assert_eq!(current_candidates.sub_texts[0], "トウイツ");
+    assert!(current_candidates
+        .candidate_ids
+        .iter()
+        .all(|candidate_id| *candidate_id == 0));
+    assert!(future_clause_snapshots.iter().all(|snapshot| snapshot
+        .candidates
+        .candidate_ids
+        .iter()
+        .all(|candidate_id| *candidate_id == 0)));
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -4,7 +4,9 @@ use super::{
     CompositionReducer, CompositionState, FutureClauseSnapshot, TextServiceFactory,
 };
 use crate::engine::{
-    client_action::{ClientAction, SetSelectionType, SetTextType},
+    client_action::{
+        ClientAction, LearningCommitKind, LearningCommitScope, SetSelectionType, SetTextType,
+    },
     input_mode::InputMode,
     ipc_service::WindowRpcDelivery,
     user_action::{Function, Navigation, UserAction},
@@ -31,7 +33,12 @@ pub(super) fn candidates(
         sub_texts: sub_texts.iter().map(|value| (*value).to_string()).collect(),
         hiragana: hiragana.to_string(),
         corresponding_count: corresponding_count.to_vec(),
+        candidate_ids: (1..=texts.len() as u64).collect(),
     }
+}
+
+fn learning_action(scope: LearningCommitScope, kind: LearningCommitKind) -> ClientAction {
+    ClientAction::CommitLearning { scope, kind }
 }
 
 pub(super) fn actual_future_snapshot(
@@ -196,6 +203,93 @@ fn delayed_candidate_window_shows_when_space_opens_preview() {
             ClientAction::SetSelection(SetSelectionType::Down)
         ]
     );
+}
+
+#[test]
+fn space_preview_does_not_commit_learning() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        raw_input: "a".to_string(),
+        ..Composition::default()
+    };
+
+    let (_, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Space,
+        &InputMode::Kana,
+        false,
+        &AppConfig::default(),
+        false,
+    )
+    .expect("space should enter preview");
+
+    assert!(!actions
+        .iter()
+        .any(|action| matches!(action, ClientAction::CommitLearning { .. })));
+}
+
+#[test]
+fn learning_candidate_filter_skips_short_latin_and_temporary_latin() {
+    let short_reading = candidates(&["は"], &[""], "は", &[1]);
+    let latin = candidates(&["abc"], &[""], "abc", &[3]);
+    let japanese = candidates(&["私"], &[""], "わたし", &[3]);
+
+    assert!(TextServiceFactory::collect_learning_candidate_ids(
+        LearningCommitScope::CurrentClause,
+        0,
+        &short_reading,
+        &[],
+        &[],
+        false,
+    )
+    .is_empty());
+    assert!(TextServiceFactory::collect_learning_candidate_ids(
+        LearningCommitScope::CurrentClause,
+        0,
+        &latin,
+        &[],
+        &[],
+        false,
+    )
+    .is_empty());
+    assert!(TextServiceFactory::collect_learning_candidate_ids(
+        LearningCommitScope::CurrentClause,
+        0,
+        &japanese,
+        &[],
+        &[],
+        true,
+    )
+    .is_empty());
+    assert_eq!(
+        TextServiceFactory::collect_learning_candidate_ids(
+            LearningCommitScope::CurrentClause,
+            0,
+            &japanese,
+            &[],
+            &[],
+            false,
+        ),
+        vec![1]
+    );
+}
+
+#[test]
+fn display_override_clears_learning_candidate_ids() {
+    let mut current_candidates = candidates(&["私", "渡し"], &["", ""], "わたし", &[3, 3]);
+
+    TextServiceFactory::clear_current_learning_candidate_ids(&mut current_candidates);
+
+    assert_eq!(current_candidates.candidate_ids, vec![0, 0]);
+    assert!(TextServiceFactory::collect_learning_candidate_ids(
+        LearningCommitScope::CurrentClause,
+        0,
+        &current_candidates,
+        &[],
+        &[],
+        false,
+    )
+    .is_empty());
 }
 
 #[test]
@@ -729,7 +823,51 @@ fn enter_commits_all_when_clause_navigation_is_active() {
     .expect("enter should commit active clause navigation");
 
     assert_eq!(transition, CompositionState::None);
-    assert_eq!(actions, vec![ClientAction::EndComposition]);
+    assert_eq!(
+        actions,
+        vec![
+            ClientAction::CommitLearning {
+                scope: LearningCommitScope::Composition,
+                kind: LearningCommitKind::Normal,
+            },
+            ClientAction::EndComposition,
+        ]
+    );
+}
+
+#[test]
+fn enter_learns_only_current_clause_when_suffix_remains() {
+    let composition = Composition {
+        state: CompositionState::Composing,
+        preview: "加減".to_string(),
+        suffix: "統一".to_string(),
+        raw_input: "kagentouitu".to_string(),
+        raw_hiragana: "かげんとういつ".to_string(),
+        corresponding_count: 5,
+        ..Composition::default()
+    };
+
+    let (transition, actions) = TextServiceFactory::plan_actions_for_user_action(
+        &composition,
+        &UserAction::Enter,
+        &InputMode::Kana,
+        false,
+        &AppConfig::default(),
+        false,
+    )
+    .expect("enter should commit the current clause");
+
+    assert_eq!(transition, CompositionState::Composing);
+    assert_eq!(
+        actions,
+        vec![
+            learning_action(
+                LearningCommitScope::CurrentClause,
+                LearningCommitKind::Partial,
+            ),
+            ClientAction::ShrinkText("".to_string()),
+        ]
+    );
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests/stateful_harness.rs
+++ b/crates/client/src/engine/composition/tests/stateful_harness.rs
@@ -405,11 +405,13 @@ fn candidates_owned(
     hiragana: String,
     corresponding_count: Vec<i32>,
 ) -> Candidates {
+    let candidate_ids = (1..=texts.len() as u64).collect();
     Candidates {
         texts,
         sub_texts,
         hiragana,
         corresponding_count,
+        candidate_ids,
     }
 }
 
@@ -1706,6 +1708,7 @@ fn apply_user_action(
                 harness.state = CompositionState::Composing;
             }
             ClientAction::ShowCandidateWindow => {}
+            ClientAction::CommitLearning { .. } => {}
             ClientAction::CommitTextDirect(text) => {
                 harness.committed_clauses.push(SimCommittedClause {
                     display: text.clone(),

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -61,6 +61,7 @@ pub struct Candidates {
     pub sub_texts: Vec<String>,
     pub hiragana: String,
     pub corresponding_count: Vec<i32>,
+    pub candidate_ids: Vec<u64>,
 }
 
 impl Candidates {
@@ -69,6 +70,7 @@ impl Candidates {
             && self.sub_texts.is_empty()
             && self.hiragana.is_empty()
             && self.corresponding_count.is_empty()
+            && self.candidate_ids.is_empty()
     }
 }
 
@@ -303,6 +305,11 @@ impl IPCService {
                     .suggestions
                     .iter()
                     .map(|s| s.corresponding_count)
+                    .collect(),
+                candidate_ids: composing_text
+                    .suggestions
+                    .iter()
+                    .map(|s| s.candidate_id)
                     .collect(),
             })
         } else {
@@ -544,6 +551,26 @@ impl IPCService {
             .block_on(self.azookey_client.clear_text(request))?;
         let response = response.into_inner();
         self.observe_server_session("clear_text", response.server_session_id);
+        Ok(())
+    }
+
+    fn send_commit_learning_candidate(
+        &mut self,
+        candidate_id: u64,
+        commit_kind: i32,
+        request_id: u64,
+    ) -> anyhow::Result<()> {
+        let request = tonic::Request::new(shared::proto::CommitLearningCandidateRequest {
+            candidate_id,
+            commit_kind,
+            request_id,
+        });
+        let response = self
+            .runtime
+            .clone()
+            .block_on(self.azookey_client.commit_learning_candidate(request))?;
+        let response = response.into_inner();
+        self.observe_server_session("commit_learning_candidate", response.server_session_id);
         Ok(())
     }
 
@@ -888,6 +915,38 @@ impl IPCService {
             || match &result {
                 Ok(((), retried)) => format!("status=success;retry={retried}"),
                 Err(error) => format!("status=error;error={error:?}"),
+            },
+        );
+        result.map(|((), _)| ())
+    }
+
+    #[tracing::instrument]
+    pub fn commit_learning_candidate(
+        &mut self,
+        candidate_id: u64,
+        commit_kind: i32,
+    ) -> anyhow::Result<()> {
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let result = self.run_rpc_with_reconnect("commit_learning_candidate", |this| {
+            this.send_commit_learning_candidate(candidate_id, commit_kind, request_id)
+        });
+        self.log_client_performance_from_start(
+            performance_start,
+            request_id,
+            "commit_learning_candidate",
+            "rpc_total",
+            || match &result {
+                Ok(((), retried)) => {
+                    format!(
+                        "status=success;retry={retried};candidate_id={candidate_id};commit_kind={commit_kind}"
+                    )
+                }
+                Err(error) => {
+                    format!(
+                        "status=error;candidate_id={candidate_id};commit_kind={commit_kind};error={error:?}"
+                    )
+                }
             },
         );
         result.map(|((), _)| ())
@@ -1371,6 +1430,7 @@ mod tests {
             sub_texts: vec![String::new()],
             hiragana: "か".to_string(),
             corresponding_count: vec![1],
+            candidate_ids: vec![1],
         };
 
         assert!(IPCService::should_retry_append_after_refresh(
@@ -1387,6 +1447,7 @@ mod tests {
             sub_texts: vec![String::new()],
             hiragana: "か".to_string(),
             corresponding_count: vec![1],
+            candidate_ids: vec![1],
         };
 
         assert!(!IPCService::should_retry_append_after_refresh(
@@ -1402,6 +1463,7 @@ mod tests {
             sub_texts: vec![String::new()],
             hiragana: "かんじ".to_string(),
             corresponding_count: vec![5],
+            candidate_ids: vec![1],
         };
 
         assert!(IPCService::should_retry_append_after_refresh(
@@ -1417,6 +1479,7 @@ mod tests {
             sub_texts: vec![String::new()],
             hiragana: "かんじ".to_string(),
             corresponding_count: vec![5],
+            candidate_ids: vec![1],
         };
 
         assert!(
@@ -1434,6 +1497,7 @@ mod tests {
             sub_texts: vec![String::new()],
             hiragana: "か".to_string(),
             corresponding_count: vec![1],
+            candidate_ids: vec![1],
         };
 
         assert!(
@@ -1451,6 +1515,7 @@ mod tests {
             sub_texts: vec![String::new()],
             hiragana: "か".to_string(),
             corresponding_count: vec![1],
+            candidate_ids: vec![1],
         };
 
         assert!(IPCService::should_retry_non_idempotent_edit_after_refresh(
@@ -1466,12 +1531,14 @@ mod tests {
             sub_texts: vec![String::new()],
             hiragana: "か".to_string(),
             corresponding_count: vec![1],
+            candidate_ids: vec![1],
         };
         let refreshed = Candidates {
             texts: vec!["".to_string()],
             sub_texts: vec![String::new()],
             hiragana: String::new(),
             corresponding_count: vec![0],
+            candidate_ids: vec![1],
         };
 
         assert!(!IPCService::should_retry_non_idempotent_edit_after_refresh(
@@ -1487,6 +1554,7 @@ mod tests {
             sub_texts: vec![String::new()],
             hiragana: "か".to_string(),
             corresponding_count: vec![1],
+            candidate_ids: vec![1],
         };
 
         assert!(!IPCService::should_retry_non_idempotent_edit_after_refresh(
@@ -1543,6 +1611,7 @@ mod tests {
             sub_texts: vec![String::new()],
             hiragana: "か".to_string(),
             corresponding_count: vec![1],
+            candidate_ids: vec![1],
         };
 
         let attempt =

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -72,6 +72,14 @@ impl Candidates {
             && self.corresponding_count.is_empty()
             && self.candidate_ids.is_empty()
     }
+
+    #[inline]
+    fn has_same_composition(&self, other: &Self) -> bool {
+        self.texts == other.texts
+            && self.sub_texts == other.sub_texts
+            && self.hiragana == other.hiragana
+            && self.corresponding_count == other.corresponding_count
+    }
 }
 
 #[derive(Debug)]
@@ -429,7 +437,8 @@ impl IPCService {
         refreshed_candidates: &Candidates,
     ) -> bool {
         previous_candidates.is_some_and(|previous| {
-            previous == refreshed_candidates && !refreshed_candidates.is_empty_composition()
+            previous.has_same_composition(refreshed_candidates)
+                && !refreshed_candidates.is_empty_composition()
         })
     }
 
@@ -717,7 +726,8 @@ impl IPCService {
         refreshed_candidates: &Candidates,
     ) -> bool {
         previous_candidates.is_some_and(|previous| {
-            previous == refreshed_candidates || refreshed_candidates.is_empty_composition()
+            previous.has_same_composition(refreshed_candidates)
+                || refreshed_candidates.is_empty_composition()
         })
     }
 
@@ -1440,6 +1450,26 @@ mod tests {
     }
 
     #[test]
+    fn append_retry_ignores_refreshed_candidate_ids() {
+        let previous = Candidates {
+            texts: vec!["か".to_string()],
+            sub_texts: vec![String::new()],
+            hiragana: "か".to_string(),
+            corresponding_count: vec![1],
+            candidate_ids: vec![1],
+        };
+        let refreshed = Candidates {
+            candidate_ids: vec![2],
+            ..previous.clone()
+        };
+
+        assert!(IPCService::should_retry_append_after_refresh(
+            Some(&previous),
+            &refreshed
+        ));
+    }
+
+    #[test]
     fn append_retry_is_disabled_when_server_state_has_changed() {
         let previous = Candidates::default();
         let refreshed = Candidates {
@@ -1521,6 +1551,26 @@ mod tests {
         assert!(IPCService::should_retry_non_idempotent_edit_after_refresh(
             Some(&previous),
             &previous
+        ));
+    }
+
+    #[test]
+    fn non_idempotent_edit_retry_ignores_refreshed_candidate_ids() {
+        let previous = Candidates {
+            texts: vec!["か".to_string()],
+            sub_texts: vec![String::new()],
+            hiragana: "か".to_string(),
+            corresponding_count: vec![1],
+            candidate_ids: vec![1],
+        };
+        let refreshed = Candidates {
+            candidate_ids: vec![2],
+            ..previous.clone()
+        };
+
+        assert!(IPCService::should_retry_non_idempotent_edit_after_refresh(
+            Some(&previous),
+            &refreshed
         ));
     }
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -393,6 +393,7 @@ struct FFICandidate {
     subtext: *mut c_char,
     hiragana: *mut c_char,
     corresponding_count: c_int,
+    candidate_id: u64,
 }
 
 unsafe extern "C" {
@@ -410,6 +411,8 @@ unsafe extern "C" {
     fn GetComposedTextForCursorPrefix(lengthPtr: *mut c_int) -> *mut *mut FFICandidate;
     fn FreeCString(ptr: *mut c_char);
     fn FreeCandidateList(ptr: *mut *mut FFICandidate, length: c_int);
+    fn CommitLearningCandidate(candidateId: u64, commitKind: c_int) -> bool;
+    fn ResetLearningMemory() -> bool;
     fn LoadConfig();
     fn SetRequestId(request_id: u64);
     fn SetServerLogCallbacks(
@@ -1184,6 +1187,14 @@ fn clear_text() {
     }
 }
 
+fn swift_commit_learning_candidate(candidate_id: u64, commit_kind: i32) -> bool {
+    unsafe { CommitLearningCandidate(candidate_id, commit_kind as c_int) }
+}
+
+fn swift_reset_learning_memory() -> bool {
+    unsafe { ResetLearningMemory() }
+}
+
 fn warmup() -> bool {
     unsafe { Warmup() }
 }
@@ -1298,6 +1309,7 @@ fn get_composed_text(use_cursor_prefix: bool, request_id: u64) -> Result<Compose
             text,
             subtext,
             corresponding_count,
+            candidate_id: candidate.candidate_id,
         };
 
         suggestions.push(suggestion);
@@ -1670,6 +1682,89 @@ impl AzookeyService for MyAzookeyService {
         );
         Ok(Response::new(shared::proto::UpdateConfigResponse {
             server_session_id: server_session_id(),
+        }))
+    }
+
+    async fn commit_learning_candidate(
+        &self,
+        request: Request<shared::proto::CommitLearningCandidateRequest>,
+    ) -> Result<Response<shared::proto::CommitLearningCandidateResponse>, Status> {
+        let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(true);
+        let request_id = request_id_or_next(request.request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+        let candidate_id = request.candidate_id;
+        let commit_kind = request.commit_kind;
+
+        let commit_start = Instant::now();
+        let committed = swift_commit_learning_candidate(candidate_id, commit_kind);
+        if !committed {
+            log_event(
+                ServerLogLevel::Warn,
+                &format!(
+                    "[commit_learning_candidate] candidate not learned candidate_id={candidate_id};commit_kind={commit_kind}"
+                ),
+            );
+        }
+        performance_event_lazy!(
+            request_id,
+            "commit_learning_candidate",
+            "swift_commit_learning_candidate",
+            elapsed_ms(commit_start),
+            "candidate_id={candidate_id};commit_kind={commit_kind};committed={committed}"
+        );
+        performance_event_lazy!(
+            request_id,
+            "commit_learning_candidate",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success;candidate_id={candidate_id};commit_kind={commit_kind};committed={committed}"
+        );
+
+        Ok(Response::new(
+            shared::proto::CommitLearningCandidateResponse {
+                server_session_id: server_session_id(),
+            },
+        ))
+    }
+
+    async fn reset_learning_memory(
+        &self,
+        request: Request<shared::proto::ResetLearningMemoryRequest>,
+    ) -> Result<Response<shared::proto::ResetLearningMemoryResponse>, Status> {
+        let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(false);
+        let request_id = request_id_or_next(request.request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+
+        let reset_start = Instant::now();
+        let reset = swift_reset_learning_memory();
+        if !reset {
+            log_event(
+                ServerLogLevel::Warn,
+                "[reset_learning_memory] Swift reset returned false",
+            );
+        }
+        performance_event_lazy!(
+            request_id,
+            "reset_learning_memory",
+            "swift_reset_learning_memory",
+            elapsed_ms(reset_start),
+            "reset={reset}"
+        );
+        performance_event_lazy!(
+            request_id,
+            "reset_learning_memory",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success;reset={reset}"
+        );
+
+        Ok(Response::new(shared::proto::ResetLearningMemoryResponse {
+            server_session_id: server_session_id(),
+            reset,
         }))
     }
 

--- a/crates/shared/service.proto
+++ b/crates/shared/service.proto
@@ -6,6 +6,7 @@ message Suggestion {
   string text = 1;    // The main suggestion text.
   string subtext = 2; // Additional information or subtext for the suggestion.
   int32 corresponding_count = 3;
+  uint64 candidate_id = 4;
 }
 
 // ComposingText represents the text and its associated suggestions.
@@ -92,6 +93,32 @@ message UpdateConfigResponse {
   uint64 server_session_id = 1; // Identifies the current server process session.
 }
 
+enum LearningCommitKind {
+  LEARNING_COMMIT_KIND_UNSPECIFIED = 0;
+  LEARNING_COMMIT_KIND_NORMAL = 1;
+  LEARNING_COMMIT_KIND_PUNCTUATION = 2;
+  LEARNING_COMMIT_KIND_PARTIAL = 3;
+}
+
+message CommitLearningCandidateRequest {
+  uint64 candidate_id = 1;
+  LearningCommitKind commit_kind = 2;
+  uint64 request_id = 3;
+}
+
+message CommitLearningCandidateResponse {
+  uint64 server_session_id = 1; // Identifies the current server process session.
+}
+
+message ResetLearningMemoryRequest {
+  uint64 request_id = 1;
+}
+
+message ResetLearningMemoryResponse {
+  uint64 server_session_id = 1; // Identifies the current server process session.
+  bool reset = 2;
+}
+
 message PerformanceLogRequest {
   uint64 request_id = 1;
   string component = 2;
@@ -113,5 +140,7 @@ service AzookeyService {
   rpc ClearText (ClearTextRequest) returns (ClearTextResponse);
   rpc SetContext (SetContextRequest) returns (SetContextResponse);
   rpc UpdateConfig (UpdateConfigRequest) returns (UpdateConfigResponse);
+  rpc CommitLearningCandidate (CommitLearningCandidateRequest) returns (CommitLearningCandidateResponse);
+  rpc ResetLearningMemory (ResetLearningMemoryRequest) returns (ResetLearningMemoryResponse);
   rpc LogPerformance (PerformanceLogRequest) returns (PerformanceLogResponse);
 }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -224,6 +224,14 @@ pub enum NumpadInputMode {
     FollowInputMode,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LearningMode {
+    Enabled,
+    ReadOnly,
+    Disabled,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct CharacterWidthGroups {
     pub alphabet: WidthMode,
@@ -446,8 +454,9 @@ pub fn zenzai_cpu_backend_supported() -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppConfig, ConfigError, DebugConfig, GeneralConfig, NumpadInputMode, ShortcutConfig,
-        CONFIG_VERSION, SETTINGS_FILENAME,
+        AppConfig, ConfigError, DebugConfig, GeneralConfig, LearningConfig, LearningMode,
+        NumpadInputMode, ShortcutConfig, CONFIG_VERSION,
+        LIVE_CONVERSION_READING_VERTICAL_ADJUSTMENT_DEFAULT, SETTINGS_FILENAME,
     };
     use std::{
         env,
@@ -576,6 +585,24 @@ mod tests {
         assert!(deserialized.ctrl_space_toggle);
         assert!(deserialized.alt_backquote_toggle);
         assert!(!deserialized.eisu_toggle);
+    }
+
+    #[test]
+    fn learning_defaults_to_enabled() {
+        let default_config = LearningConfig::default();
+        assert_eq!(default_config.mode, LearningMode::Enabled);
+
+        let deserialized: LearningConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(deserialized.mode, LearningMode::Enabled);
+
+        let app_config: AppConfig = serde_json::from_str(
+            r#"{
+                "version": "0.1.2",
+                "zenzai": { "enable": false, "profile": "", "backend": "cpu" }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(app_config.learning.mode, LearningMode::Enabled);
     }
 
     #[test]
@@ -847,6 +874,20 @@ pub struct UserDictionaryConfig {
     pub entries: Vec<UserDictionaryEntry>,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct LearningConfig {
+    #[serde(default)]
+    pub mode: LearningMode,
+}
+
+impl Default for LearningConfig {
+    fn default() -> Self {
+        Self {
+            mode: LearningMode::Enabled,
+        }
+    }
+}
+
 impl Default for CharacterWidthConfig {
     fn default() -> Self {
         Self {
@@ -877,6 +918,12 @@ impl Default for SpaceInputMode {
 impl Default for NumpadInputMode {
     fn default() -> Self {
         Self::DirectInput
+    }
+}
+
+impl Default for LearningMode {
+    fn default() -> Self {
+        Self::Enabled
     }
 }
 
@@ -930,6 +977,8 @@ pub struct AppConfig {
     pub character_width: CharacterWidthConfig,
     #[serde(default)]
     pub user_dictionary: UserDictionaryConfig,
+    #[serde(default)]
+    pub learning: LearningConfig,
 }
 
 impl Default for AppConfig {
@@ -947,6 +996,7 @@ impl Default for AppConfig {
             romaji_table: RomajiTableConfig::default(),
             character_width: CharacterWidthConfig::default(),
             user_dictionary: UserDictionaryConfig::default(),
+            learning: LearningConfig::default(),
         }
     }
 }

--- a/frontend/src-tauri/src/ipc.rs
+++ b/frontend/src-tauri/src/ipc.rs
@@ -107,6 +107,18 @@ impl IPCService {
 
         Ok(())
     }
+
+    pub fn reset_learning_memory(&mut self) -> anyhow::Result<bool> {
+        let request =
+            tonic::Request::new(shared::proto::ResetLearningMemoryRequest { request_id: 0 });
+        let response = self
+            .runtime
+            .clone()
+            .block_on(self.azookey_client.reset_learning_memory(request))?
+            .into_inner();
+
+        Ok(response.reset)
+    }
 }
 
 #[cfg(test)]

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -70,6 +70,13 @@ struct UpdateConfigResponse {
     message: Option<String>,
 }
 
+#[derive(Debug, Serialize, Clone)]
+struct ResetLearningHistoryResponse {
+    reset: bool,
+    server_applied: bool,
+    message: Option<String>,
+}
+
 fn notice_from_recovery(recovery: &ConfigRecovery) -> ConfigStartupNotice {
     ConfigStartupNotice {
         kind: "recovered".to_string(),
@@ -164,6 +171,48 @@ fn update_config_impl(
         server_applied: true,
         message: None,
     })
+}
+
+#[tauri::command]
+fn reset_learning_history(
+    state: tauri::State<AppState>,
+) -> Result<ResetLearningHistoryResponse, String> {
+    Ok(reset_learning_history_impl(&state))
+}
+
+fn reset_learning_history_impl(state: &AppState) -> ResetLearningHistoryResponse {
+    if let Some(ipc) = state.ipc.lock().unwrap().as_mut() {
+        let reset = match ipc.reset_learning_memory() {
+            Ok(reset) => reset,
+            Err(error) => {
+                eprintln!("Failed to reset learning memory: {}", error);
+                return ResetLearningHistoryResponse {
+                    reset: false,
+                    server_applied: false,
+                    message: Some(error.to_string()),
+                };
+            }
+        };
+        if !reset {
+            return ResetLearningHistoryResponse {
+                reset: false,
+                server_applied: true,
+                message: Some("サーバー側で学習履歴の削除に失敗しました。".to_string()),
+            };
+        }
+    } else {
+        return ResetLearningHistoryResponse {
+            reset: false,
+            server_applied: false,
+            message: Some("IPC service is not initialized".to_string()),
+        };
+    }
+
+    ResetLearningHistoryResponse {
+        reset: true,
+        server_applied: true,
+        message: None,
+    }
 }
 
 #[tauri::command]
@@ -272,7 +321,8 @@ pub fn run() {
             check_for_updates,
             start_update,
             take_update_install_result,
-            restart_server
+            restart_server,
+            reset_learning_history
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -372,6 +422,17 @@ mod tests {
 
         assert!(error.contains("APPDATA"));
         assert!(!state.settings.lock().unwrap().zenzai.enable);
+    }
+
+    #[test]
+    fn reset_learning_history_reports_unavailable_server() {
+        let state = test_state();
+
+        let result = reset_learning_history_impl(&state);
+
+        assert!(!result.reset);
+        assert!(!result.server_applied);
+        assert!(result.message.is_some());
     }
 
     #[test]

--- a/frontend/src/pages/general.tsx
+++ b/frontend/src/pages/general.tsx
@@ -7,6 +7,17 @@ import { Download, Keyboard, RefreshCcw, Table2, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
     Select,
     SelectContent,
     SelectItem,
@@ -17,6 +28,7 @@ import { Switch } from "@/components/ui/switch";
 import { saveConfigWithToast } from "@/lib/config";
 
 type WidthMode = "half" | "full";
+type LearningMode = "enabled" | "read_only" | "disabled";
 
 type GeneralConfigState = {
     punctuation_style: string;
@@ -59,6 +71,12 @@ type UpdateCheckResponse = {
     release_name: string;
     release_url: string;
     update_available: boolean;
+};
+
+type ResetLearningHistoryResponse = {
+    reset: boolean;
+    server_applied: boolean;
+    message?: string | null;
 };
 
 type UpdateStatus =
@@ -141,6 +159,12 @@ const NUMPAD_OPTIONS = [
     { value: "follow_input_mode", label: "入力モードに従う" },
 ];
 
+const LEARNING_MODE_OPTIONS: Array<{ value: LearningMode; label: string }> = [
+    { value: "enabled", label: "有効" },
+    { value: "read_only", label: "新規学習はしない" },
+    { value: "disabled", label: "無効" },
+];
+
 const WIDTH_OPTIONS = [
     { value: "half", label: "半角" },
     { value: "full", label: "全角" },
@@ -215,6 +239,13 @@ const normalizeGeneralConfig = (value?: Record<string, unknown>): GeneralConfigS
         ),
 });
 
+const normalizeLearningMode = (value?: unknown): LearningMode => {
+    if (value === "enabled" || value === "read_only" || value === "disabled") {
+        return value;
+    }
+    return "enabled";
+};
+
 const normalizeWidthGroups = (
     value?: Record<string, unknown>,
 ): CharacterWidthGroupsState => {
@@ -277,6 +308,7 @@ export const General = () => {
     const [generalValue, setGeneralValue] = useState<GeneralConfigState>(
         DEFAULT_GENERAL_CONFIG,
     );
+    const [learningMode, setLearningMode] = useState<LearningMode>("enabled");
     const [widthGroups, setWidthGroups] =
         useState<CharacterWidthGroupsState>(DEFAULT_WIDTH_GROUPS);
     const [romajiRows, setRomajiRows] = useState<RomajiRow[]>([]);
@@ -307,6 +339,7 @@ export const General = () => {
                 });
 
                 setGeneralValue(normalizeGeneralConfig(data.general));
+                setLearningMode(normalizeLearningMode(data.learning?.mode));
                 setWidthGroups(normalizeWidthGroups(data.character_width?.groups));
                 setRomajiRows(normalizeRomajiRows(data.romaji_table?.rows));
             })
@@ -558,6 +591,38 @@ export const General = () => {
         const normalizedValue = clampLiveConversionReadingVerticalAdjustment(nextValue);
         liveConversionReadingAdjustmentSaveRef.current.pendingValue = normalizedValue;
         void flushLiveConversionReadingVerticalAdjustmentSave();
+    };
+
+    const updateLearningMode = async (nextValue: LearningMode) => {
+        const data = await updateConfig((config) => {
+            config.learning = config.learning ?? {};
+            config.learning.mode = nextValue;
+        });
+
+        if (data) {
+            setLearningMode(normalizeLearningMode(data.learning?.mode));
+        }
+    };
+
+    const resetLearningHistory = async () => {
+        try {
+            const result = await invoke<ResetLearningHistoryResponse>(
+                "reset_learning_history",
+            );
+            if (result.reset && result.server_applied) {
+                toast("学習履歴を削除しました");
+                return;
+            }
+
+            toast("学習履歴を削除できませんでした", {
+                description: result.message ?? undefined,
+            });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            toast("学習履歴を削除できませんでした", {
+                description: message,
+            });
+        }
     };
 
     const updateWidthGroup = async (
@@ -871,6 +936,72 @@ export const General = () => {
                                 />
                             </div>
                         ) : null}
+                    </div>
+                </section>
+
+                <section className="space-y-3">
+                    <h1 className="text-sm font-bold text-foreground">変換学習</h1>
+                    <div className="space-y-3 rounded-md border p-4">
+                        <div className="grid grid-cols-[1fr_220px] items-center gap-4">
+                            <div className="space-y-1">
+                                <p className="text-sm font-medium leading-none">変換学習</p>
+                                <p className="text-xs text-muted-foreground">
+                                    確定した候補を次回以降の変換順位に反映します
+                                </p>
+                            </div>
+                            <div className="flex justify-end">
+                                <Select
+                                    value={learningMode}
+                                    onValueChange={(value: LearningMode) =>
+                                        void updateLearningMode(value)
+                                    }
+                                >
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="変換学習" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {LEARNING_MODE_OPTIONS.map((option) => (
+                                            <SelectItem key={option.value} value={option.value}>
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        </div>
+
+                        <div className="flex items-center gap-4 border-t pt-3">
+                            <div className="flex-1 space-y-1">
+                                <p className="text-sm font-medium leading-none">学習履歴を削除</p>
+                                <p className="text-xs text-muted-foreground">
+                                    保存済みの変換学習データを削除します
+                                </p>
+                            </div>
+                            <AlertDialog>
+                                <AlertDialogTrigger asChild>
+                                    <Button variant="outline">
+                                        <Trash2 />
+                                        削除
+                                    </Button>
+                                </AlertDialogTrigger>
+                                <AlertDialogContent>
+                                    <AlertDialogHeader>
+                                        <AlertDialogTitle>学習履歴を削除</AlertDialogTitle>
+                                        <AlertDialogDescription>
+                                            これまでの変換学習データを削除します。
+                                        </AlertDialogDescription>
+                                    </AlertDialogHeader>
+                                    <AlertDialogFooter>
+                                        <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                                        <AlertDialogAction
+                                            onClick={() => void resetLearningHistory()}
+                                        >
+                                            削除
+                                        </AlertDialogAction>
+                                    </AlertDialogFooter>
+                                </AlertDialogContent>
+                            </AlertDialog>
+                        </div>
                     </div>
                 </section>
 

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -27,6 +27,10 @@ private let fallbackDictionaryURL =
 @MainActor var composingTextSnapshots: [ComposingText] = []
 @MainActor var currentInputStyle: InputStyle = .roman2kana
 @MainActor var customRomajiTableEnabled = false
+@MainActor var currentLearningType: LearningType = .inputAndOutput
+@MainActor var currentLearningMemoryDirectoryURL: URL?
+@MainActor var nextLearningCandidateId: UInt64 = 1
+@MainActor var learningCandidateCache: [UInt64: Candidate] = [:]
 
 @MainActor var execURL = URL(filePath: "")
 @MainActor var config: [String : Any] = [
@@ -384,20 +388,119 @@ private func shouldOffloadZenzaiToGpu(zenzaiEnabled: Bool, backend: String?) -> 
     )
 }
 
+@MainActor private func learningMemoryDirectoryURL(settingsPath: URL?) -> URL {
+    if let settingsPath {
+        return settingsPath
+            .deletingLastPathComponent()
+            .appendingPathComponent("LearningMemory", isDirectory: true)
+    }
+
+    if let appDataPath = ProcessInfo.processInfo.environment["APPDATA"] {
+        return URL(filePath: appDataPath)
+            .appendingPathComponent("Azookey", isDirectory: true)
+            .appendingPathComponent("LearningMemory", isDirectory: true)
+    }
+
+    return converterRuntimeDirectoryURL()
+        .appendingPathComponent("LearningMemory", isDirectory: true)
+}
+
+private func normalizedLearningMode(_ mode: String?) -> String {
+    (mode ?? "enabled")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .lowercased()
+        .replacingOccurrences(of: "-", with: "_")
+}
+
+private func learningType(for mode: String?) -> LearningType {
+    switch normalizedLearningMode(mode) {
+    case "read_only", "readonly", "no_new_learning":
+        return .onlyOutput
+    case "disabled":
+        return .nothing
+    default:
+        return .inputAndOutput
+    }
+}
+
+@MainActor private func ensureLearningMemoryDirectoryIfNeeded() {
+    guard currentLearningType != .nothing,
+          let currentLearningMemoryDirectoryURL else {
+        return
+    }
+
+    do {
+        try FileManager.default.createDirectory(
+            at: currentLearningMemoryDirectoryURL,
+            withIntermediateDirectories: true
+        )
+    } catch {
+        serverLog(
+            "WARN",
+            "Failed to create learning memory directory \(currentLearningMemoryDirectoryURL.path): \(error)"
+        )
+    }
+}
+
+@MainActor private func resetLearningMemoryDirectory() -> Bool {
+    guard let currentLearningMemoryDirectoryURL else {
+        serverLog("WARN", "ResetLearningMemory: learning memory directory is not configured")
+        return false
+    }
+
+    do {
+        if FileManager.default.fileExists(atPath: currentLearningMemoryDirectoryURL.path) {
+            try FileManager.default.removeItem(at: currentLearningMemoryDirectoryURL)
+        }
+        try FileManager.default.createDirectory(
+            at: currentLearningMemoryDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        return true
+    } catch {
+        serverLog(
+            "WARN",
+            "ResetLearningMemory: failed to reset directory \(currentLearningMemoryDirectoryURL.path): \(error)"
+        )
+        return false
+    }
+}
+
+@MainActor private func clearLearningCandidateCache() {
+    learningCandidateCache.removeAll()
+    nextLearningCandidateId = 1
+}
+
+@MainActor private func recordLearningCandidate(_ candidate: Candidate) -> UInt64 {
+    if nextLearningCandidateId == UInt64.max {
+        clearLearningCandidateCache()
+    }
+    let candidateId = nextLearningCandidateId
+    nextLearningCandidateId += 1
+    learningCandidateCache[candidateId] = candidate
+    return candidateId
+}
+
+@MainActor func consumeLearningCandidate(_ candidateId: UInt64) -> Candidate? {
+    learningCandidateCache.removeValue(forKey: candidateId)
+}
+
 private func makeConvertRequestOptions(
     context: String,
     zenzaiEnabled: Bool,
     runtimeDirectoryURL: URL,
     emojiDictionaryURL: URL,
     zenzaiWeightURL: URL,
-    profile: String
+    profile: String,
+    learningType: LearningType = .nothing,
+    learningMemoryDirectoryURL: URL? = nil
 ) -> ConvertRequestOptions {
     return ConvertRequestOptions(
         requireJapanesePrediction: .disabled,
         requireEnglishPrediction: .disabled,
         keyboardLanguage: .ja_JP,
-        learningType: .nothing,
-        memoryDirectoryURL: runtimeDirectoryURL,
+        learningType: learningType,
+        memoryDirectoryURL: learningMemoryDirectoryURL ?? runtimeDirectoryURL,
         sharedContainerURL: runtimeDirectoryURL,
         textReplacer: .init {
             return emojiDictionaryURL
@@ -421,8 +524,13 @@ private func makeConvertRequestOptions(
 
 private struct AppSettings: Decodable {
     let zenzai: ZenzaiSettings?
+    let learning: LearningSettings?
     let user_dictionary: UserDictionarySettings?
     let romaji_table: RomajiTableSettings?
+}
+
+private struct LearningSettings: Decodable {
+    let mode: String?
 }
 
 private struct ZenzaiSettings: Decodable {
@@ -1105,7 +1213,9 @@ private func preferCursorPrefixBoundary(
             .appendingPathComponent("EmojiDictionary")
             .appendingPathComponent("emoji_all_E15.1.txt"),
         zenzaiWeightURL: execURL.appendingPathComponent("zenz.gguf"),
-        profile: (config["profile"] as? String) ?? ""
+        profile: (config["profile"] as? String) ?? "",
+        learningType: currentLearningType,
+        learningMemoryDirectoryURL: currentLearningMemoryDirectoryURL
     )
 }
 
@@ -1569,6 +1679,8 @@ func cursorPrefixBoundaryFirstClauseResults(
         cpuBackendSupported: cpuZenzaiBackendSupportedFromEnvironment()
     )
     let previousUsedCustomRomajiTable = customRomajiTableEnabled
+    let previousLearningType = currentLearningType
+    let previousLearningMemoryDirectoryURL = currentLearningMemoryDirectoryURL
     var dynamicUserDictionary: [DicdataElement] = []
     defer {
         converter.importDynamicUserDictionary(dynamicUserDictionary)
@@ -1579,6 +1691,8 @@ func cursorPrefixBoundaryFirstClauseResults(
     config["profile"] = ""
     config["backend"] = "cpu"
     setRoman2KanaInputStyle()
+    currentLearningType = .inputAndOutput
+    currentLearningMemoryDirectoryURL = learningMemoryDirectoryURL(settingsPath: loadedSettingsPath)
 
     if let settings = loadedSettings {
         if let loadedSettingsPath {
@@ -1600,6 +1714,7 @@ func cursorPrefixBoundaryFirstClauseResults(
         }
 
         applyRomajiInputStyle(rows: settings.romaji_table?.rows)
+        currentLearningType = learningType(for: settings.learning?.mode)
 
         let sourceEntries = settings.user_dictionary?.entries ?? []
         var seen: Set<String> = []
@@ -1668,10 +1783,16 @@ func cursorPrefixBoundaryFirstClauseResults(
         composingText = ComposingText()
         composingTextSnapshots.removeAll()
     }
+    if previousLearningType != currentLearningType
+        || previousLearningMemoryDirectoryURL != currentLearningMemoryDirectoryURL
+    {
+        clearLearningCandidateCache()
+    }
+    ensureLearningMemoryDirectoryIfNeeded()
 
     serverLog(
         "INFO",
-        "LoadConfig: completed enable=\(currentZenzaiEnabled) backend=\(currentBackend) effectiveEnable=\(currentEffectiveZenzaiEnabled) customRomaji=\(currentUsedCustomRomajiTable)"
+        "LoadConfig: completed enable=\(currentZenzaiEnabled) backend=\(currentBackend) effectiveEnable=\(currentEffectiveZenzaiEnabled) customRomaji=\(currentUsedCustomRomajiTable) learningType=\(currentLearningType)"
     )
 }
 
@@ -1686,6 +1807,7 @@ func cursorPrefixBoundaryFirstClauseResults(
     converterDictionaryURL = execURL.appendingPathComponent("Dictionary")
     converterPreloadDictionary = true
     rebuildConverter()
+    clearLearningCandidateCache()
 
     load_config()
 
@@ -1843,7 +1965,50 @@ func cursorPrefixBoundaryFirstClauseResults(
     serverLog("DEBUG", "ClearText: start")
     composingText = ComposingText()
     composingTextSnapshots.removeAll()
+    clearLearningCandidateCache()
     serverLog("DEBUG", "ClearText: completed")
+}
+
+@_silgen_name("CommitLearningCandidate")
+@MainActor public func commit_learning_candidate(
+    candidateId: UInt64,
+    commitKind: Int32
+) -> Bool {
+    guard currentLearningType == .inputAndOutput else {
+        serverLog(
+            "DEBUG",
+            "CommitLearningCandidate: skipped learningType=\(currentLearningType) candidateId=\(candidateId) commitKind=\(commitKind)"
+        )
+        return true
+    }
+
+    guard let candidate = consumeLearningCandidate(candidateId) else {
+        serverLog(
+            "WARN",
+            "CommitLearningCandidate: candidate not found candidateId=\(candidateId) commitKind=\(commitKind)"
+        )
+        return false
+    }
+
+    ensureLearningMemoryDirectoryIfNeeded()
+    converter.setCompletedData(candidate)
+    converter.updateLearningData(candidate)
+    converter.commitUpdateLearningData()
+    serverLog(
+        "DEBUG",
+        "CommitLearningCandidate: completed candidateId=\(candidateId) commitKind=\(commitKind)"
+    )
+    return true
+}
+
+@_silgen_name("ResetLearningMemory")
+@MainActor public func reset_learning_memory() -> Bool {
+    let resetDirectory = resetLearningMemoryDirectory()
+    converter.resetMemory()
+    normalNBestSupplementConverter.resetMemory()
+    clearLearningCandidateCache()
+    serverLog("INFO", "ResetLearningMemory: completed resetDirectory=\(resetDirectory)")
+    return resetDirectory
 }
 
 func to_list_pointer(_ list: [FFICandidate]) -> UnsafeMutablePointer<UnsafeMutablePointer<FFICandidate>?> {
@@ -2054,7 +2219,15 @@ public func free_candidate_list(
             strdupCandidatesMs += elapsedPerformanceMilliseconds(since: strdupStart)
         }
 
-        result.append(FFICandidate(text: text, subtext: subtext, hiragana: hiragana, correspondingCount: Int32(correspondingCount)))
+        result.append(
+            FFICandidate(
+                text: text,
+                subtext: subtext,
+                hiragana: hiragana,
+                correspondingCount: Int32(correspondingCount),
+                candidateId: recordLearningCandidate(candidate)
+            )
+        )
     }
 
     lengthPtr.pointee = CInt(result.count)
@@ -2363,7 +2536,15 @@ public func free_candidate_list(
             strdupCandidatesMs += elapsedPerformanceMilliseconds(since: strdupStart)
         }
 
-        result.append(FFICandidate(text: text, subtext: subtext, hiragana: hiragana, correspondingCount: Int32(correspondingCount)))
+        result.append(
+            FFICandidate(
+                text: text,
+                subtext: subtext,
+                hiragana: hiragana,
+                correspondingCount: Int32(correspondingCount),
+                candidateId: recordLearningCandidate(candidate)
+            )
+        )
     }
 
     lengthPtr.pointee = CInt(result.count)

--- a/server-swift/Sources/ffi/include/ffi.h
+++ b/server-swift/Sources/ffi/include/ffi.h
@@ -1,6 +1,7 @@
 #ifndef ffi_h
 #define ffi_h
 
+#include <stdbool.h>
 #include <stdio.h>
 
 #ifdef __cplusplus
@@ -12,10 +13,13 @@ struct FFICandidate {
     char *subtext;
     char *hiragana;
     int correspondingCount;
+    unsigned long long candidateId;
 };
 
 void FreeCString(char *ptr);
 void FreeCandidateList(struct FFICandidate **ptr, int length);
+bool CommitLearningCandidate(unsigned long long candidateId, int commitKind);
+bool ResetLearningMemory(void);
 
 #ifdef __cplusplus
 }

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -78,6 +78,24 @@ private func testCandidate(
     )
 }
 
+@Test func learningCandidateCanOnlyBeConsumedOnce() async throws {
+    let candidate = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+
+    await MainActor.run {
+        learningCandidateCache.removeAll()
+        learningCandidateCache[42] = candidate
+
+        #expect(consumeLearningCandidate(42) != nil)
+        #expect(consumeLearningCandidate(42) == nil)
+
+        learningCandidateCache.removeAll()
+    }
+}
+
 @Test func ffiFreeCStringAcceptsNullAndAllocatedStrings() async throws {
     free_c_string(nil)
 
@@ -99,7 +117,8 @@ private func testCandidate(
             text: text,
             subtext: subtext,
             hiragana: hiragana,
-            correspondingCount: 1
+            correspondingCount: 1,
+            candidateId: 1
         )
     ]
 
@@ -112,7 +131,8 @@ private func testCandidate(
             text: nilHiraganaText,
             subtext: nilHiraganaSubtext,
             hiragana: nil,
-            correspondingCount: 1
+            correspondingCount: 1,
+            candidateId: 2
         )
     ]
 
@@ -127,7 +147,8 @@ private func testCandidate(
             text: firstLegacyText,
             subtext: firstLegacySubtext,
             hiragana: firstLegacyHiragana,
-            correspondingCount: 1
+            correspondingCount: 1,
+            candidateId: 3
         )
     )
 
@@ -139,7 +160,8 @@ private func testCandidate(
             text: secondLegacyText,
             subtext: secondLegacySubtext,
             hiragana: nil,
-            correspondingCount: 1
+            correspondingCount: 1,
+            candidateId: 4
         )
     )
 

--- a/settings.json
+++ b/settings.json
@@ -5,6 +5,9 @@
         "profile": "",
         "backend": "cpu"
     },
+    "learning": {
+        "mode": "enabled"
+    },
     "shortcuts": {
         "ctrl_space_toggle": true,
         "alt_backquote_toggle": true


### PR DESCRIPTION
## Summary
- Enter で明示的に確定した変換候補を学習し、以降の候補順位へ反映します。
- 設定画面から変換学習モードの切り替えと学習履歴の削除を行えるようにします。

## Background
- Issue: Closes #108
- 意図しない確定経路や機微な入力欄を学習対象にせず、変換確定履歴を安全に永続化する仕組みが必要でした。

## Changes
- client/server 間に候補 ID と学習確定 API を追加し、通常変換・文節変換とも明示的な Enter 確定時だけ学習するようにしました。
- 句読点確定、プレビュー後の追加入力、フォーカス移動、IME モード切替など、Enter 以外の確定経路では学習しません。
- パスワード・プライベート入力欄、キーボード無効時、短すぎる入力、英数入力を学習対象外にしました。
- 候補 ID を一度だけ消費することで、RPC 応答消失時の再試行でも二重学習を防ぎます。
- Swift server に学習データの保存、学習モード（有効・新規学習なし・無効）、履歴削除を追加しました。
- 設定画面に学習モード選択と履歴削除の確認 UI を追加しました。
- Enter のみを学習対象とする回帰 test と、候補 ID の一度限り消費を確認する test を追加しました。

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/29154046867
- [x] Windows VM 確認
  - client composition test: 120 passed
  - IPC reconnect regression test: 2 passed
  - Swift focused test (`learningCandidateCanOnlyBeConsumedOnce`): 1 passed
  - release build、TypeScript/Vite、x64/x86 client、Swift server、installer build: 成功
  - installer SHA256: `5896590e3435b1877cfecc43d677c413b22584a583f5484bf4653dc6530e89ad`

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した
