### PR TITLE
Fix learning candidate cache performance and recency

### DIFF
--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -29,8 +29,8 @@ private let fallbackDictionaryURL =
 @MainActor var customRomajiTableEnabled = false
 @MainActor var currentLearningType: LearningType = .inputAndOutput
 @MainActor var currentLearningMemoryDirectoryURL: URL?
-@MainActor var nextLearningCandidateId: UInt64 = 1
-@MainActor var learningCandidateCache: [UInt64: Candidate] = [:]
+@MainActor var learningCandidateCache = LearningCandidateCache()
+@MainActor var learningSelectionOverrides: [String: String] = [:]
 
 @MainActor var execURL = URL(filePath: "")
 @MainActor var config: [String : Any] = [
@@ -45,6 +45,8 @@ let zenzaiWarmupRomanInput = "nihongo"
 let warmupRequestCandidatesWarningMs = 5_000
 // Request exact-clause supplements only when boundary-matched candidates are sparse.
 let cursorPrefixExactClauseSupplementCandidateThreshold = 5
+let maxLearningSelectionOverrideCount = 4_096
+let learningSelectionOverridesFilename = "selection-overrides.json"
 
 @MainActor var currentRequestId: UInt64 = 0
 
@@ -466,23 +468,245 @@ private func learningType(for mode: String?) -> LearningType {
     }
 }
 
-@MainActor private func clearLearningCandidateCache() {
-    learningCandidateCache.removeAll()
-    nextLearningCandidateId = 1
+struct LearningCandidateCache {
+    private struct Batch {
+        let firstId: UInt64
+        let candidates: [Candidate]
+    }
+
+    private var batches: [Batch] = []
+    private var nextCandidateId: UInt64 = 1
+    private var idSpaceExhausted = false
+    private var consumedCandidateIds: Set<UInt64> = []
+
+    var slotCount: Int {
+        batches.reduce(into: 0) { $0 += $1.candidates.count }
+    }
+
+    var batchCount: Int {
+        batches.count
+    }
+
+    mutating func appendBatch(_ candidates: [Candidate]) -> UInt64? {
+        guard !candidates.isEmpty, !idSpaceExhausted else {
+            return nil
+        }
+
+        let candidateCount = UInt64(candidates.count)
+        let (nextId, overflow) = nextCandidateId.addingReportingOverflow(candidateCount)
+        if overflow {
+            idSpaceExhausted = true
+            return nil
+        }
+
+        let firstId = nextCandidateId
+        batches.append(Batch(firstId: firstId, candidates: candidates))
+        nextCandidateId = nextId
+        return firstId
+    }
+
+    func candidateId(at index: Int, batchFirstId: UInt64) -> UInt64 {
+        guard index >= 0,
+              let batch = batches.last,
+              batch.firstId == batchFirstId,
+              index < batch.candidates.count else {
+            return 0
+        }
+
+        return batchFirstId + UInt64(index)
+    }
+
+    mutating func consume(_ candidateId: UInt64) -> Candidate? {
+        guard candidateId > 0,
+              consumedCandidateIds.insert(candidateId).inserted else {
+            return nil
+        }
+
+        var lowerBound = 0
+        var upperBound = batches.count
+        while lowerBound < upperBound {
+            let middle = lowerBound + (upperBound - lowerBound) / 2
+            if batches[middle].firstId <= candidateId {
+                lowerBound = middle + 1
+            } else {
+                upperBound = middle
+            }
+        }
+
+        guard lowerBound > 0 else {
+            consumedCandidateIds.remove(candidateId)
+            return nil
+        }
+        let batch = batches[lowerBound - 1]
+        let offset = candidateId - batch.firstId
+        guard offset < UInt64(batch.candidates.count) else {
+            consumedCandidateIds.remove(candidateId)
+            return nil
+        }
+
+        return batch.candidates[Int(offset)]
+    }
+
+    mutating func removeAll() {
+        batches.removeAll(keepingCapacity: false)
+        consumedCandidateIds.removeAll(keepingCapacity: true)
+    }
 }
 
-@MainActor private func recordLearningCandidate(_ candidate: Candidate) -> UInt64 {
-    if nextLearningCandidateId == UInt64.max {
-        clearLearningCandidateCache()
+@MainActor private func clearLearningCandidateCache() {
+    learningCandidateCache.removeAll()
+}
+
+@MainActor func cacheLearningCandidates(_ candidates: [Candidate]) -> UInt64? {
+    guard currentLearningType == .inputAndOutput else {
+        return nil
     }
-    let candidateId = nextLearningCandidateId
-    nextLearningCandidateId += 1
-    learningCandidateCache[candidateId] = candidate
-    return candidateId
+
+    return learningCandidateCache.appendBatch(candidates)
+}
+
+@MainActor func learningCandidateId(at index: Int, batchFirstId: UInt64?) -> UInt64 {
+    guard let batchFirstId else {
+        return 0
+    }
+
+    return learningCandidateCache.candidateId(at: index, batchFirstId: batchFirstId)
 }
 
 @MainActor func consumeLearningCandidate(_ candidateId: UInt64) -> Candidate? {
-    learningCandidateCache.removeValue(forKey: candidateId)
+    learningCandidateCache.consume(candidateId)
+}
+
+private func normalizedLearningRuby(_ ruby: String) -> String {
+    ruby.unicodeScalars.reduce(into: "") { normalized, scalar in
+        let value = scalar.value
+        let normalizedValue = switch value {
+        case 0x3041...0x3096, 0x309D...0x309F:
+            value + 0x60
+        default:
+            value
+        }
+        normalized.unicodeScalars.append(UnicodeScalar(normalizedValue)!)
+    }
+}
+
+private func learningCandidateRuby(_ candidate: Candidate) -> String {
+    normalizedLearningRuby(candidate.data.reduce(into: "") { $0 += $1.ruby })
+}
+
+private func learningCandidateOutput(_ candidate: Candidate) -> String {
+    candidate.data.reduce(into: "") { $0 += $1.word }
+}
+
+@MainActor private func learningSelectionOverridesURL() -> URL? {
+    currentLearningMemoryDirectoryURL?.appendingPathComponent(
+        learningSelectionOverridesFilename,
+        isDirectory: false
+    )
+}
+
+@MainActor func loadLearningSelectionOverrides() {
+    guard currentLearningType != .nothing,
+          let overridesURL = learningSelectionOverridesURL() else {
+        learningSelectionOverrides.removeAll(keepingCapacity: false)
+        return
+    }
+
+    guard FileManager.default.fileExists(atPath: overridesURL.path) else {
+        learningSelectionOverrides.removeAll(keepingCapacity: false)
+        return
+    }
+
+    do {
+        let data = try Data(contentsOf: overridesURL)
+        let decoded = try JSONDecoder().decode([String: String].self, from: data)
+        learningSelectionOverrides = Dictionary(
+            uniqueKeysWithValues: decoded.prefix(maxLearningSelectionOverrideCount).map {
+                ($0.key, $0.value)
+            }
+        )
+    } catch {
+        learningSelectionOverrides.removeAll(keepingCapacity: false)
+        serverLog(
+            "WARN",
+            "Failed to load learning selection overrides at \(overridesURL.path): \(error)"
+        )
+    }
+}
+
+@MainActor private func saveLearningSelectionOverrides() {
+    guard let overridesURL = learningSelectionOverridesURL() else {
+        return
+    }
+
+    do {
+        ensureLearningMemoryDirectoryIfNeeded()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(learningSelectionOverrides)
+        try data.write(to: overridesURL, options: .atomic)
+    } catch {
+        serverLog(
+            "WARN",
+            "Failed to save learning selection overrides at \(overridesURL.path): \(error)"
+        )
+    }
+}
+
+@MainActor private func recordLearningSelectionOverride(_ candidate: Candidate) {
+    guard candidate.isLearningTarget else {
+        return
+    }
+
+    let ruby = learningCandidateRuby(candidate)
+    let output = learningCandidateOutput(candidate)
+    guard !ruby.isEmpty, !output.isEmpty else {
+        return
+    }
+
+    if learningSelectionOverrides[ruby] == nil,
+       learningSelectionOverrides.count >= maxLearningSelectionOverrideCount,
+       let evictedRuby = learningSelectionOverrides.keys.first {
+        learningSelectionOverrides.removeValue(forKey: evictedRuby)
+    }
+    learningSelectionOverrides[ruby] = output
+    saveLearningSelectionOverrides()
+}
+
+@MainActor func prioritizeLearningSelectionOverrides<Element>(
+    _ elements: [Element],
+    ruby: String,
+    candidate: (Element) -> Candidate
+) -> [Element] {
+    let normalizedRuby = normalizedLearningRuby(ruby)
+    guard currentLearningType != .nothing,
+          let preferredOutput = learningSelectionOverrides[normalizedRuby],
+          elements.count > 1 else {
+        return elements
+    }
+
+    var firstIndex: Int?
+    var preferredIndex: Int?
+    for (index, element) in elements.enumerated() {
+        let value = candidate(element)
+        guard learningCandidateRuby(value) == normalizedRuby else {
+            continue
+        }
+        if firstIndex == nil {
+            firstIndex = index
+        }
+        if preferredOutput == learningCandidateOutput(value) {
+            preferredIndex = index
+            break
+        }
+    }
+
+    guard let firstIndex, let preferredIndex, firstIndex != preferredIndex else {
+        return elements
+    }
+    var prioritized = elements
+    prioritized.swapAt(firstIndex, preferredIndex)
+    return prioritized
 }
 
 private func makeConvertRequestOptions(
@@ -1789,6 +2013,7 @@ func cursorPrefixBoundaryFirstClauseResults(
         clearLearningCandidateCache()
     }
     ensureLearningMemoryDirectoryIfNeeded()
+    loadLearningSelectionOverrides()
 
     serverLog(
         "INFO",
@@ -1963,6 +2188,8 @@ func cursorPrefixBoundaryFirstClauseResults(
 @_silgen_name("ClearText")
 @MainActor public func clear_text() {
     serverLog("DEBUG", "ClearText: start")
+    converter.stopComposition()
+    normalNBestSupplementConverter.stopComposition()
     composingText = ComposingText()
     composingTextSnapshots.removeAll()
     clearLearningCandidateCache()
@@ -1994,6 +2221,7 @@ func cursorPrefixBoundaryFirstClauseResults(
     converter.setCompletedData(candidate)
     converter.updateLearningData(candidate)
     converter.commitUpdateLearningData()
+    recordLearningSelectionOverride(candidate)
     serverLog(
         "DEBUG",
         "CommitLearningCandidate: completed candidateId=\(candidateId) commitKind=\(commitKind)"
@@ -2007,6 +2235,7 @@ func cursorPrefixBoundaryFirstClauseResults(
     converter.resetMemory()
     normalNBestSupplementConverter.resetMemory()
     clearLearningCandidateCache()
+    learningSelectionOverrides.removeAll(keepingCapacity: false)
     serverLog("INFO", "ResetLearningMemory: completed resetDirectory=\(resetDirectory)")
     return resetDirectory
 }
@@ -2162,13 +2391,17 @@ public func free_candidate_list(
         details: "candidate_count=\(converted.mainResults.count);\(diagnosticDetails)"
     )
     serverLog("DEBUG", "GetComposedText: requestCandidates returned candidateCount=\(converted.mainResults.count) \(diagnosticDetails)")
-    let mainResults = normalNBestConverted.map {
+    let mergedMainResults = normalNBestConverted.map {
         mergeZenzaiMainResultsWithNormalNBest(
             zenzaiResults: converted.mainResults,
             normalNBestResults: $0.mainResults,
             hiragana: previewHiragana
         )
     } ?? converted.mainResults
+    let mainResults = prioritizeLearningSelectionOverrides(
+        mergedMainResults,
+        ruby: previewHiragana
+    ) { $0 }
     if let normalNBestConverted {
         serverLog(
             "DEBUG",
@@ -2189,6 +2422,7 @@ public func free_candidate_list(
     var resolutionCache: [String: CandidateDisplayResolution] = [:]
     var result: [FFICandidate] = []
     result.reserveCapacity(mainResults.count)
+    let learningCandidateBatchFirstId = cacheLearningCandidates(mainResults)
 
     for i in 0..<mainResults.count {
         let candidate = mainResults[i]
@@ -2225,7 +2459,7 @@ public func free_candidate_list(
                 subtext: subtext,
                 hiragana: hiragana,
                 correspondingCount: Int32(correspondingCount),
-                candidateId: recordLearningCandidate(candidate)
+                candidateId: learningCandidateId(at: i, batchFirstId: learningCandidateBatchFirstId)
             )
         )
     }
@@ -2486,7 +2720,7 @@ public func free_candidate_list(
         state: "begin",
         details: "phase=merge;preliminary_candidate_count=\(preliminaryCursorPrefixResults.count);exact_clause_candidate_count=\(exactClauseResults.count);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
     )
-    let cursorPrefixResults = exactClauseResults.isEmpty
+    let rawCursorPrefixResults = exactClauseResults.isEmpty
         ? preliminaryCursorPrefixResults
         : cursorPrefixCandidateDisplayResults(
             mainResults: cursorPrefixMainResults,
@@ -2498,6 +2732,10 @@ public func free_candidate_list(
             previewHiragana: previewPrefixHiragana,
             resolutionCache: &cursorPrefixResolutionCache
         )
+    let cursorPrefixResults = prioritizeLearningSelectionOverrides(
+        rawCursorPrefixResults,
+        ruby: previewPrefixHiragana
+    ) { $0.candidate }
     let totalMs = elapsedPerformanceMilliseconds(since: totalStart)
     performanceLog(
         operation: "get_composed_text_for_cursor_prefix",
@@ -2510,6 +2748,9 @@ public func free_candidate_list(
     var strdupCandidatesMs = 0
     var result: [FFICandidate] = []
     result.reserveCapacity(cursorPrefixResults.count)
+    let learningCandidateBatchFirstId = cacheLearningCandidates(
+        cursorPrefixResults.map(\.candidate)
+    )
     let ffiHiragana = previewPrefixHiragana + suffixAfterCursor
 
     for i in 0..<cursorPrefixResults.count {
@@ -2542,7 +2783,7 @@ public func free_candidate_list(
                 subtext: subtext,
                 hiragana: hiragana,
                 correspondingCount: Int32(correspondingCount),
-                candidateId: recordLearningCandidate(candidate)
+                candidateId: learningCandidateId(at: i, batchFirstId: learningCandidateBatchFirstId)
             )
         )
     }

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -56,6 +56,27 @@ private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions 
     )
 }
 
+private func testLearningConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions {
+    let packageRoot = packageRootURL()
+    return ConvertRequestOptions(
+        requireJapanesePrediction: .disabled,
+        requireEnglishPrediction: .disabled,
+        keyboardLanguage: .ja_JP,
+        learningType: .inputAndOutput,
+        memoryDirectoryURL: memoryURL,
+        sharedContainerURL: memoryURL,
+        textReplacer: .init {
+            packageRoot
+                .appending(path: "azooKey_emoji_dictionary_storage")
+                .appending(path: "EmojiDictionary")
+                .appending(path: "emoji_all_E15.1.txt")
+        },
+        specialCandidateProviders: nil,
+        zenzaiMode: .off,
+        metadata: .init(versionString: "Azookey for Windows learning test")
+    )
+}
+
 private func testCandidate(
     word: String,
     ruby: String,
@@ -86,13 +107,251 @@ private func testCandidate(
     )
 
     await MainActor.run {
+        let previousLearningType = currentLearningType
+        currentLearningType = .inputAndOutput
         learningCandidateCache.removeAll()
-        learningCandidateCache[42] = candidate
+        let batchFirstId = cacheLearningCandidates([candidate])
+        let candidateId = learningCandidateId(at: 0, batchFirstId: batchFirstId)
 
-        #expect(consumeLearningCandidate(42) != nil)
-        #expect(consumeLearningCandidate(42) == nil)
+        #expect(candidateId != 0)
+        #expect(consumeLearningCandidate(candidateId) != nil)
+        #expect(consumeLearningCandidate(candidateId) == nil)
 
         learningCandidateCache.removeAll()
+        currentLearningType = previousLearningType
+    }
+}
+
+@Test func learningCandidateIdsUseDenseSequentialSlots() async throws {
+    let first = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let second = testCandidate(
+        word: "教",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+
+    await MainActor.run {
+        let previousLearningType = currentLearningType
+        currentLearningType = .inputAndOutput
+        learningCandidateCache.removeAll()
+
+        let batchFirstId = cacheLearningCandidates([first, second])
+        let firstId = learningCandidateId(at: 0, batchFirstId: batchFirstId)
+        let secondId = learningCandidateId(at: 1, batchFirstId: batchFirstId)
+
+        #expect(firstId != 0)
+        #expect(secondId == firstId + 1)
+        #expect(learningCandidateCache.slotCount == 2)
+
+        learningCandidateCache.removeAll()
+        currentLearningType = previousLearningType
+    }
+}
+
+@Test func learningCandidateIdsRemainValidAcrossLaterBatches() {
+    var cache = LearningCandidateCache()
+    let first = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let second = testCandidate(
+        word: "教",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+
+    let firstBatchId = cache.appendBatch([first, second])!
+    let firstId = cache.candidateId(at: 0, batchFirstId: firstBatchId)
+    let firstBatchLastId = cache.candidateId(at: 1, batchFirstId: firstBatchId)
+    let secondBatchId = cache.appendBatch([second])!
+    let secondId = cache.candidateId(at: 0, batchFirstId: secondBatchId)
+
+    #expect(firstId != secondId)
+    #expect(firstBatchLastId + 1 == secondId)
+    #expect(cache.batchCount == 2)
+    #expect(cache.consume(firstId)?.text == "今日")
+    #expect(cache.consume(firstBatchLastId)?.text == "教")
+    #expect(cache.consume(secondId)?.text == "教")
+}
+
+@Test func clearingLearningCandidateCacheInvalidatesAllBatches() {
+    var cache = LearningCandidateCache()
+    let candidate = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let batchFirstId = cache.appendBatch([candidate])!
+    let oldCandidateId = cache.candidateId(at: 0, batchFirstId: batchFirstId)
+
+    cache.removeAll()
+    let newBatchFirstId = cache.appendBatch([candidate])!
+    let newCandidateId = cache.candidateId(at: 0, batchFirstId: newBatchFirstId)
+
+    #expect(oldCandidateId != newCandidateId)
+    #expect(cache.consume(oldCandidateId) == nil)
+    #expect(cache.consume(newCandidateId)?.text == "今日")
+    #expect(cache.batchCount == 1)
+}
+
+@Test func emptyLearningCandidateBatchDoesNotAllocateIds() {
+    var cache = LearningCandidateCache()
+
+    #expect(cache.appendBatch([]) == nil)
+    #expect(cache.batchCount == 0)
+    #expect(cache.slotCount == 0)
+}
+
+@Test func learningCandidateCacheIsSkippedWhenLearningDoesNotAcceptInput() async throws {
+    let candidate = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+
+    await MainActor.run {
+        let previousLearningType = currentLearningType
+        learningCandidateCache.removeAll()
+
+        currentLearningType = .onlyOutput
+        #expect(cacheLearningCandidates([candidate]) == nil)
+        #expect(learningCandidateCache.slotCount == 0)
+
+        currentLearningType = .nothing
+        #expect(cacheLearningCandidates([candidate]) == nil)
+        #expect(learningCandidateCache.slotCount == 0)
+
+        learningCandidateCache.removeAll()
+        currentLearningType = previousLearningType
+    }
+}
+
+@Test func latestLearningSelectionIsPrioritizedOnlyForItsReading() async {
+    let katouSugar = testCandidate(
+        word: "果糖",
+        ruby: "かとう",
+        composingCount: .inputCount(3)
+    )
+    let today = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let katouSurname = testCandidate(
+        word: "加藤",
+        ruby: "かとう",
+        composingCount: .inputCount(3)
+    )
+    let candidates = [katouSugar, today, katouSurname]
+
+    await MainActor.run {
+        let previousLearningType = currentLearningType
+        let previousLearningSelectionOverrides = learningSelectionOverrides
+        defer {
+            currentLearningType = previousLearningType
+            learningSelectionOverrides = previousLearningSelectionOverrides
+        }
+
+        currentLearningType = .inputAndOutput
+        learningSelectionOverrides = ["カトウ": "加藤"]
+        let prioritized = prioritizeLearningSelectionOverrides(candidates, ruby: "かとう") { $0 }
+        #expect(prioritized.map(\.text) == ["加藤", "今日", "果糖"])
+
+        var unrelatedCandidateAccessCount = 0
+        let unrelated = prioritizeLearningSelectionOverrides(candidates, ruby: "しゅう") {
+            unrelatedCandidateAccessCount += 1
+            return $0
+        }
+        #expect(unrelated.map(\.text) == ["果糖", "今日", "加藤"])
+        #expect(unrelatedCandidateAccessCount == 0)
+
+        currentLearningType = .nothing
+        let learningDisabled = prioritizeLearningSelectionOverrides(candidates, ruby: "かとう") { $0 }
+        #expect(learningDisabled.map(\.text) == ["果糖", "今日", "加藤"])
+    }
+}
+
+@Test func latestSelectionReplacesPreviouslyLearnedFirstCandidate() async throws {
+    let packageRoot = packageRootURL()
+    let dictionaryURL = packageRoot
+        .appending(path: "azooKey_dictionary_storage")
+        .appending(path: "Dictionary")
+    let memoryURL = FileManager.default.temporaryDirectory
+        .appending(path: "azookey-server-learning-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: memoryURL, withIntermediateDirectories: true)
+    defer {
+        try? FileManager.default.removeItem(at: memoryURL)
+    }
+
+    try await MainActor.run {
+        let previousConverter = converter
+        let previousSupplementConverter = normalNBestSupplementConverter
+        let previousComposingText = composingText
+        let previousComposingTextSnapshots = composingTextSnapshots
+        let previousLearningType = currentLearningType
+        let previousLearningMemoryDirectoryURL = currentLearningMemoryDirectoryURL
+        let previousLearningCandidateCache = learningCandidateCache
+        let previousLearningSelectionOverrides = learningSelectionOverrides
+        defer {
+            converter = previousConverter
+            normalNBestSupplementConverter = previousSupplementConverter
+            composingText = previousComposingText
+            composingTextSnapshots = previousComposingTextSnapshots
+            currentLearningType = previousLearningType
+            currentLearningMemoryDirectoryURL = previousLearningMemoryDirectoryURL
+            learningCandidateCache = previousLearningCandidateCache
+            learningSelectionOverrides = previousLearningSelectionOverrides
+        }
+
+        var source = ComposingText()
+        source.insertAtCursorPosition("かとう", inputStyle: .direct)
+        let options = testLearningConvertRequestOptions(memoryURL: memoryURL)
+        converter = KanaKanjiConverter(dictionaryURL: dictionaryURL, preloadDictionary: true)
+        normalNBestSupplementConverter = KanaKanjiConverter(
+            dictionaryURL: dictionaryURL,
+            preloadDictionary: false
+        )
+        currentLearningType = .inputAndOutput
+        currentLearningMemoryDirectoryURL = memoryURL
+        learningCandidateCache.removeAll()
+        learningSelectionOverrides.removeAll()
+
+        @MainActor func candidates() -> [Candidate] {
+            prioritizeLearningSelectionOverrides(
+                converter.requestCandidates(source, options: options).mainResults,
+                ruby: source.convertTarget
+            ) { $0 }
+        }
+
+        @MainActor func commit(_ candidate: Candidate, from candidates: [Candidate]) throws {
+            let index = try #require(candidates.firstIndex { $0.text == candidate.text })
+            let batchFirstId = try #require(cacheLearningCandidates(candidates))
+            let candidateId = learningCandidateId(at: index, batchFirstId: batchFirstId)
+            #expect(commit_learning_candidate(candidateId: candidateId, commitKind: 1))
+            clear_text()
+        }
+
+        let initial = candidates()
+        let katouSugar = try #require(initial.first { $0.text == "果糖" })
+        try commit(katouSugar, from: initial)
+
+        let afterFirstCommit = candidates()
+        #expect(afterFirstCommit.first?.text == "果糖")
+        let katouSurname = try #require(afterFirstCommit.first { $0.text == "加藤" })
+        try commit(katouSurname, from: afterFirstCommit)
+
+        learningSelectionOverrides.removeAll()
+        loadLearningSelectionOverrides()
+        let afterSecondCommit = candidates()
+        #expect(
+            afterSecondCommit.first?.text == "加藤",
+            "first candidates: \(afterSecondCommit.prefix(5).map(\.text))"
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- 学習候補IDのキャッシュをバッチ単位の連番管理へ変更し、リアルタイム変換中の候補キャッシュ処理を軽量化します。
- 同じ読みで後から確定した候補を永続的に優先し、以前学習した候補が第1候補に残り続ける問題を修正します。

## Background
- Issue: N/A
- Issue close: N/A
- `master` 最新ビルドで、学習有効時のリアルタイム変換が以前のリリースよりカクつくという実利用フィードバックがありました。
- 「かとう」で一度「果糖」を学習した後に「加藤」を確定しても、次回以降「果糖」が第1候補に残り続け、最新の選択が順位へ反映されない場合がありました。
- 変換セッションをまたいでconverter内部状態が残ることと、学習回数が同数の場合に古い候補が先行することを併せて対処します。

## Changes
- server/learning candidate cache: 候補をバッチ単位で保持し、候補IDを密な連番として割り当てる実装へ変更
- server/learning candidate cache: バッチを二分探索して候補を解決し、候補IDのconsume-onceとcomposition終了時の一括破棄を維持
- server/learning mode: 入力学習を行う`inputAndOutput`の場合だけ候補をキャッシュし、学習無効時とoutput-only時の追加処理を省略
- server/learning session: `ClearText`で通常converterとnormal N-best補助converterのcompositionを終了し、前回候補の状態を次の入力へ持ち越さないよう変更
- server/learning recency: 読みごとの最新確定候補を上限4096件の`selection-overrides.json`へatomic保存し、再起動後も同じ読みの第1候補へ反映
- server/learning performance: 最新候補が登録されていない読みでは候補配列を走査せず、登録済みの同一読みだけを検索・並べ替え
- test/server: 候補ID、複数バッチ、consume-once、学習モード、別読みへの非干渉、「果糖」から「加藤」への再学習と永続化の回帰テストを追加

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/29456768759
- [x] Windows VM 確認
  - `azookey-serverPackageTests.exe --testing-library swift-testing`: 54 tests pass
  - `latestSelectionReplacesPreviouslyLearnedFirstCandidate`: 「果糖」確定後に「加藤」を確定し、学習データ再読込後も「加藤」が第1候補になることを確認
  - `.local/vm_build_master.sh fix/learning-candidate-cache-performance`: Swift server、Rust x64/x86 client、Tauri、installer build 成功
  - installer: `.local/artifacts/azookey-setup-fix_learning-candidate-cache-performance-20260715-235334.exe`
- [x] ローカル確認
  - `git diff --check`: pass
  - read-only review: Blocking 0 / Major 0
  - GitHub Codex Review（`7e24b79`）: major issueなし

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
