### PR TITLE
chore(release): prepare v0.1.0-batao.10

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,3 +1,3 @@
 {
-  "version": "0.1.0-batao.9"
+  "version": "0.1.0-batao.10"
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0-batao.9",
+  "version": "0.1.0-batao.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0-batao.9",
+      "version": "0.1.0-batao.10",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-dialog": "^1.1.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0-batao.9",
+  "version": "0.1.0-batao.10",
   "type": "module",
   "scripts": {
     "sync-version": "node ../scripts/sync-version.mjs",

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Azookey",
-  "version": "0.1.0-batao.9",
+  "version": "0.1.0-batao.10",
   "identifier": "com.azookey.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/installer/AppVersion.iss
+++ b/installer/AppVersion.iss
@@ -1,2 +1,2 @@
 ; Generated from app-version.json by scripts/sync-version.mjs.
-#define MyAppVersion "0.1.0-batao.9"
+#define MyAppVersion "0.1.0-batao.10"


### PR DESCRIPTION
## Summary
- app-version.json を 0.1.0-batao.10 に更新
- scripts/sync-version.mjs で frontend / Tauri / installer のバージョンを同期

## Verification
- [x] node scripts/sync-version.mjs
- [x] git diff --check
- [x] node node_modules/typescript/bin/tsc（frontend/）

## Issue
- Issue: N/A
