### PR TITLE
docs: defer issue closure until release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,8 @@
 - <変更の要約を1-3行で記載>
 
 ## Background
-- Issue: Closes #<issue_number>
+- Issue: #<issue_number>（該当なしの場合は N/A）
+- Issue close: 対象リリース公開・成果物確認後（該当なしの場合は N/A）
 - <背景、再現条件、目的を記載>
 
 ## Changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,15 @@
 6. 必要に応じて CI で生成したビルドを実機にインストールし、動作を確認する。
 7. `origin/master` へ PR を出す。
 
+## Issue のクローズ運用
+
+- 機能追加・不具合修正の PR では、PR 本文に `Issue: #<issue-number>` と記載して関連 Issue を参照する。
+- PR 本文や commit message では `Closes`、`Fixes`、`Resolves` などの closing keyword を使わず、PR の merge 時点では Issue を close しない。
+- GitHub の Issue / PR sidebar から Development link を設定する場合は、repository の auto-close 設定が無効であることを確認する。
+- Issue は、その変更を含む GitHub Release が公開され、tag・CI・配布 asset の確認が完了した後に `completed` として close する。
+- リリース時は、前回 release 以降に merge された PR の Issue 参照から close 候補を作り、リリース内容の承認時に対象を確定する。部分対応や残作業がある Issue は open のまま残す。
+- Issue を close するときは、対象 release の URL を comment に記載する。
+
 ## ビルド / 検証
 
 - 正式なビルド判定は GitHub CI とする。


### PR DESCRIPTION
## Summary
- Issue を PR merge 時ではなく、その変更を含む GitHub Release の公開・検証後に close する運用へ変更します。
- PR テンプレートから closing keyword を除去し、関連 Issue の参照と close 時期を明示します。

## Background
- Issue: N/A
- Issue close: N/A
- PR merge とユーザーが利用できる release の間で Issue が先に close される状態を避けるための運用変更です。

## Changes
- repository rules: PR 本文・commit message で closing keyword を使わず、release 公開後に release URL 付きで Issue を close するルールを追加
- PR template: `Closes` を通常の Issue 参照へ変更し、close 時期の記入欄を追加

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/29250494252
- [x] ローカル確認
  - `git diff --check`: pass
  - `quick_validate.py .codex/skills/azookey-pr`: pass
  - `quick_validate.py .codex/skills/azookey-release`: pass
- [x] Windows 実機確認
  - ドキュメント・運用ルールのみの変更のため対象外

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
