### PR TITLE
fix(ui): optimize candidate window updates

### DIFF
--- a/crates/ui/src/candidate.rs
+++ b/crates/ui/src/candidate.rs
@@ -81,7 +81,6 @@ pub fn create_candidate_webview<'a>() -> Result<WebViewBuilder<'a>> {
                         scroll-snap-type: y proximity;
                         list-style-position: inside;
                         list-style-type: none;
-                        counter-reset: number 0;
                         user-select: none;
                         cursor: pointer;
 
@@ -102,8 +101,7 @@ pub fn create_candidate_webview<'a>() -> Result<WebViewBuilder<'a>> {
                         scroll-snap-align: start;
 
                         &::before {
-                            content: counter(number);
-                            counter-increment: number 1;
+                            content: attr(data-number);
                             color: #636363;
                             font-weight: bold;
                             font-size: 0.75rem;
@@ -118,6 +116,12 @@ pub fn create_candidate_webview<'a>() -> Result<WebViewBuilder<'a>> {
                             outline: 1px solid #2CB5FF;
                             outline-offset: -1px;
                         }
+                    }
+                    .candidate-text {
+                        min-width: 0;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
                     }
                     footer {
                         display: flex;
@@ -159,6 +163,10 @@ pub fn create_candidate_webview<'a>() -> Result<WebViewBuilder<'a>> {
                     }
                 </style>
                 <script>
+                    const candidatePageSize = 5;
+                    let currentCandidates = [];
+                    let currentSelectionIndex = 0;
+                    let renderedPageStart = -1;
                     let adjustWindowSizeFrame = null;
 
                     function scheduleAdjustWindowSize() {
@@ -172,27 +180,59 @@ pub fn create_candidate_webview<'a>() -> Result<WebViewBuilder<'a>> {
                         });
                     }
 
-                    function updateCandidates(candidates) {
+                    function candidatePageStart(index) {
+                        return Math.floor(index / candidatePageSize) * candidatePageSize;
+                    }
+
+                    function clampSelectionIndex(index) {
+                        if (currentCandidates.length === 0) {
+                            return 0;
+                        }
+
+                        const numericIndex = Number(index);
+                        return Number.isFinite(numericIndex)
+                            ? Math.min(Math.max(Math.trunc(numericIndex), 0), currentCandidates.length - 1)
+                            : 0;
+                    }
+
+                    function renderCandidatePage() {
                         const candidateList = document.getElementById('candidate-list');
-                        if (!candidateList || !Array.isArray(candidates)) {
+                        if (!candidateList) {
                             return;
                         }
 
-                        const existingItems = Array.from(candidateList.children);
+                        const pageStart = candidatePageStart(currentSelectionIndex);
+                        const pageEnd = Math.min(pageStart + candidatePageSize, currentCandidates.length);
+                        const fragment = document.createDocumentFragment();
 
-                        candidates.forEach((candidate, index) => {
-                            if (existingItems[index]) {
-                                existingItems[index].textContent = candidate;
-                            } else {
-                                const li = document.createElement('li');
-                                li.textContent = candidate;
-                                candidateList.appendChild(li);
+                        for (let index = pageStart; index < pageEnd; index += 1) {
+                            const li = document.createElement('li');
+                            const text = document.createElement('span');
+                            text.className = 'candidate-text';
+                            text.textContent = currentCandidates[index];
+                            text.title = currentCandidates[index];
+                            li.appendChild(text);
+                            li.setAttribute('data-number', String(index + 1));
+                            if (index === currentSelectionIndex) {
+                                li.setAttribute('data-selected', '');
                             }
-                        });
-
-                        while (existingItems.length > candidates.length) {
-                            candidateList.removeChild(existingItems.pop());
+                            fragment.appendChild(li);
                         }
+
+                        candidateList.replaceChildren(fragment);
+                        renderedPageStart = pageStart;
+                    }
+
+                    function updateCandidates(candidates, selectedIndex = null) {
+                        if (!Array.isArray(candidates)) {
+                            return;
+                        }
+
+                        currentCandidates = candidates;
+                        currentSelectionIndex = clampSelectionIndex(
+                            selectedIndex === null ? currentSelectionIndex : selectedIndex
+                        );
+                        renderCandidatePage();
 
                         scheduleAdjustWindowSize();
                     }
@@ -214,48 +254,29 @@ pub fn create_candidate_webview<'a>() -> Result<WebViewBuilder<'a>> {
 
                     function updateSelection(index) {
                         const candidateList = document.getElementById('candidate-list');
-                        if (!candidateList || candidateList.children.length === 0) {
+                        if (!candidateList || currentCandidates.length === 0) {
                             return;
                         }
 
-                        const childCount = candidateList.children.length;
-                        const numericIndex = Number(index);
-                        const safeIndex = Number.isFinite(numericIndex)
-                            ? Math.min(Math.max(Math.trunc(numericIndex), 0), childCount - 1)
-                            : 0;
+                        const safeIndex = clampSelectionIndex(index);
+                        const pageStart = candidatePageStart(safeIndex);
+                        currentSelectionIndex = safeIndex;
+
+                        if (pageStart !== renderedPageStart) {
+                            renderCandidatePage();
+                            scheduleAdjustWindowSize();
+                            return;
+                        }
 
                         const selected = candidateList.querySelector('[data-selected]');
                         if (selected) {
                             selected.removeAttribute('data-selected');
                         }
                         
-                        const target = candidateList.children[safeIndex];
-                        target.setAttribute('data-selected', '');
-                        
-                        const itemHeight = candidateList.children[0].offsetHeight;
-                        if (itemHeight <= 0) {
-                            return;
+                        const target = candidateList.children[safeIndex - pageStart];
+                        if (target) {
+                            target.setAttribute('data-selected', '');
                         }
-                        const visibleItems = Math.floor(candidateList.clientHeight / itemHeight);
-                        
-                        const groupSize = 5;
-                        const groupIndex = Math.floor(safeIndex / groupSize);
-                        const scrollToIndex = groupIndex * groupSize;
-                        const scrollTarget = candidateList.children[scrollToIndex];
-                        
-                        if (scrollTarget && (safeIndex === scrollToIndex || !isElementInView(target, candidateList))) {
-                            scrollTarget.scrollIntoView({ behavior: "instant", block: "start", inline: "start" });
-                        }
-                    }
-                    
-                    function isElementInView(element, container) {
-                        const containerRect = container.getBoundingClientRect();
-                        const elementRect = element.getBoundingClientRect();
-                        
-                        return (
-                            elementRect.top >= containerRect.top &&
-                            elementRect.bottom <= containerRect.bottom
-                        );
                     }
 
                     function measureListItemHeight(candidateList) {

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -1,4 +1,3 @@
-use std::cmp::max;
 use std::sync::Arc;
 
 use azookey_server::TonicNamedPipeServer;
@@ -37,6 +36,10 @@ pub mod uiaccess;
 pub mod utils;
 
 const INDICATOR_WINDOW_LEFT_OFFSET: i32 = 45;
+const CANDIDATE_WINDOW_MIN_WIDTH: u32 = 225;
+const CANDIDATE_WINDOW_MAX_WIDTH: u32 = 640;
+const CANDIDATE_WINDOW_BASE_WIDTH: u32 = 120;
+const CANDIDATE_CHARACTER_WIDTH: u32 = 18;
 
 #[derive(Clone, Copy, Debug)]
 struct RubyMeasuredSize {
@@ -157,26 +160,48 @@ fn evaluate_script(webview: &wry::WebView, script: &str) {
     }
 }
 
-fn set_candidate_window_width(candidate_window: &tao::window::Window, candidates: &[String]) {
+fn candidate_window_width(candidates: &[String]) -> u32 {
     let max_len = candidates
         .iter()
         .map(|s| s.chars().count())
         .max()
         .unwrap_or(0) as u32;
 
-    let height = candidate_window.inner_size().height as i32;
+    CANDIDATE_WINDOW_BASE_WIDTH
+        .saturating_add(max_len.saturating_mul(CANDIDATE_CHARACTER_WIDTH))
+        .clamp(CANDIDATE_WINDOW_MIN_WIDTH, CANDIDATE_WINDOW_MAX_WIDTH)
+}
+
+fn logical_width_for_physical_width(physical_width: u32, scale_factor: f64) -> f64 {
+    let scale_factor = if scale_factor.is_finite() && scale_factor > 0.0 {
+        scale_factor
+    } else {
+        1.0
+    };
+    physical_width as f64 / scale_factor
+}
+
+fn set_candidate_window_width(candidate_window: &tao::window::Window, candidates: &[String]) {
+    let height = candidate_window.inner_size().height;
     candidate_window.set_inner_size(PhysicalSize::new(
-        max(225, 120 + max_len * 18),
-        height as u32,
+        candidate_window_width(candidates),
+        height,
     ));
 }
 
-fn update_candidate_list(candidate_webview: &wry::WebView, candidates: &[String]) {
+fn update_candidate_list(
+    candidate_webview: &wry::WebView,
+    candidates: &[String],
+    selected_index: Option<i32>,
+) {
     match serde_json::to_string(candidates) {
         Ok(candidates) => {
+            let selected_index = selected_index
+                .map(|index| index.to_string())
+                .unwrap_or_else(|| "null".to_string());
             evaluate_script(
                 candidate_webview,
-                &format!("updateCandidates({})", candidates),
+                &format!("updateCandidates({}, {})", candidates, selected_index),
             );
         }
         Err(error) => {
@@ -428,8 +453,11 @@ async fn main() -> anyhow::Result<()> {
                     update_indicator(&indicator_webview, &input_method);
                 }
                 UserEvent::UpdateHeight(height) => {
-                    let width = candidate_window.inner_size().width as i32;
-                    candidate_window.set_inner_size(LogicalSize::new(width, height));
+                    let width = candidate_window.inner_size().width;
+                    let logical_width =
+                        logical_width_for_physical_width(width, candidate_window.scale_factor());
+                    candidate_window
+                        .set_inner_size(LogicalSize::new(logical_width, height.max(0) as f64));
                     if let Some(rect) = last_candidate_rect {
                         place_candidate_windows(
                             &candidate_window,
@@ -592,7 +620,7 @@ async fn main() -> anyhow::Result<()> {
                             current_candidate_list_visible = true;
                             set_candidate_list_visible(&candidate_webview, true);
                             set_candidate_window_width(&candidate_window, &candidates);
-                            update_candidate_list(&candidate_webview, &candidates);
+                            update_candidate_list(&candidate_webview, &candidates, None);
                             if let Some(rect) = last_candidate_rect {
                                 place_candidate_windows(
                                     &candidate_window,
@@ -686,14 +714,20 @@ async fn main() -> anyhow::Result<()> {
 
                             if let Some(ref candidates) = candidates {
                                 set_candidate_window_width(&candidate_window, candidates);
-                                update_candidate_list(&candidate_webview, candidates);
+                                update_candidate_list(
+                                    &candidate_webview,
+                                    candidates,
+                                    selected_index,
+                                );
                             }
 
-                            if let Some(index) = selected_index {
-                                evaluate_script(
-                                    &candidate_webview,
-                                    &format!("updateSelection({})", index),
-                                );
+                            if candidates.is_none() {
+                                if let Some(index) = selected_index {
+                                    evaluate_script(
+                                        &candidate_webview,
+                                        &format!("updateSelection({})", index),
+                                    );
+                                }
                             }
 
                             if let Some(position) = position {
@@ -856,4 +890,44 @@ async fn main() -> anyhow::Result<()> {
             _ => (),
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        candidate_window_width, logical_width_for_physical_width, CANDIDATE_WINDOW_MAX_WIDTH,
+        CANDIDATE_WINDOW_MIN_WIDTH,
+    };
+
+    #[test]
+    fn candidate_window_width_uses_minimum_for_short_candidates() {
+        let candidates = vec!["候補".to_string(), "candidate".to_string()];
+
+        assert_eq!(
+            candidate_window_width(&candidates),
+            CANDIDATE_WINDOW_MIN_WIDTH
+        );
+    }
+
+    #[test]
+    fn candidate_window_width_is_capped_for_unusually_long_candidates() {
+        let candidates = vec!["候補".repeat(1_000)];
+
+        assert_eq!(
+            candidate_window_width(&candidates),
+            CANDIDATE_WINDOW_MAX_WIDTH
+        );
+    }
+
+    #[test]
+    fn candidate_window_resize_preserves_physical_width_at_high_dpi() {
+        assert_eq!(logical_width_for_physical_width(300, 1.25), 240.0);
+        assert_eq!(logical_width_for_physical_width(300, 1.5), 200.0);
+    }
+
+    #[test]
+    fn candidate_window_resize_uses_safe_scale_for_invalid_dpi() {
+        assert_eq!(logical_width_for_physical_width(300, 0.0), 300.0);
+        assert_eq!(logical_width_for_physical_width(300, f64::NAN), 300.0);
+    }
 }


### PR DESCRIPTION
## Summary
- 候補ウィンドウで選択中ページの5件だけをDOMへ描画し、候補数が多い入力でのレイアウト負荷を抑えます。
- 候補ウィンドウの横幅に上限を設け、高DPI環境でも論理pxと物理pxを正しく変換して異常な横幅拡大を防ぎます。

## Background
- Issue: #122
- 候補数が多い語の入力中、候補ウィンドウ更新と候補計算が重なると入力やUIに遅延が発生し、候補ウィンドウの横幅が長大化することがありました。
- 従来は全候補をWebViewのDOMへ反映し、表示されない長い候補も上限なしの横幅計算へ含めていました。また、高さ更新時に物理幅を論理幅として再利用していました。

## Changes
- ui/candidate-window: 全候補をJavaScript側に保持しつつ、選択中の5件だけをDocumentFragmentでDOMへ描画
- ui/candidate-window: ページを跨ぐ選択時に表示候補と通し番号を更新し、同一ページ内では選択属性だけを更新
- ui/layout: 候補ウィンドウ幅を225〜640pxに制限し、長い候補はellipsis表示
- ui/layout: WebView由来の論理px高さへ合わせ、現在の物理幅をscale factorで論理幅へ戻してからリサイズ
- ui/ipc: 候補一覧と選択位置を同じWebViewスクリプト呼び出しで反映
- test/ui: 短い候補の最小幅、長い候補の最大幅、125%/150% DPIでの幅維持を確認する回帰testを追加

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/29247459180
- [x] Windows VM 確認
  - `.local/vm_build_master.sh feature/122-candidate-window-performance`: release build、x64/x86 client、Swift server、TypeScript/Vite、installer build 成功
  - `.local/vm_stage_for_manual_test.sh .local/artifacts/azookey-setup-feature_122-candidate-window-performance-20260713-084308.exe`: サイレントインストール成功
  - Notepad / 「けいゆして」: 候補1〜5件が約225pxの正常な横幅で表示され、長大化しないことを確認
- [x] ローカル確認
  - `cargo fmt --all -- --check`: pass
  - `git diff --check`: pass
  - `cargo test -p ui`: Linux環境の `pkg-config` / GTK依存不足によりビルド前段で実行不可。Windows VM release buildで対象UIクレートのコンパイル成功を確認
- [x] Read-only review
  - 初回レビューの高DPIリサイズ指摘を修正し、再レビューでHigh / Mediumの未解決指摘なし

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した
