### PR TITLE
fix(installer): harden startup task execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,7 @@ dependencies = [
  "tonic",
  "tower 0.5.2",
  "windows",
+ "windows-registry",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ cargo make build [--debug/--release]
 
 `build`フォルダーが作成され、ビルドされた実行ファイルが格納されます。
 
-配布用インストーラーは Inno Setup で作成する `build/azookey-setup.exe` の 1 種類です。Tauri は設定アプリ `frontend.exe` のビルドにのみ使用し、Tauri/NSIS インストーラーは生成・同梱しません。`frontend.exe` を含むアプリ本体、IME DLL、サーバー、UI、ランチャー、辞書、Zenzai model、llama backend は Inno installer が `{userappdata}\Azookey` に配置します。
+配布用インストーラーは Inno Setup で作成する `build/azookey-setup.exe` の 1 種類です。Tauri は設定アプリ `frontend.exe` のビルドにのみ使用し、Tauri/NSIS インストーラーは生成・同梱しません。`frontend.exe` を含むアプリ本体、IME DLL、サーバー、UI、ランチャー、辞書、Zenzai model、llama backend は Inno installer が `{autopf}\Azookey`（通常は `C:\Program Files\Azookey`）に配置します。設定・学習・ログ・`EngineRuntime` は `%APPDATA%\Azookey`、候補 UI の WebView2 data は `%LOCALAPPDATA%\Azookey\ui-webview` に保存します。
 
 `launcher.exe`を管理者権限で実行すると、azookeyの変換エンジンが起動します。
 

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 use shared::{zenzai_cpu_backend_supported, AppConfig};
 use std::collections::VecDeque;
 use std::ffi::c_void;
@@ -41,6 +43,7 @@ const LAUNCHER_CRASH_TRACE_FILE_NAME: &str = "launcher-crash-trace.json";
 const LAUNCHER_PREVIOUS_CRASH_TRACE_FILE_NAME: &str = "launcher-crash-trace.previous.json";
 
 fn main() -> anyhow::Result<()> {
+    shared::enable_redirection_guard().map_err(anyhow::Error::msg)?;
     let cpu_backend_supported = zenzai_cpu_backend_supported();
     env::set_var(
         "AZOOKEY_ZENZAI_CPU_SUPPORTED",
@@ -132,7 +135,7 @@ fn start_server_process(install_dir: &Path, cpu_backend_supported: bool) -> anyh
         eprintln!("[launcher] CPU backend requires AVX support. Zenzai will fall back to standard conversion.");
     }
 
-    let mut command = process_command_with_backend(install_dir, "azookey-server.exe", &config);
+    let mut command = process_command_with_backend(install_dir, "azookey-server.exe", &config)?;
     command.env(
         "AZOOKEY_ZENZAI_CPU_SUPPORTED",
         if cpu_backend_supported { "1" } else { "0" },
@@ -178,26 +181,33 @@ fn start_server_process(install_dir: &Path, cpu_backend_supported: bool) -> anyh
 
 fn start_ui_process(install_dir: &Path) -> anyhow::Result<Child> {
     let config = load_config();
-    let command = process_command_with_backend(install_dir, "ui.exe", &config);
+    let command = process_command_with_backend(install_dir, "ui.exe", &config)?;
     spawn_process(command, "ui.exe", "[ui]")
 }
 
-fn process_command_with_backend(install_dir: &Path, exe: &str, config: &AppConfig) -> Command {
+fn process_command_with_backend(
+    install_dir: &Path,
+    exe: &str,
+    config: &AppConfig,
+) -> anyhow::Result<Command> {
     let backend_path = install_dir.join(backend_dir(config));
-    let mut command = process_command(install_dir, exe);
+    let mut command = process_command(install_dir, exe)?;
     command.env("PATH", prepend_to_path(&backend_path));
-    command
+    Ok(command)
 }
 
-fn process_command(install_dir: &Path, exe: &str) -> Command {
+fn process_command(install_dir: &Path, exe: &str) -> anyhow::Result<Command> {
     let exe_path = install_dir.join(exe);
-    let mut command = if exe_path.is_file() {
-        Command::new(&exe_path)
-    } else {
-        Command::new(exe)
-    };
+    if !exe_path.is_file() {
+        anyhow::bail!(
+            "Refusing to launch {exe} outside the protected install directory; expected file is missing: {}",
+            exe_path.display()
+        );
+    }
+
+    let mut command = Command::new(&exe_path);
     command.current_dir(install_dir);
-    command
+    Ok(command)
 }
 
 fn resolve_log_path(file_name: &str) -> Option<std::path::PathBuf> {
@@ -638,7 +648,7 @@ unsafe impl Sync for UnsafeSecurityAttributes {}
 #[cfg(test)]
 mod tests {
     use super::{
-        launcher_pipe_sddl, launcher_response, parse_launcher_command,
+        launcher_pipe_sddl, launcher_response, parse_launcher_command, process_command,
         restart_delay_after_server_exit, LauncherCommandKind, SERVER_RESTART_BURST_LIMIT,
         SERVER_RESTART_COOLDOWN, SERVER_RESTART_DELAY,
     };
@@ -679,6 +689,16 @@ mod tests {
         assert!(!sddl.contains(";;;AC)"));
         assert!(!sddl.contains(";;;RC)"));
         assert!(!sddl.contains(";;;LW)"));
+    }
+
+    #[test]
+    fn missing_protected_executable_never_falls_back_to_path() {
+        let install_dir = std::env::temp_dir().join("azookey-missing-protected-executable-test");
+
+        let error = process_command(&install_dir, "ui.exe").unwrap_err();
+
+        assert!(error.to_string().contains("protected install directory"));
+        assert!(error.to_string().contains("ui.exe"));
     }
 
     #[test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 use azookey_server::TonicNamedPipeServer;
 use tonic::{transport::Server, Request, Response, Status};
 use tonic_reflection::server::Builder as ReflectionBuilder;
@@ -14,10 +16,10 @@ use shared::AppConfig;
 use std::{
     backtrace::Backtrace,
     collections::HashSet,
-    ffi::{c_char, c_int, CStr, CString},
+    ffi::{c_char, c_int, CStr, CString, OsStr},
     fs::{self, File, OpenOptions},
     io::{BufWriter, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
         mpsc, OnceLock,
@@ -661,19 +663,23 @@ fn now_timestamp_millis() -> u128 {
 }
 
 fn resolve_log_path(file_name: &str) -> PathBuf {
-    if let Ok(appdata) = std::env::var("APPDATA") {
-        PathBuf::from(appdata)
-            .join("Azookey")
-            .join("logs")
-            .join(file_name)
-    } else {
-        std::env::current_exe()
-            .ok()
-            .and_then(|path| path.parent().map(|parent| parent.to_path_buf()))
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("logs")
-            .join(file_name)
-    }
+    resolve_log_path_from_roots(
+        std::env::var_os("APPDATA").as_deref(),
+        &std::env::temp_dir(),
+        file_name,
+    )
+}
+
+fn resolve_log_path_from_roots(
+    app_data: Option<&OsStr>,
+    temporary_directory: &Path,
+    file_name: &str,
+) -> PathBuf {
+    let root = app_data
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| temporary_directory.to_path_buf());
+    root.join("Azookey").join("logs").join(file_name)
 }
 
 fn configure_server_logging(config: &AppConfig) -> Option<LogPaths> {
@@ -1788,6 +1794,7 @@ impl AzookeyService for MyAzookeyService {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    shared::enable_redirection_guard().map_err(std::io::Error::other)?;
     install_panic_hook();
     let log_paths = reload_server_logging_from_settings();
     if let Some(trace) = preserve_crash_trace_if_incomplete(
@@ -1926,4 +1933,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod path_tests {
+    use super::resolve_log_path_from_roots;
+    use std::{ffi::OsStr, path::Path};
+
+    #[test]
+    fn server_logs_use_app_data() {
+        let path = resolve_log_path_from_roots(
+            Some(OsStr::new("/users/test/roaming")),
+            Path::new("/users/test/temp"),
+            "server.log",
+        );
+
+        assert_eq!(
+            path,
+            Path::new("/users/test/roaming/Azookey/logs/server.log")
+        );
+    }
+
+    #[test]
+    fn server_logs_fall_back_to_temp_instead_of_install_directory() {
+        let install_directory = Path::new("/program-files/Azookey");
+        let path = resolve_log_path_from_roots(
+            Some(OsStr::new("")),
+            Path::new("/users/test/temp"),
+            "server.log",
+        );
+
+        assert_eq!(path, Path::new("/users/test/temp/Azookey/logs/server.log"));
+        assert!(!path.starts_with(install_directory));
+    }
 }

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58.0", features = ["Win32_Storage_FileSystem"] }
+windows = { version = "0.58.0", features = ["Win32_Storage_FileSystem", "Win32_System_Threading"] }
 
 [dev-dependencies]
 tempfile = "3.14.0"

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -12,6 +12,48 @@ pub mod proto {
         tonic::include_file_descriptor_set!("azookey_service_descriptor");
 }
 
+/// Enables RedirectionGuard before a privileged process reads or writes data
+/// below user-writable directories. The policy blocks traversal through
+/// junctions and symbolic links created by non-administrators.
+#[cfg(windows)]
+pub fn enable_redirection_guard() -> Result<(), String> {
+    use windows::Win32::System::Threading::{
+        GetCurrentProcess, GetProcessMitigationPolicy, ProcessRedirectionTrustPolicy,
+        SetProcessMitigationPolicy,
+    };
+
+    const ENFORCE_REDIRECTION_TRUST: u32 = 1;
+    let requested = ENFORCE_REDIRECTION_TRUST;
+    unsafe {
+        SetProcessMitigationPolicy(
+            ProcessRedirectionTrustPolicy,
+            (&requested as *const u32).cast(),
+            std::mem::size_of::<u32>(),
+        )
+        .map_err(|error| format!("failed to enable RedirectionGuard: {error}"))?;
+    }
+
+    let mut actual = 0_u32;
+    unsafe {
+        GetProcessMitigationPolicy(
+            GetCurrentProcess(),
+            ProcessRedirectionTrustPolicy,
+            (&mut actual as *mut u32).cast(),
+            std::mem::size_of::<u32>(),
+        )
+        .map_err(|error| format!("failed to verify RedirectionGuard: {error}"))?;
+    }
+    if actual & ENFORCE_REDIRECTION_TRUST == 0 {
+        return Err("RedirectionGuard is not enforced for this process".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+pub fn enable_redirection_guard() -> Result<(), String> {
+    Ok(())
+}
+
 fn get_config_root() -> Result<PathBuf, ConfigError> {
     let appdata = env::var_os("APPDATA").ok_or(ConfigError::MissingAppData)?;
     Ok(PathBuf::from(appdata).join("Azookey"))

--- a/crates/ui/src/candidate.rs
+++ b/crates/ui/src/candidate.rs
@@ -11,7 +11,7 @@ use windows::Win32::{
         WS_POPUP,
     },
 };
-use wry::WebViewBuilder;
+use wry::{WebContext, WebViewBuilder};
 
 use crate::UserEvent;
 
@@ -44,7 +44,7 @@ pub fn create_candidate_window(event_loop: &EventLoop<UserEvent>) -> Result<Wind
     Ok(window)
 }
 
-pub fn create_candidate_webview<'a>() -> Result<WebViewBuilder<'a>> {
+pub fn create_candidate_webview<'a>(web_context: &'a mut WebContext) -> Result<WebViewBuilder<'a>> {
     let html = r##"
         <html>
             <head>
@@ -433,7 +433,9 @@ pub fn create_candidate_webview<'a>() -> Result<WebViewBuilder<'a>> {
         </html>"##
         .replace("__CANDIDATE_SCROLLER_SCRIPT__", CANDIDATE_SCROLLER_SCRIPT);
 
-    let webview_builder = WebViewBuilder::new().with_transparent(true).with_html(html);
+    let webview_builder = WebViewBuilder::with_web_context(web_context)
+        .with_transparent(true)
+        .with_html(html);
 
     Ok(webview_builder)
 }

--- a/crates/ui/src/data_paths.rs
+++ b/crates/ui/src/data_paths.rs
@@ -1,0 +1,71 @@
+use std::{env, ffi::OsStr, path::PathBuf};
+
+const APP_DIRECTORY_NAME: &str = "Azookey";
+const UI_WEBVIEW_DIRECTORY_NAME: &str = "ui-webview";
+
+pub(crate) fn ui_webview_data_directory() -> PathBuf {
+    resolve_ui_webview_data_directory(
+        env::var_os("LOCALAPPDATA").as_deref(),
+        env::var_os("APPDATA").as_deref(),
+        env::temp_dir(),
+    )
+}
+
+fn resolve_ui_webview_data_directory(
+    local_app_data: Option<&OsStr>,
+    app_data: Option<&OsStr>,
+    temporary_directory: PathBuf,
+) -> PathBuf {
+    let root = [local_app_data, app_data]
+        .into_iter()
+        .flatten()
+        .find(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or(temporary_directory);
+
+    root.join(APP_DIRECTORY_NAME)
+        .join(UI_WEBVIEW_DIRECTORY_NAME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn webview_data_prefers_local_app_data() {
+        let path = resolve_ui_webview_data_directory(
+            Some(OsStr::new("/users/test/local")),
+            Some(OsStr::new("/users/test/roaming")),
+            PathBuf::from("/tmp"),
+        );
+
+        assert_eq!(path, PathBuf::from("/users/test/local/Azookey/ui-webview"));
+    }
+
+    #[test]
+    fn webview_data_falls_back_to_roaming_app_data() {
+        let path = resolve_ui_webview_data_directory(
+            None,
+            Some(OsStr::new("/users/test/roaming")),
+            PathBuf::from("/tmp"),
+        );
+
+        assert_eq!(
+            path,
+            PathBuf::from("/users/test/roaming/Azookey/ui-webview")
+        );
+    }
+
+    #[test]
+    fn webview_data_falls_back_to_temporary_directory() {
+        let install_directory = PathBuf::from("/program-files/Azookey");
+        let path = resolve_ui_webview_data_directory(
+            Some(OsStr::new("")),
+            None,
+            PathBuf::from("/users/test/temp"),
+        );
+
+        assert_eq!(path, PathBuf::from("/users/test/temp/Azookey/ui-webview"));
+        assert!(!path.starts_with(install_directory));
+    }
+}

--- a/crates/ui/src/indicator.rs
+++ b/crates/ui/src/indicator.rs
@@ -12,7 +12,7 @@ use windows::Win32::{
         WS_POPUP,
     },
 };
-use wry::{WebView, WebViewBuilder};
+use wry::{WebContext, WebView, WebViewBuilder};
 
 use crate::UserEvent;
 
@@ -45,8 +45,8 @@ pub fn create_indicator_window(event_loop: &EventLoop<UserEvent>) -> Result<Wind
     Ok(window)
 }
 
-pub fn create_indicator_webview(window: &Window) -> Result<WebView> {
-    let webview = WebViewBuilder::new()
+pub fn create_indicator_webview(window: &Window, web_context: &mut WebContext) -> Result<WebView> {
+    let webview = WebViewBuilder::with_web_context(web_context)
         .with_transparent(true)
         .with_html(
             r##"

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -1,4 +1,6 @@
-use std::sync::Arc;
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use std::{fs, sync::Arc};
 
 use azookey_server::TonicNamedPipeServer;
 use ipc::{WindowAction, WindowController, WindowService};
@@ -27,8 +29,10 @@ use windows::Win32::{
     Foundation::HWND,
     UI::WindowsAndMessaging::{ShowWindow, SW_SHOWNOACTIVATE},
 };
+use wry::WebContext;
 
 pub mod candidate;
+pub mod data_paths;
 pub mod indicator;
 pub mod ipc;
 pub mod ruby;
@@ -331,8 +335,13 @@ pub enum UserEvent {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    shared::enable_redirection_guard().map_err(anyhow::Error::msg)?;
     // obtain uiaccess token
     prepare_uiaccess_token()?;
+
+    let webview_data_directory = data_paths::ui_webview_data_directory();
+    fs::create_dir_all(&webview_data_directory)?;
+    let mut web_context = WebContext::new(Some(webview_data_directory));
 
     let event_loop = EventLoopBuilder::<UserEvent>::with_user_event()
         .with_any_thread(true)
@@ -360,7 +369,7 @@ async fn main() -> anyhow::Result<()> {
 
     let proxy_clone = event_loop_proxy.clone();
     let candidate_window = candidate::create_candidate_window(&event_loop)?;
-    let candidate_webview_builder = candidate::create_candidate_webview()?;
+    let candidate_webview_builder = candidate::create_candidate_webview(&mut web_context)?;
     let candidate_webview = candidate_webview_builder
         .with_devtools(cfg!(debug_assertions))
         .with_ipc_handler(move |message| {
@@ -378,10 +387,11 @@ async fn main() -> anyhow::Result<()> {
         .build(&candidate_window)?;
 
     let indicator_window = indicator::create_indicator_window(&event_loop)?;
-    let indicator_webview = indicator::create_indicator_webview(&indicator_window)?;
+    let indicator_webview =
+        indicator::create_indicator_webview(&indicator_window, &mut web_context)?;
     let ruby_window = ruby::create_ruby_window(&event_loop)?;
     let proxy_clone = event_loop_proxy.clone();
-    let ruby_webview_builder = ruby::create_ruby_webview()?;
+    let ruby_webview_builder = ruby::create_ruby_webview(&mut web_context)?;
     let ruby_webview = ruby_webview_builder
         .with_devtools(cfg!(debug_assertions))
         .with_ipc_handler(move |message| {

--- a/crates/ui/src/ruby.rs
+++ b/crates/ui/src/ruby.rs
@@ -11,7 +11,7 @@ use windows::Win32::{
         WS_POPUP,
     },
 };
-use wry::WebViewBuilder;
+use wry::{WebContext, WebViewBuilder};
 
 use crate::UserEvent;
 
@@ -39,9 +39,11 @@ pub fn create_ruby_window(event_loop: &EventLoop<UserEvent>) -> Result<Window> {
     Ok(window)
 }
 
-pub fn create_ruby_webview<'a>() -> Result<WebViewBuilder<'a>> {
-    let webview_builder = WebViewBuilder::new().with_transparent(true).with_html(
-        r##"
+pub fn create_ruby_webview<'a>(web_context: &'a mut WebContext) -> Result<WebViewBuilder<'a>> {
+    let webview_builder = WebViewBuilder::with_web_context(web_context)
+        .with_transparent(true)
+        .with_html(
+            r##"
         <html>
             <head>
                 <style>
@@ -231,7 +233,7 @@ pub fn create_ruby_webview<'a>() -> Result<WebViewBuilder<'a>> {
                 </main>
             </body>
         </html>"##,
-    );
+        );
 
     Ok(webview_builder)
 }

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ windows-registry = "0.2"
 version = "0.58.0"
 features = [
     "Win32_Foundation",
+    "Win32_Security_Authorization",
     "Win32_System_Registry",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Com",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -32,13 +32,18 @@ hyper-util = { version = "0.1.9", features = ["tokio"] }
 reqwest = { version = "0.12.12", features = ["json"] }
 semver = "1.0"
 sha2 = "0.10"
+windows-registry = "0.2"
 
 [dependencies.windows]
 version = "0.58.0"
 features = [
     "Win32_Foundation",
+    "Win32_System_Registry",
     "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Com",
     "Win32_System_Threading",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
 ]
 
 [dev-dependencies]

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -304,6 +304,37 @@ fn take_update_install_result() -> Result<Option<updater::UpdateInstallResult>, 
     updater::take_update_install_result().map_err(|error| error.to_string())
 }
 
+/// Runs the production updater without starting the Tauri UI for Windows VM
+/// verification. The marker must be created beside the protected executable by
+/// an administrator, so normal users cannot turn environment overrides into an
+/// unattended update trigger.
+pub fn run_updater_integration_test() -> Result<updater::UpdateStartResponse, String> {
+    let executable = std::env::current_exe().map_err(|error| error.to_string())?;
+    let install_dir = executable
+        .parent()
+        .ok_or_else(|| "failed to resolve frontend install directory".to_string())?;
+    let marker = install_dir.join(".azookey-updater-integration-test");
+    if !marker.is_file() {
+        return Err(format!(
+            "protected updater integration marker is missing: {}",
+            marker.display()
+        ));
+    }
+
+    let runtime = tokio::runtime::Runtime::new().map_err(|error| error.to_string())?;
+    runtime
+        .block_on(updater::download_and_launch_update_for_integration_test())
+        .map_err(|error| error.to_string())
+}
+
+/// Runs the protected updater helper copy. The helper reopens and hashes the
+/// downloaded installer while denying write/delete sharing, then holds that
+/// handle until Windows has created the elevated installer process.
+pub fn run_updater_helper() -> Result<(), String> {
+    updater::run_installer_helper_cli(std::env::args_os().skip(2))
+        .map_err(|error| error.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let app_state = AppState::new();

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -2,5 +2,23 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    let mode = std::env::args().nth(1);
+    if mode.as_deref() == Some("--azookey-updater-integration-test") {
+        match frontend_lib::run_updater_integration_test() {
+            Ok(_) => return,
+            Err(error) => {
+                eprintln!("updater integration test failed: {error}");
+                std::process::exit(1);
+            }
+        }
+    }
+    if mode.as_deref() == Some("--azookey-apply-update") {
+        if let Err(error) = frontend_lib::run_updater_helper() {
+            eprintln!("updater helper failed: {error}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
     frontend_lib::run()
 }

--- a/frontend/src-tauri/src/updater.rs
+++ b/frontend/src-tauri/src/updater.rs
@@ -3,22 +3,91 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
-    env, fs,
-    io::Write,
+    env,
+    ffi::OsString,
+    fs,
+    io::{Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
-    process::Command,
     time::{SystemTime, UNIX_EPOCH},
 };
+
+#[cfg(not(windows))]
+use std::process::Command;
 
 const DEFAULT_RELEASE_API_URL: &str =
     "https://api.github.com/repos/batao9/azooKey-Windows/releases/latest";
 const RELEASE_API_URL_ENV: &str = "AZOOKEY_UPDATE_RELEASE_API_URL";
 const CURRENT_VERSION_ENV: &str = "AZOOKEY_UPDATE_CURRENT_VERSION";
 const INSTALLER_ASSET_NAME: &str = "azookey-setup.exe";
+const UPDATE_DOWNLOAD_STAGING_PREFIX: &str = "azookey-update-";
 const SHA256SUMS_ASSET_NAME: &str = "SHA256SUMS.txt";
+const UPDATE_HELPER_EXE_NAME: &str = "azookey-updater-helper.exe";
+const INSTALLER_LOCK_SHARE_MODE: u32 = 0x0000_0001;
+const PROTECTED_UPDATE_STAGING_DIRECTORY_NAME: &str = ".azookey-updater-staging";
 const UPDATE_RESULT_FILENAME: &str = "update-result.json";
+const UPDATE_RESULT_REGISTRY_KEY: &str = r"Software\Azookey";
+const UPDATE_RESULT_REGISTRY_VALUE: &str = "UpdateResultJson";
 const APP_VERSION_JSON: &str = include_str!("../../../app-version.json");
-const UTF8_BOM: &[u8] = b"\xEF\xBB\xBF";
+
+#[cfg(windows)]
+fn reject_reparse_point(path: &Path, label: &str) -> Result<()> {
+    use std::os::windows::fs::MetadataExt;
+
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect {label}: {}", path.display()))?;
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(anyhow!("{label} is a reparse point: {}", path.display()));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn protected_install_directory(executable: &Path) -> Result<PathBuf> {
+    use windows::Win32::{
+        Foundation::HANDLE,
+        System::Com::CoTaskMemFree,
+        UI::Shell::{FOLDERID_ProgramFiles, SHGetKnownFolderPath, KF_FLAG_DEFAULT},
+    };
+
+    let raw_program_files =
+        unsafe { SHGetKnownFolderPath(&FOLDERID_ProgramFiles, KF_FLAG_DEFAULT, HANDLE::default()) }
+            .context("failed to resolve Program Files")?;
+    let program_files_string = unsafe { raw_program_files.to_string() };
+    unsafe { CoTaskMemFree(Some(raw_program_files.0.cast())) };
+    let expected =
+        PathBuf::from(program_files_string.context("Program Files is not valid UTF-16")?)
+            .join("Azookey");
+    reject_reparse_point(&expected, "expected Azookey install directory")?;
+
+    let install_dir = executable
+        .parent()
+        .ok_or_else(|| anyhow!("updater executable has no parent"))?;
+    reject_reparse_point(install_dir, "updater install directory")?;
+
+    let expected = fs::canonicalize(&expected).with_context(|| {
+        format!(
+            "failed to canonicalize expected Azookey install directory: {}",
+            expected.display()
+        )
+    })?;
+    let actual = fs::canonicalize(install_dir).with_context(|| {
+        format!(
+            "failed to canonicalize updater install directory: {}",
+            install_dir.display()
+        )
+    })?;
+    if !actual
+        .to_string_lossy()
+        .eq_ignore_ascii_case(&expected.to_string_lossy())
+    {
+        return Err(anyhow!(
+            "updater executable is outside the protected install directory: {}",
+            actual.display()
+        ));
+    }
+    Ok(actual)
+}
 
 #[derive(Debug, Deserialize)]
 struct AppVersionConfig {
@@ -84,6 +153,14 @@ pub async fn check_for_updates() -> Result<UpdateCheckResponse> {
 }
 
 pub async fn download_and_launch_update() -> Result<UpdateStartResponse> {
+    download_and_launch_update_impl(false).await
+}
+
+pub async fn download_and_launch_update_for_integration_test() -> Result<UpdateStartResponse> {
+    download_and_launch_update_impl(true).await
+}
+
+async fn download_and_launch_update_impl(silent_installer: bool) -> Result<UpdateStartResponse> {
     let release = fetch_latest_release().await?;
     let check = update_check_response(&release)?;
     if !check.update_available {
@@ -107,12 +184,12 @@ pub async fn download_and_launch_update() -> Result<UpdateStartResponse> {
         match download_file_with_sha256(&client, &assets.installer_url, &installer_path).await {
             Ok(hash) => hash,
             Err(error) => {
-                cleanup_download_paths(&installer_path);
+                cleanup_owned_update_staging(&installer_path);
                 return Err(error);
             }
         };
     if !hashes_match(&expected_hash, &actual_hash) {
-        cleanup_download_paths(&installer_path);
+        cleanup_owned_update_staging(&installer_path);
         return Err(anyhow!(
             "installer hash mismatch: expected {}, actual {}",
             expected_hash,
@@ -120,9 +197,27 @@ pub async fn download_and_launch_update() -> Result<UpdateStartResponse> {
         ));
     }
 
-    let result_path = update_result_path()?;
-    let install_log_path = staging_dir.join("azookey-update-install.log");
-    launch_installer_helper(&installer_path, &result_path, &install_log_path)?;
+    let launch_result = (|| -> Result<(PathBuf, PathBuf)> {
+        let result_path = update_result_path()?;
+        let install_log_path = staging_dir.join("azookey-update-install.log");
+        delete_protected_update_result()?;
+        delete_legacy_update_result(&result_path)?;
+        launch_installer_helper(
+            &installer_path,
+            &expected_hash,
+            &result_path,
+            &install_log_path,
+            silent_installer,
+        )?;
+        Ok((result_path, install_log_path))
+    })();
+    let (result_path, install_log_path) = match launch_result {
+        Ok(paths) => paths,
+        Err(error) => {
+            cleanup_owned_update_staging(&installer_path);
+            return Err(error);
+        }
+    };
 
     Ok(UpdateStartResponse {
         latest_version: check.latest_version,
@@ -135,18 +230,41 @@ pub async fn download_and_launch_update() -> Result<UpdateStartResponse> {
 
 pub fn take_update_install_result() -> Result<Option<UpdateInstallResult>> {
     let path = update_result_path()?;
-    if !path.exists() {
+    // The elevated helper writes the current result to HKCU. Prefer it over the
+    // pre-#129 AppData file so a stale or malformed legacy file cannot shadow a
+    // completed update forever.
+    let Some((data, from_legacy_file)) =
+        select_update_result_data(read_protected_update_result()?, &path)?
+    else {
         return Ok(None);
-    }
-
-    let data = fs::read_to_string(&path)
-        .with_context(|| format!("failed to read update result: {}", path.display()))?;
+    };
     let mut result: UpdateInstallResult = serde_json::from_str(&data)
         .with_context(|| format!("failed to parse update result: {}", path.display()))?;
     normalize_update_install_result(&mut result);
-    fs::remove_file(&path)
-        .with_context(|| format!("failed to remove update result: {}", path.display()))?;
+    if from_legacy_file {
+        delete_legacy_update_result(&path)?;
+    } else {
+        delete_protected_update_result()?;
+        // Best-effort cleanup of a stale pre-#129 result. It must never prevent
+        // consuming the authenticated current result from the registry.
+        let _ = delete_legacy_update_result(&path);
+    }
     Ok(Some(result))
+}
+
+fn select_update_result_data(
+    protected_result: Option<String>,
+    legacy_path: &Path,
+) -> Result<Option<(String, bool)>> {
+    if let Some(data) = protected_result {
+        return Ok(Some((data, false)));
+    }
+    if legacy_path.exists() {
+        let data = fs::read_to_string(legacy_path)
+            .with_context(|| format!("failed to read update result: {}", legacy_path.display()))?;
+        return Ok(Some((data, true)));
+    }
+    Ok(None)
 }
 
 fn normalize_update_install_result(result: &mut UpdateInstallResult) {
@@ -322,6 +440,37 @@ fn cleanup_download_paths(destination: &Path) {
     let _ = fs::remove_file(partial_download_path(destination));
 }
 
+fn is_owned_update_staging_installer(installer_path: &Path) -> bool {
+    if installer_path.file_name() != Some(std::ffi::OsStr::new(INSTALLER_ASSET_NAME)) {
+        return false;
+    }
+    let Some(staging_dir) = installer_path.parent() else {
+        return false;
+    };
+    let Some(staging_name) = staging_dir.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some(nonce) = staging_name.strip_prefix(UPDATE_DOWNLOAD_STAGING_PREFIX) else {
+        return false;
+    };
+    if nonce.is_empty() || !nonce.bytes().all(|byte| byte.is_ascii_digit()) {
+        return false;
+    }
+    staging_dir.parent() == Some(env::temp_dir().as_path())
+}
+
+fn cleanup_owned_update_staging(installer_path: &Path) {
+    if !is_owned_update_staging_installer(installer_path) {
+        return;
+    }
+    cleanup_download_paths(installer_path);
+    let Some(staging_dir) = installer_path.parent() else {
+        return;
+    };
+    let _ = fs::remove_file(staging_dir.join("azookey-update-install.log"));
+    let _ = fs::remove_dir(staging_dir);
+}
+
 fn partial_download_path(destination: &Path) -> PathBuf {
     let file_name = destination
         .file_name()
@@ -375,182 +524,611 @@ fn update_result_path() -> Result<PathBuf> {
     Ok(dir.join(UPDATE_RESULT_FILENAME))
 }
 
+fn delete_legacy_update_result(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() || metadata.file_type().is_symlink() => {
+            fs::remove_file(path).with_context(|| {
+                format!("failed to remove legacy update result: {}", path.display())
+            })?;
+        }
+        Ok(_) => {
+            return Err(anyhow!(
+                "legacy update result is not a file: {}",
+                path.display()
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("failed to inspect legacy update result: {}", path.display())
+            });
+        }
+    }
+
+    if fs::symlink_metadata(path).is_ok() {
+        return Err(anyhow!(
+            "legacy update result still exists after deletion: {}",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
 fn updater_staging_dir() -> Result<PathBuf> {
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .context("system clock is before UNIX epoch")?
         .as_secs();
-    Ok(env::temp_dir().join(format!("azookey-update-{nonce}")))
+    Ok(env::temp_dir().join(format!("{UPDATE_DOWNLOAD_STAGING_PREFIX}{nonce}")))
 }
 
+#[cfg(windows)]
 fn launch_installer_helper(
     installer_path: &Path,
+    expected_hash: &str,
     result_path: &Path,
     install_log_path: &Path,
+    silent_installer: bool,
 ) -> Result<()> {
-    let staging_dir = installer_path
-        .parent()
-        .ok_or_else(|| anyhow!("installer path has no parent"))?;
-    let helper_script_path = staging_dir.join("azookey-update-helper.ps1");
-    let launcher_script_path = staging_dir.join("azookey-update-launcher.ps1");
-    write_installer_helper_script(&helper_script_path)?;
-    write_installer_launcher_script(&launcher_script_path)?;
+    use std::{ffi::OsStr, mem::size_of, os::windows::ffi::OsStrExt};
+    use windows::{
+        core::PCWSTR,
+        Win32::{
+            Foundation::{CloseHandle, HANDLE},
+            UI::{
+                Shell::{ShellExecuteExW, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW},
+                WindowsAndMessaging::SW_SHOWNORMAL,
+            },
+        },
+    };
 
-    let status = Command::new("powershell")
-        .arg("-NoProfile")
-        .arg("-ExecutionPolicy")
-        .arg("Bypass")
-        .arg("-WindowStyle")
-        .arg("Hidden")
-        .arg("-File")
-        .arg(&launcher_script_path)
-        .arg("-HelperPath")
-        .arg(&helper_script_path)
-        .arg("-InstallerPath")
-        .arg(installer_path)
-        .arg("-ResultPath")
-        .arg(result_path)
-        .arg("-InstallLogPath")
-        .arg(install_log_path)
-        .status()
-        .context("failed to launch updater helper launcher")?;
+    let executable = env::current_exe().context("failed to resolve updater executable")?;
+    let install_dir = protected_install_directory(&executable)?;
+    let helper_path = install_dir.join(UPDATE_HELPER_EXE_NAME);
+    if !helper_path.is_file() {
+        return Err(anyhow!(
+            "protected updater helper is missing: {}",
+            helper_path.display()
+        ));
+    }
+    reject_reparse_point(&helper_path, "protected updater helper")?;
 
-    if !status.success() {
-        return Err(anyhow!("updater helper launcher failed: {status}"));
+    let quoted = |value: &OsStr| -> Result<String> {
+        let value = value.to_string_lossy();
+        if value.contains('"') {
+            return Err(anyhow!("updater helper argument contains a quote"));
+        }
+        Ok(format!("\"{value}\""))
+    };
+    let mut parameters = format!(
+        "--azookey-apply-update --installer-path {} --expected-sha256 {} --result-path {} --install-log-path {}",
+        quoted(installer_path.as_os_str())?,
+        expected_hash,
+        quoted(result_path.as_os_str())?,
+        quoted(install_log_path.as_os_str())?
+    );
+    if silent_installer {
+        parameters.push_str(" --silent");
     }
 
+    let verb: Vec<u16> = OsStr::new("runas").encode_wide().chain(Some(0)).collect();
+    let helper: Vec<u16> = helper_path
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    let parameters: Vec<u16> = OsStr::new(&parameters)
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    let working_dir: Vec<u16> = install_dir
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    let mut execute_info = SHELLEXECUTEINFOW {
+        cbSize: size_of::<SHELLEXECUTEINFOW>() as u32,
+        fMask: SEE_MASK_NOCLOSEPROCESS,
+        lpVerb: PCWSTR(verb.as_ptr()),
+        lpFile: PCWSTR(helper.as_ptr()),
+        lpParameters: PCWSTR(parameters.as_ptr()),
+        lpDirectory: PCWSTR(working_dir.as_ptr()),
+        nShow: SW_SHOWNORMAL.0,
+        ..Default::default()
+    };
+    unsafe { ShellExecuteExW(&mut execute_info) }
+        .context("failed to launch elevated protected updater helper")?;
+    if execute_info.hProcess == HANDLE::default() {
+        return Err(anyhow!(
+            "ShellExecuteEx returned no updater helper process handle"
+        ));
+    }
+    let _ = unsafe { CloseHandle(execute_info.hProcess) };
+
     Ok(())
 }
 
-fn write_installer_helper_script(script_path: &Path) -> Result<()> {
-    write_powershell_script(script_path, INSTALLER_HELPER_PS1, "updater helper")
-}
-
-fn write_installer_launcher_script(script_path: &Path) -> Result<()> {
-    write_powershell_script(
-        script_path,
-        INSTALLER_LAUNCHER_PS1,
-        "updater helper launcher",
-    )
-}
-
-fn write_powershell_script(script_path: &Path, contents: &str, label: &str) -> Result<()> {
-    let mut file = fs::File::create(script_path)
-        .with_context(|| format!("failed to create {label}: {}", script_path.display()))?;
-    file.write_all(UTF8_BOM)
-        .with_context(|| format!("failed to write {label}: {}", script_path.display()))?;
-    file.write_all(contents.as_bytes())
-        .with_context(|| format!("failed to write {label}: {}", script_path.display()))?;
+#[cfg(not(windows))]
+fn launch_installer_helper(
+    installer_path: &Path,
+    expected_hash: &str,
+    result_path: &Path,
+    install_log_path: &Path,
+    silent_installer: bool,
+) -> Result<()> {
+    let executable = env::current_exe().context("failed to resolve updater executable")?;
+    let install_dir = executable
+        .parent()
+        .ok_or_else(|| anyhow!("updater executable has no parent"))?;
+    let helper_path = install_dir.join(UPDATE_HELPER_EXE_NAME);
+    let mut command = Command::new(&helper_path);
+    command
+        .arg("--azookey-apply-update")
+        .arg("--installer-path")
+        .arg(installer_path)
+        .arg("--expected-sha256")
+        .arg(expected_hash)
+        .arg("--result-path")
+        .arg(result_path)
+        .arg("--install-log-path")
+        .arg(install_log_path);
+    if silent_installer {
+        command.arg("--silent");
+    }
+    command
+        .spawn()
+        .context("failed to launch protected updater helper")?;
     Ok(())
 }
 
-const INSTALLER_LAUNCHER_PS1: &str = r#"
-param(
-  [Parameter(Mandatory = $true)][string]$HelperPath,
-  [Parameter(Mandatory = $true)][string]$InstallerPath,
-  [Parameter(Mandatory = $true)][string]$ResultPath,
-  [Parameter(Mandatory = $true)][string]$InstallLogPath
-)
-
-$ErrorActionPreference = "Stop"
-
-function Quote-ProcessArgument {
-  param([Parameter(Mandatory = $true)][string]$Value)
-  '"' + ($Value -replace '"', '\"') + '"'
+#[derive(Debug, PartialEq, Eq)]
+struct InstallerHelperArgs {
+    installer_path: PathBuf,
+    expected_sha256: String,
+    result_path: PathBuf,
+    install_log_path: PathBuf,
+    silent: bool,
 }
 
-$helperArgs = @(
-  "-NoProfile",
-  "-ExecutionPolicy",
-  "Bypass",
-  "-WindowStyle",
-  "Hidden",
-  "-File",
-  (Quote-ProcessArgument $HelperPath),
-  "-InstallerPath",
-  (Quote-ProcessArgument $InstallerPath),
-  "-ResultPath",
-  (Quote-ProcessArgument $ResultPath),
-  "-InstallLogPath",
-  (Quote-ProcessArgument $InstallLogPath)
-)
-
-# Keep the long-running helper out of frontend.exe's process tree. The installer
-# intentionally stops frontend.exe before replacing files, and taskkill /T would
-# otherwise kill the updater helper and its installer child.
-Start-Process -FilePath "powershell.exe" -ArgumentList $helperArgs -WindowStyle Hidden | Out-Null
-"#;
-
-const INSTALLER_HELPER_PS1: &str = r#"
-param(
-  [Parameter(Mandatory = $true)][string]$InstallerPath,
-  [Parameter(Mandatory = $true)][string]$ResultPath,
-  [Parameter(Mandatory = $true)][string]$InstallLogPath
-)
-
-$ErrorActionPreference = "Stop"
-
-function Write-UpdateResult {
-  param(
-    [Parameter(Mandatory = $true)][string]$Status,
-    [object]$ExitCode,
-    [Parameter(Mandatory = $true)][bool]$NeedsRestart,
-    [Parameter(Mandatory = $true)][string]$Message
-  )
-
-  $resultDir = Split-Path -Parent $ResultPath
-  New-Item -ItemType Directory -Force -Path $resultDir | Out-Null
-  $json = [PSCustomObject]@{
-    status = $Status
-    exit_code = $ExitCode
-    needs_restart = $NeedsRestart
-    message = $Message
-    completed_at = (Get-Date).ToUniversalTime().ToString("o")
-    installer_path = $InstallerPath
-    install_log_path = $InstallLogPath
-  } | ConvertTo-Json -Depth 3
-  $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
-  [System.IO.File]::WriteAllText($ResultPath, $json, $utf8NoBom)
+fn next_helper_arg(args: &mut impl Iterator<Item = OsString>, option: &str) -> Result<OsString> {
+    args.next()
+        .ok_or_else(|| anyhow!("missing value for updater helper option: {option}"))
 }
 
-function Test-IsProcessElevated {
-  $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
-  $principal = [System.Security.Principal.WindowsPrincipal]::new($identity)
-  $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+fn parse_installer_helper_args(
+    args: impl IntoIterator<Item = OsString>,
+) -> Result<InstallerHelperArgs> {
+    let mut args = args.into_iter();
+    let mut installer_path = None;
+    let mut expected_sha256 = None;
+    let mut result_path = None;
+    let mut install_log_path = None;
+    let mut silent = false;
+
+    while let Some(option) = args.next() {
+        match option.to_string_lossy().as_ref() {
+            "--installer-path" => {
+                installer_path = Some(PathBuf::from(next_helper_arg(
+                    &mut args,
+                    "--installer-path",
+                )?));
+            }
+            "--expected-sha256" => {
+                expected_sha256 = Some(
+                    next_helper_arg(&mut args, "--expected-sha256")?
+                        .to_string_lossy()
+                        .into_owned(),
+                );
+            }
+            "--result-path" => {
+                result_path = Some(PathBuf::from(next_helper_arg(&mut args, "--result-path")?));
+            }
+            "--install-log-path" => {
+                install_log_path = Some(PathBuf::from(next_helper_arg(
+                    &mut args,
+                    "--install-log-path",
+                )?));
+            }
+            "--silent" => silent = true,
+            unexpected => return Err(anyhow!("unexpected updater helper option: {unexpected}")),
+        }
+    }
+
+    let expected_sha256 = expected_sha256
+        .filter(|value| is_sha256(value))
+        .ok_or_else(|| anyhow!("missing or invalid expected installer SHA-256"))?;
+    Ok(InstallerHelperArgs {
+        installer_path: installer_path.ok_or_else(|| anyhow!("missing installer path"))?,
+        expected_sha256,
+        result_path: result_path.ok_or_else(|| anyhow!("missing result path"))?,
+        install_log_path: install_log_path.ok_or_else(|| anyhow!("missing install log path"))?,
+        silent,
+    })
 }
 
-try {
-  $installerArgs = @(
-    "/RESTARTEXITCODE=3010",
-    "/LOG=$InstallLogPath"
-  )
-  $startProcessArgs = @{
-    FilePath = $InstallerPath
-    ArgumentList = $installerArgs
-    Wait = $true
-    PassThru = $true
-  }
-  if (-not (Test-IsProcessElevated)) {
-    $startProcessArgs["Verb"] = "RunAs"
-  }
-
-  $proc = Start-Process @startProcessArgs
-  if ($proc.ExitCode -eq 0) {
-    Write-UpdateResult -Status "success" -ExitCode $proc.ExitCode -NeedsRestart $false -Message "更新が完了しました。"
-    exit 0
-  }
-  if ($proc.ExitCode -eq 3010) {
-    Write-UpdateResult -Status "success" -ExitCode $proc.ExitCode -NeedsRestart $true -Message "更新が完了しました。Windows の再起動が必要です。"
-    exit 0
-  }
-
-  Write-UpdateResult -Status "failed" -ExitCode $proc.ExitCode -NeedsRestart $false -Message "更新に失敗しました。終了コード: $($proc.ExitCode)"
-  exit 1
-} catch {
-  Write-UpdateResult -Status "failed" -ExitCode $null -NeedsRestart $false -Message $_.Exception.Message
-  exit 1
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
-"#;
+
+fn sha256_from_reader(reader: &mut impl Read) -> Result<String> {
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .context("failed to read installer")?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format_sha256(&hasher.finalize()))
+}
+
+fn completed_at_string() -> String {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    format!("unix:{seconds}")
+}
+
+#[cfg(not(windows))]
+fn write_update_result(path: &Path, result: &UpdateInstallResult) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("update result path has no parent"))?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create update result dir: {}", parent.display()))?;
+    let temporary = path.with_extension("json.tmp");
+    let data = serde_json::to_vec_pretty(result).context("failed to serialize update result")?;
+    fs::write(&temporary, data)
+        .with_context(|| format!("failed to write update result: {}", temporary.display()))?;
+    if path.exists() {
+        fs::remove_file(path)
+            .with_context(|| format!("failed to replace update result: {}", path.display()))?;
+    }
+    fs::rename(&temporary, path)
+        .with_context(|| format!("failed to publish update result: {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn write_update_result(_path: &Path, result: &UpdateInstallResult) -> Result<()> {
+    let data = serde_json::to_string_pretty(result).context("failed to serialize update result")?;
+    let key = windows_registry::CURRENT_USER
+        .create(UPDATE_RESULT_REGISTRY_KEY)
+        .context("failed to create updater result registry key")?;
+    key.set_string(UPDATE_RESULT_REGISTRY_VALUE, &data)
+        .context("failed to write updater result registry value")?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn read_protected_update_result() -> Result<Option<String>> {
+    let key = match windows_registry::CURRENT_USER.open(UPDATE_RESULT_REGISTRY_KEY) {
+        Ok(key) => key,
+        Err(_) => return Ok(None),
+    };
+    match key.get_string(UPDATE_RESULT_REGISTRY_VALUE) {
+        Ok(value) => Ok(Some(value)),
+        Err(_) => Ok(None),
+    }
+}
+
+#[cfg(not(windows))]
+fn read_protected_update_result() -> Result<Option<String>> {
+    Ok(None)
+}
+
+#[cfg(windows)]
+fn delete_protected_update_result() -> Result<()> {
+    // `Key::open` is read-only. Use `create` to obtain KEY_WRITE as well, and
+    // verify absence so a stale success cannot be mistaken for the next run.
+    let key = windows_registry::CURRENT_USER
+        .create(UPDATE_RESULT_REGISTRY_KEY)
+        .context("failed to open updater result registry key for deletion")?;
+    let _ = key.remove_value(UPDATE_RESULT_REGISTRY_VALUE);
+    if key.get_string(UPDATE_RESULT_REGISTRY_VALUE).is_ok() {
+        return Err(anyhow!("failed to remove updater result registry value"));
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn delete_protected_update_result() -> Result<()> {
+    Ok(())
+}
+
+#[derive(Debug)]
+struct InstallerExecution {
+    exit_code: i32,
+    install_log_path: PathBuf,
+}
+
+#[cfg(windows)]
+fn execute_verified_installer(
+    installer_path: &Path,
+    expected_sha256: &str,
+    _requested_install_log_path: &Path,
+    silent: bool,
+) -> Result<InstallerExecution> {
+    use std::{
+        mem::size_of,
+        os::windows::{ffi::OsStrExt, fs::OpenOptionsExt},
+        process,
+    };
+    use windows::{
+        core::PCWSTR,
+        Win32::{
+            Foundation::{CloseHandle, HANDLE, WAIT_OBJECT_0},
+            System::Threading::{GetExitCodeProcess, WaitForSingleObject, INFINITE},
+            UI::{
+                Shell::{ShellExecuteExW, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW},
+                WindowsAndMessaging::SW_SHOWNORMAL,
+            },
+        },
+    };
+
+    // The download directory is user-writable and may contain reparse points.
+    // Pin the downloaded bytes with a deny-write/delete handle, then copy those
+    // exact bytes into a Program Files child that an unprivileged process cannot
+    // replace before execution.
+    let mut installer = fs::OpenOptions::new()
+        .read(true)
+        .share_mode(INSTALLER_LOCK_SHARE_MODE)
+        .open(installer_path)
+        .with_context(|| format!("failed to lock installer: {}", installer_path.display()))?;
+    let actual_hash = sha256_from_reader(&mut installer)?;
+    if !hashes_match(expected_sha256, &actual_hash) {
+        return Err(anyhow!(
+            "installer changed before elevation: expected {}, actual {}",
+            expected_sha256,
+            actual_hash
+        ));
+    }
+
+    let helper_executable = env::current_exe().context("failed to resolve updater helper")?;
+    let install_dir = protected_install_directory(&helper_executable)?;
+    reject_reparse_point(&helper_executable, "protected updater helper")?;
+
+    let protected_staging_dir = install_dir.join(PROTECTED_UPDATE_STAGING_DIRECTORY_NAME);
+    fs::create_dir_all(&protected_staging_dir).with_context(|| {
+        format!(
+            "failed to create protected updater staging dir: {}",
+            protected_staging_dir.display()
+        )
+    })?;
+    reject_reparse_point(
+        &protected_staging_dir,
+        "protected updater staging directory",
+    )?;
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let protected_installer_path = protected_staging_dir.join(format!(
+        ".azookey-setup-verified-{}-{nonce}.exe",
+        process::id()
+    ));
+    let protected_install_log_path = protected_staging_dir.join(format!(
+        "azookey-update-install-{}-{nonce}.log",
+        process::id()
+    ));
+    struct ProtectedInstallerCleanup {
+        file: PathBuf,
+        directory: PathBuf,
+    }
+    impl Drop for ProtectedInstallerCleanup {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.file);
+            let _ = fs::remove_dir(&self.directory);
+        }
+    }
+    let _protected_cleanup = ProtectedInstallerCleanup {
+        file: protected_installer_path.clone(),
+        directory: protected_staging_dir.clone(),
+    };
+    let mut protected_installer = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .share_mode(INSTALLER_LOCK_SHARE_MODE)
+        .open(&protected_installer_path)
+        .with_context(|| {
+            format!(
+                "failed to create protected installer copy: {}",
+                protected_installer_path.display()
+            )
+        })?;
+    installer.seek(SeekFrom::Start(0))?;
+    std::io::copy(&mut installer, &mut protected_installer)
+        .context("failed to copy verified installer into Program Files")?;
+    protected_installer
+        .sync_all()
+        .context("failed to flush protected installer copy")?;
+    protected_installer.seek(SeekFrom::Start(0))?;
+    let protected_hash = sha256_from_reader(&mut protected_installer)?;
+    if !hashes_match(expected_sha256, &protected_hash) {
+        return Err(anyhow!(
+            "protected installer copy hash mismatch: expected {}, actual {}",
+            expected_sha256,
+            protected_hash
+        ));
+    }
+
+    // The destination is now an independently verified file under the
+    // protected Program Files ACL. Close the write handle before CreateProcess:
+    // keeping it open with FILE_SHARE_READ only prevents the Windows loader
+    // from reopening the executable and can deadlock ShellExecuteEx.
+    drop(protected_installer);
+    drop(installer);
+
+    // The protected helper was already started with `runas`. Using `runas`
+    // again here can leave a second UAC prompt waiting in a non-interactive
+    // session. `open` inherits the helper's elevated token; the installer's
+    // own requestedExecutionLevel still prompts if the helper was invoked
+    // directly without elevation.
+    let verb: Vec<u16> = std::ffi::OsStr::new("open")
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    let executable: Vec<u16> = protected_installer_path
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    let parameters = if silent {
+        format!(
+            "/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /RESTARTEXITCODE=3010 /LOG=\"{}\"",
+            protected_install_log_path.display()
+        )
+    } else {
+        format!(
+            "/RESTARTEXITCODE=3010 /LOG=\"{}\"",
+            protected_install_log_path.display()
+        )
+    };
+    let parameters: Vec<u16> = std::ffi::OsStr::new(&parameters)
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    let working_dir: Vec<u16> = protected_staging_dir
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+
+    let mut execute_info = SHELLEXECUTEINFOW {
+        cbSize: size_of::<SHELLEXECUTEINFOW>() as u32,
+        fMask: SEE_MASK_NOCLOSEPROCESS,
+        lpVerb: PCWSTR(verb.as_ptr()),
+        lpFile: PCWSTR(executable.as_ptr()),
+        lpParameters: PCWSTR(parameters.as_ptr()),
+        lpDirectory: PCWSTR(working_dir.as_ptr()),
+        nShow: SW_SHOWNORMAL.0,
+        ..Default::default()
+    };
+    let result = (|| -> Result<InstallerExecution> {
+        unsafe { ShellExecuteExW(&mut execute_info) }
+            .context("failed to create elevated installer process")?;
+        if execute_info.hProcess == HANDLE::default() {
+            return Err(anyhow!(
+                "ShellExecuteEx returned no installer process handle"
+            ));
+        }
+        let process = execute_info.hProcess;
+        let wait = unsafe { WaitForSingleObject(process, INFINITE) };
+        if wait != WAIT_OBJECT_0 {
+            let _ = unsafe { CloseHandle(process) };
+            return Err(anyhow!("failed while waiting for installer: {wait:?}"));
+        }
+        let mut exit_code = 0_u32;
+        let exit_result = unsafe { GetExitCodeProcess(process, &mut exit_code) }
+            .context("failed to read installer exit code");
+        let _ = unsafe { CloseHandle(process) };
+        exit_result?;
+        Ok(InstallerExecution {
+            exit_code: exit_code as i32,
+            install_log_path: protected_install_log_path,
+        })
+    })();
+    result
+}
+
+#[cfg(not(windows))]
+fn execute_verified_installer(
+    _installer_path: &Path,
+    _expected_sha256: &str,
+    _install_log_path: &Path,
+    _silent: bool,
+) -> Result<InstallerExecution> {
+    Err(anyhow!("the Azookey updater helper is Windows-only"))
+}
+
+fn helper_result(args: &InstallerHelperArgs) -> UpdateInstallResult {
+    let execution = execute_verified_installer(
+        &args.installer_path,
+        &args.expected_sha256,
+        &args.install_log_path,
+        args.silent,
+    );
+    // The helper has copied and re-verified the installer under Program Files
+    // before it returns from execution. Remove only the exact staging shape
+    // created by this updater; direct helper invocations must not be able to
+    // turn an arbitrary --installer-path into an elevated delete primitive.
+    cleanup_owned_update_staging(&args.installer_path);
+    match execution {
+        Ok(InstallerExecution {
+            exit_code: exit_code @ (0 | 3010),
+            install_log_path,
+        }) => {
+            let parent = install_log_path.parent().map(Path::to_path_buf);
+            let _ = fs::remove_file(&install_log_path);
+            if let Some(parent) = parent {
+                let _ = fs::remove_dir(parent);
+            }
+            UpdateInstallResult {
+                status: "success".to_string(),
+                exit_code: Some(exit_code),
+                needs_restart: exit_code == 3010,
+                message: if exit_code == 3010 {
+                    "更新が完了しました。Windows の再起動が必要です。".to_string()
+                } else {
+                    "更新が完了しました。".to_string()
+                },
+                completed_at: completed_at_string(),
+                installer_path: Some(args.installer_path.display().to_string()),
+                install_log_path: None,
+            }
+        }
+        Ok(InstallerExecution {
+            exit_code,
+            install_log_path,
+        }) => UpdateInstallResult {
+            status: "failed".to_string(),
+            exit_code: Some(exit_code),
+            needs_restart: false,
+            message: format!("更新に失敗しました。終了コード: {exit_code}"),
+            completed_at: completed_at_string(),
+            installer_path: Some(args.installer_path.display().to_string()),
+            install_log_path: Some(install_log_path.display().to_string()),
+        },
+        Err(error) => UpdateInstallResult {
+            status: "failed".to_string(),
+            exit_code: None,
+            needs_restart: false,
+            message: error.to_string(),
+            completed_at: completed_at_string(),
+            installer_path: Some(args.installer_path.display().to_string()),
+            install_log_path: None,
+        },
+    }
+}
+
+pub fn run_installer_helper_cli(args: impl IntoIterator<Item = OsString>) -> Result<()> {
+    shared::enable_redirection_guard().map_err(anyhow::Error::msg)?;
+    let executable = env::current_exe().context("failed to resolve updater helper executable")?;
+    let file_name = executable
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    if !file_name.eq_ignore_ascii_case(UPDATE_HELPER_EXE_NAME) {
+        return Err(anyhow!(
+            "updater helper mode is only available from {UPDATE_HELPER_EXE_NAME}"
+        ));
+    }
+
+    let args = parse_installer_helper_args(args)?;
+    let result = helper_result(&args);
+    write_update_result(&args.result_path, &result)?;
+    if result.status == "success" {
+        Ok(())
+    } else {
+        Err(anyhow!(result.message))
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -747,42 +1325,127 @@ mod tests {
     }
 
     #[test]
-    fn helper_launches_installer_with_visible_ui() {
-        assert!(!INSTALLER_HELPER_PS1.contains(r#""/VERYSILENT""#));
-        assert!(!INSTALLER_HELPER_PS1.contains(r#""/SUPPRESSMSGBOXES""#));
-        assert!(!INSTALLER_HELPER_PS1.contains(r#""/NORESTART""#));
-        assert!(INSTALLER_HELPER_PS1.contains(r#""/RESTARTEXITCODE=3010""#));
-        assert!(INSTALLER_HELPER_PS1.contains(r#""/LOG=$InstallLogPath""#));
+    fn cleanup_removes_only_the_owned_updater_staging_shape() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let staging = env::temp_dir().join(format!(
+            "{UPDATE_DOWNLOAD_STAGING_PREFIX}{}{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir(&staging).unwrap();
+        let installer = staging.join(INSTALLER_ASSET_NAME);
+        fs::write(&installer, b"installer").unwrap();
+        fs::write(partial_download_path(&installer), b"partial").unwrap();
+        fs::write(staging.join("azookey-update-install.log"), b"log").unwrap();
+
+        assert!(is_owned_update_staging_installer(&installer));
+        cleanup_owned_update_staging(&installer);
+
+        assert!(!staging.exists());
+        assert!(!is_owned_update_staging_installer(
+            &env::temp_dir().join("unrelated").join(INSTALLER_ASSET_NAME)
+        ));
+        assert!(!is_owned_update_staging_installer(
+            &env::temp_dir()
+                .join(format!("{UPDATE_DOWNLOAD_STAGING_PREFIX}123"))
+                .join("unrelated.exe")
+        ));
+        assert!(!is_owned_update_staging_installer(
+            &env::temp_dir()
+                .join(format!("{UPDATE_DOWNLOAD_STAGING_PREFIX}not-a-nonce"))
+                .join(INSTALLER_ASSET_NAME)
+        ));
     }
 
     #[test]
-    fn helper_elevates_installer_when_needed() {
-        assert!(INSTALLER_HELPER_PS1.contains("Test-IsProcessElevated"));
-        assert!(INSTALLER_HELPER_PS1.contains(r#"$startProcessArgs["Verb"] = "RunAs""#));
-        assert!(INSTALLER_HELPER_PS1.contains("Start-Process @startProcessArgs"));
+    fn parses_protected_helper_arguments_without_losing_path_spaces() {
+        let expected_hash = "a".repeat(64);
+        let args = parse_installer_helper_args(
+            [
+                "--installer-path",
+                r"C:\User Data\azookey-setup.exe",
+                "--expected-sha256",
+                &expected_hash,
+                "--result-path",
+                r"C:\User Data\update-result.json",
+                "--install-log-path",
+                r"C:\User Data\install.log",
+            ]
+            .into_iter()
+            .map(OsString::from),
+        )
+        .unwrap();
+
+        assert_eq!(
+            args.installer_path,
+            PathBuf::from(r"C:\User Data\azookey-setup.exe")
+        );
+        assert_eq!(args.expected_sha256, expected_hash);
+        assert!(!args.silent);
+        assert_eq!(
+            args.result_path,
+            PathBuf::from(r"C:\User Data\update-result.json")
+        );
     }
 
     #[test]
-    fn launcher_starts_helper_as_separate_process() {
-        assert!(INSTALLER_LAUNCHER_PS1.contains("Start-Process"));
-        assert!(INSTALLER_LAUNCHER_PS1.contains(r#""powershell.exe""#));
-        assert!(INSTALLER_LAUNCHER_PS1.contains("Quote-ProcessArgument $HelperPath"));
-        assert!(!INSTALLER_LAUNCHER_PS1.contains("-Wait"));
+    fn parses_silent_installer_helper_mode() {
+        let expected_hash = "a".repeat(64);
+        let args = parse_installer_helper_args(
+            [
+                "--installer-path",
+                "installer.exe",
+                "--expected-sha256",
+                &expected_hash,
+                "--result-path",
+                "result.json",
+                "--install-log-path",
+                "install.log",
+                "--silent",
+            ]
+            .into_iter()
+            .map(OsString::from),
+        )
+        .unwrap();
+
+        assert!(args.silent);
     }
 
     #[test]
-    fn helper_scripts_are_written_with_utf8_bom() {
-        let temp = tempfile::tempdir().unwrap();
-        let helper = temp.path().join("azookey-update-helper.ps1");
-        let launcher = temp.path().join("azookey-update-launcher.ps1");
+    fn rejects_invalid_helper_hash() {
+        let error = parse_installer_helper_args(
+            [
+                "--installer-path",
+                "installer.exe",
+                "--expected-sha256",
+                "not-a-hash",
+                "--result-path",
+                "result.json",
+                "--install-log-path",
+                "install.log",
+            ]
+            .into_iter()
+            .map(OsString::from),
+        )
+        .unwrap_err();
 
-        write_installer_helper_script(&helper).unwrap();
-        write_installer_launcher_script(&launcher).unwrap();
+        assert!(error.to_string().contains("SHA-256"));
+    }
 
-        for path in [helper, launcher] {
-            let data = fs::read(path).unwrap();
-            assert!(data.starts_with(UTF8_BOM));
-        }
+    #[test]
+    fn hashes_the_bytes_read_from_the_locked_installer_handle() {
+        let mut bytes = &b"verified installer bytes"[..];
+        assert_eq!(
+            sha256_from_reader(&mut bytes).unwrap(),
+            "f12fa6b847f35162dbbacc2fe6870f73824c25140f77218e49b047beb434cfef"
+        );
+    }
+
+    #[test]
+    fn installer_lock_allows_reads_but_denies_write_and_delete_sharing() {
+        assert_eq!(INSTALLER_LOCK_SHARE_MODE, 0x0000_0001);
     }
 
     #[test]
@@ -828,6 +1491,31 @@ mod tests {
             "更新が完了しました。Windows の再起動が必要です。"
         );
         assert!(take_update_install_result().unwrap().is_none());
+    }
+
+    #[test]
+    fn protected_update_result_takes_priority_over_malformed_legacy_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let legacy_path = temp.path().join(UPDATE_RESULT_FILENAME);
+        fs::write(&legacy_path, "not valid json").unwrap();
+        let protected = r#"{
+  "status": "success",
+  "exit_code": 0,
+  "needs_restart": false,
+  "message": "updated",
+  "completed_at": "2026-07-21T00:00:00Z",
+  "installer_path": "protected-installer.exe",
+  "install_log_path": null
+}"#
+        .to_string();
+
+        let (selected, from_legacy) =
+            select_update_result_data(Some(protected.clone()), &legacy_path)
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(selected, protected);
+        assert!(!from_legacy);
     }
 
     #[test]

--- a/frontend/src-tauri/src/updater.rs
+++ b/frontend/src-tauri/src/updater.rs
@@ -27,6 +27,7 @@ const PROTECTED_UPDATE_STAGING_DIRECTORY_NAME: &str = ".azookey-updater-staging"
 const UPDATE_RESULT_FILENAME: &str = "update-result.json";
 const UPDATE_RESULT_REGISTRY_KEY: &str = r"Software\Azookey";
 const UPDATE_RESULT_REGISTRY_VALUE: &str = "UpdateResultJson";
+const PENDING_UPDATE_REQUEST_REGISTRY_VALUE: &str = "PendingUpdateRequestId";
 const APP_VERSION_JSON: &str = include_str!("../../../app-version.json");
 
 #[cfg(windows)]
@@ -141,6 +142,18 @@ pub struct UpdateInstallResult {
     pub install_log_path: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+struct ProtectedUpdateResult {
+    request_id: String,
+    result: UpdateInstallResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UpdateResultTarget {
+    user_sid: String,
+    request_id: String,
+}
+
 #[derive(Debug)]
 struct ReleaseAssets {
     installer_url: String,
@@ -200,15 +213,19 @@ async fn download_and_launch_update_impl(silent_installer: bool) -> Result<Updat
     let launch_result = (|| -> Result<(PathBuf, PathBuf)> {
         let result_path = update_result_path()?;
         let install_log_path = staging_dir.join("azookey-update-install.log");
-        delete_protected_update_result()?;
         delete_legacy_update_result(&result_path)?;
-        launch_installer_helper(
+        let result_target = prepare_update_result_target()?;
+        if let Err(error) = launch_installer_helper(
             &installer_path,
             &expected_hash,
             &result_path,
             &install_log_path,
             silent_installer,
-        )?;
+            &result_target,
+        ) {
+            let _ = clear_protected_update_result();
+            return Err(error);
+        }
         Ok((result_path, install_log_path))
     })();
     let (result_path, install_log_path) = match launch_result {
@@ -230,9 +247,10 @@ async fn download_and_launch_update_impl(silent_installer: bool) -> Result<Updat
 
 pub fn take_update_install_result() -> Result<Option<UpdateInstallResult>> {
     let path = update_result_path()?;
-    // The elevated helper writes the current result to HKCU. Prefer it over the
-    // pre-#129 AppData file so a stale or malformed legacy file cannot shadow a
-    // completed update forever.
+    // The elevated helper writes the current result to the launching user's
+    // explicit HKEY_USERS hive, rather than its own HKCU. The request id stored
+    // by that user before elevation prevents a stale helper from publishing to
+    // a newer update request. Prefer it over the pre-#129 AppData file.
     let Some((data, from_legacy_file)) =
         select_update_result_data(read_protected_update_result()?, &path)?
     else {
@@ -244,7 +262,7 @@ pub fn take_update_install_result() -> Result<Option<UpdateInstallResult>> {
     if from_legacy_file {
         delete_legacy_update_result(&path)?;
     } else {
-        delete_protected_update_result()?;
+        clear_protected_update_result()?;
         // Best-effort cleanup of a stale pre-#129 result. It must never prevent
         // consuming the authenticated current result from the registry.
         let _ = delete_legacy_update_result(&path);
@@ -524,6 +542,116 @@ fn update_result_path() -> Result<PathBuf> {
     Ok(dir.join(UPDATE_RESULT_FILENAME))
 }
 
+fn new_update_request_id() -> Result<String> {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before UNIX epoch")?
+        .as_nanos();
+    Ok(format!("{:x}-{:x}", std::process::id(), nonce))
+}
+
+fn is_supported_user_sid(value: &str) -> bool {
+    let Some(rest) = value
+        .strip_prefix("S-1-5-21-")
+        .or_else(|| value.strip_prefix("S-1-12-1-"))
+    else {
+        return false;
+    };
+    !rest.is_empty()
+        && rest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || byte == b'-')
+        && rest.split('-').all(|part| !part.is_empty())
+}
+
+fn is_update_request_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 96
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
+}
+
+#[cfg(windows)]
+fn current_user_sid_string() -> Result<String> {
+    use windows::{
+        core::PWSTR,
+        Win32::{
+            Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL},
+            Security::{
+                Authorization::ConvertSidToStringSidW, GetTokenInformation, TokenUser, TOKEN_QUERY,
+                TOKEN_USER,
+            },
+            System::Threading::{GetCurrentProcess, OpenProcessToken},
+        },
+    };
+
+    unsafe {
+        let mut token = HANDLE::default();
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token)
+            .context("failed to open updater process token")?;
+        let result = (|| -> Result<String> {
+            let mut token_info_length = 0;
+            let _ = GetTokenInformation(token, TokenUser, None, 0, &mut token_info_length);
+            if token_info_length == 0 {
+                return Err(anyhow!("failed to get updater user SID size"));
+            }
+
+            let mut token_info = vec![0_u8; token_info_length as usize];
+            GetTokenInformation(
+                token,
+                TokenUser,
+                Some(token_info.as_mut_ptr().cast()),
+                token_info_length,
+                &mut token_info_length,
+            )
+            .context("failed to get updater user SID")?;
+            let token_user = &*(token_info.as_ptr() as *const TOKEN_USER);
+            let mut sid_string = PWSTR::null();
+            ConvertSidToStringSidW(token_user.User.Sid, &mut sid_string)
+                .context("failed to convert updater user SID")?;
+            let result = sid_string
+                .to_string()
+                .context("failed to decode updater user SID");
+            let _ = LocalFree(HLOCAL(sid_string.as_ptr().cast()));
+            result
+        })();
+        let _ = CloseHandle(token);
+        result
+    }
+}
+
+#[cfg(not(windows))]
+fn current_user_sid_string() -> Result<String> {
+    Ok("S-1-5-21-0".to_string())
+}
+
+#[cfg(windows)]
+fn prepare_update_result_target() -> Result<UpdateResultTarget> {
+    let user_sid = current_user_sid_string()?;
+    if !is_supported_user_sid(&user_sid) {
+        return Err(anyhow!("unsupported updater user SID: {user_sid}"));
+    }
+    let request_id = new_update_request_id()?;
+    let key = windows_registry::CURRENT_USER
+        .create(UPDATE_RESULT_REGISTRY_KEY)
+        .context("failed to create updater request registry key")?;
+    key.set_string(PENDING_UPDATE_REQUEST_REGISTRY_VALUE, &request_id)
+        .context("failed to write updater request id")?;
+    Ok(UpdateResultTarget {
+        user_sid,
+        request_id,
+    })
+}
+
+#[cfg(not(windows))]
+fn prepare_update_result_target() -> Result<UpdateResultTarget> {
+    Ok(UpdateResultTarget {
+        user_sid: current_user_sid_string()?,
+        request_id: new_update_request_id()?,
+    })
+}
+
 fn delete_legacy_update_result(path: &Path) -> Result<()> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_file() || metadata.file_type().is_symlink() => {
@@ -569,6 +697,7 @@ fn launch_installer_helper(
     result_path: &Path,
     install_log_path: &Path,
     silent_installer: bool,
+    result_target: &UpdateResultTarget,
 ) -> Result<()> {
     use std::{ffi::OsStr, mem::size_of, os::windows::ffi::OsStrExt};
     use windows::{
@@ -601,11 +730,13 @@ fn launch_installer_helper(
         Ok(format!("\"{value}\""))
     };
     let mut parameters = format!(
-        "--azookey-apply-update --installer-path {} --expected-sha256 {} --result-path {} --install-log-path {}",
+        "--azookey-apply-update --installer-path {} --expected-sha256 {} --result-path {} --install-log-path {} --result-user-sid {} --result-request-id {}",
         quoted(installer_path.as_os_str())?,
         expected_hash,
         quoted(result_path.as_os_str())?,
-        quoted(install_log_path.as_os_str())?
+        quoted(install_log_path.as_os_str())?,
+        result_target.user_sid,
+        result_target.request_id,
     );
     if silent_installer {
         parameters.push_str(" --silent");
@@ -655,6 +786,7 @@ fn launch_installer_helper(
     result_path: &Path,
     install_log_path: &Path,
     silent_installer: bool,
+    result_target: &UpdateResultTarget,
 ) -> Result<()> {
     let executable = env::current_exe().context("failed to resolve updater executable")?;
     let install_dir = executable
@@ -671,7 +803,11 @@ fn launch_installer_helper(
         .arg("--result-path")
         .arg(result_path)
         .arg("--install-log-path")
-        .arg(install_log_path);
+        .arg(install_log_path)
+        .arg("--result-user-sid")
+        .arg(&result_target.user_sid)
+        .arg("--result-request-id")
+        .arg(&result_target.request_id);
     if silent_installer {
         command.arg("--silent");
     }
@@ -687,6 +823,7 @@ struct InstallerHelperArgs {
     expected_sha256: String,
     result_path: PathBuf,
     install_log_path: PathBuf,
+    result_target: UpdateResultTarget,
     silent: bool,
 }
 
@@ -703,6 +840,8 @@ fn parse_installer_helper_args(
     let mut expected_sha256 = None;
     let mut result_path = None;
     let mut install_log_path = None;
+    let mut result_user_sid = None;
+    let mut result_request_id = None;
     let mut silent = false;
 
     while let Some(option) = args.next() {
@@ -729,6 +868,20 @@ fn parse_installer_helper_args(
                     "--install-log-path",
                 )?));
             }
+            "--result-user-sid" => {
+                result_user_sid = Some(
+                    next_helper_arg(&mut args, "--result-user-sid")?
+                        .to_string_lossy()
+                        .into_owned(),
+                );
+            }
+            "--result-request-id" => {
+                result_request_id = Some(
+                    next_helper_arg(&mut args, "--result-request-id")?
+                        .to_string_lossy()
+                        .into_owned(),
+                );
+            }
             "--silent" => silent = true,
             unexpected => return Err(anyhow!("unexpected updater helper option: {unexpected}")),
         }
@@ -737,11 +890,21 @@ fn parse_installer_helper_args(
     let expected_sha256 = expected_sha256
         .filter(|value| is_sha256(value))
         .ok_or_else(|| anyhow!("missing or invalid expected installer SHA-256"))?;
+    let user_sid = result_user_sid
+        .filter(|value| is_supported_user_sid(value))
+        .ok_or_else(|| anyhow!("missing or invalid updater result user SID"))?;
+    let request_id = result_request_id
+        .filter(|value| is_update_request_id(value))
+        .ok_or_else(|| anyhow!("missing or invalid updater result request id"))?;
     Ok(InstallerHelperArgs {
         installer_path: installer_path.ok_or_else(|| anyhow!("missing installer path"))?,
         expected_sha256,
         result_path: result_path.ok_or_else(|| anyhow!("missing result path"))?,
         install_log_path: install_log_path.ok_or_else(|| anyhow!("missing install log path"))?,
+        result_target: UpdateResultTarget {
+            user_sid,
+            request_id,
+        },
         silent,
     })
 }
@@ -774,7 +937,11 @@ fn completed_at_string() -> String {
 }
 
 #[cfg(not(windows))]
-fn write_update_result(path: &Path, result: &UpdateInstallResult) -> Result<()> {
+fn write_update_result(
+    path: &Path,
+    result: &UpdateInstallResult,
+    _target: &UpdateResultTarget,
+) -> Result<()> {
     let parent = path
         .parent()
         .ok_or_else(|| anyhow!("update result path has no parent"))?;
@@ -794,26 +961,48 @@ fn write_update_result(path: &Path, result: &UpdateInstallResult) -> Result<()> 
 }
 
 #[cfg(windows)]
-fn write_update_result(_path: &Path, result: &UpdateInstallResult) -> Result<()> {
-    let data = serde_json::to_string_pretty(result).context("failed to serialize update result")?;
-    let key = windows_registry::CURRENT_USER
-        .create(UPDATE_RESULT_REGISTRY_KEY)
-        .context("failed to create updater result registry key")?;
+fn write_update_result(
+    _path: &Path,
+    result: &UpdateInstallResult,
+    target: &UpdateResultTarget,
+) -> Result<()> {
+    let registry_path = user_update_result_registry_path(&target.user_sid)?;
+    let envelope = ProtectedUpdateResult {
+        request_id: target.request_id.clone(),
+        result: result.clone(),
+    };
+    let data = serde_json::to_string_pretty(&envelope)
+        .context("failed to serialize protected update result")?;
+    let key = windows_registry::USERS
+        .create(&registry_path)
+        .context("failed to open launching user updater result registry key")?;
+    let pending_request = key
+        .get_string(PENDING_UPDATE_REQUEST_REGISTRY_VALUE)
+        .context("launching user has no pending updater request")?;
+    if pending_request != target.request_id {
+        return Err(anyhow!(
+            "launching user's pending updater request does not match helper request"
+        ));
+    }
     key.set_string(UPDATE_RESULT_REGISTRY_VALUE, &data)
-        .context("failed to write updater result registry value")?;
+        .context("failed to write launching user updater result registry value")?;
     Ok(())
 }
 
 #[cfg(windows)]
 fn read_protected_update_result() -> Result<Option<String>> {
+    let Some(request_id) = read_pending_update_request()? else {
+        return Ok(None);
+    };
     let key = match windows_registry::CURRENT_USER.open(UPDATE_RESULT_REGISTRY_KEY) {
         Ok(key) => key,
         Err(_) => return Ok(None),
     };
-    match key.get_string(UPDATE_RESULT_REGISTRY_VALUE) {
-        Ok(value) => Ok(Some(value)),
-        Err(_) => Ok(None),
-    }
+    let data = match key.get_string(UPDATE_RESULT_REGISTRY_VALUE) {
+        Ok(value) => value,
+        Err(_) => return Ok(None),
+    };
+    select_protected_update_result(&data, &request_id)
 }
 
 #[cfg(not(windows))]
@@ -821,22 +1010,61 @@ fn read_protected_update_result() -> Result<Option<String>> {
     Ok(None)
 }
 
+fn select_protected_update_result(data: &str, request_id: &str) -> Result<Option<String>> {
+    let envelope: ProtectedUpdateResult = serde_json::from_str(data)
+        .context("failed to parse launching user updater result registry value")?;
+    if envelope.request_id != request_id {
+        return Ok(None);
+    }
+    serde_json::to_string(&envelope.result)
+        .map(Some)
+        .context("failed to serialize selected updater result")
+}
+
 #[cfg(windows)]
-fn delete_protected_update_result() -> Result<()> {
-    // `Key::open` is read-only. Use `create` to obtain KEY_WRITE as well, and
-    // verify absence so a stale success cannot be mistaken for the next run.
+fn read_pending_update_request() -> Result<Option<String>> {
+    let key = match windows_registry::CURRENT_USER.open(UPDATE_RESULT_REGISTRY_KEY) {
+        Ok(key) => key,
+        Err(_) => return Ok(None),
+    };
+    match key.get_string(PENDING_UPDATE_REQUEST_REGISTRY_VALUE) {
+        Ok(value) if is_update_request_id(&value) => Ok(Some(value)),
+        Ok(_) => Err(anyhow!("invalid pending updater request id")),
+        Err(_) => Ok(None),
+    }
+}
+
+#[cfg(not(windows))]
+fn read_pending_update_request() -> Result<Option<String>> {
+    Ok(None)
+}
+
+fn user_update_result_registry_path(user_sid: &str) -> Result<String> {
+    if !is_supported_user_sid(user_sid) {
+        return Err(anyhow!("unsupported updater result user SID: {user_sid}"));
+    }
+    Ok(format!("{user_sid}\\{UPDATE_RESULT_REGISTRY_KEY}"))
+}
+
+#[cfg(windows)]
+fn clear_protected_update_result() -> Result<()> {
     let key = windows_registry::CURRENT_USER
         .create(UPDATE_RESULT_REGISTRY_KEY)
-        .context("failed to open updater result registry key for deletion")?;
+        .context("failed to open updater request registry key for deletion")?;
+    let _ = key.remove_value(PENDING_UPDATE_REQUEST_REGISTRY_VALUE);
     let _ = key.remove_value(UPDATE_RESULT_REGISTRY_VALUE);
-    if key.get_string(UPDATE_RESULT_REGISTRY_VALUE).is_ok() {
-        return Err(anyhow!("failed to remove updater result registry value"));
+    if key
+        .get_string(PENDING_UPDATE_REQUEST_REGISTRY_VALUE)
+        .is_ok()
+        || key.get_string(UPDATE_RESULT_REGISTRY_VALUE).is_ok()
+    {
+        return Err(anyhow!("failed to remove updater result/request values"));
     }
     Ok(())
 }
 
 #[cfg(not(windows))]
-fn delete_protected_update_result() -> Result<()> {
+fn clear_protected_update_result() -> Result<()> {
     Ok(())
 }
 
@@ -1122,7 +1350,7 @@ pub fn run_installer_helper_cli(args: impl IntoIterator<Item = OsString>) -> Res
 
     let args = parse_installer_helper_args(args)?;
     let result = helper_result(&args);
-    write_update_result(&args.result_path, &result)?;
+    write_update_result(&args.result_path, &result, &args.result_target)?;
     if result.status == "success" {
         Ok(())
     } else {
@@ -1372,6 +1600,10 @@ mod tests {
                 r"C:\User Data\update-result.json",
                 "--install-log-path",
                 r"C:\User Data\install.log",
+                "--result-user-sid",
+                "S-1-5-21-100-200-300-400",
+                "--result-request-id",
+                "abc123-def456",
             ]
             .into_iter()
             .map(OsString::from),
@@ -1383,6 +1615,8 @@ mod tests {
             PathBuf::from(r"C:\User Data\azookey-setup.exe")
         );
         assert_eq!(args.expected_sha256, expected_hash);
+        assert_eq!(args.result_target.user_sid, "S-1-5-21-100-200-300-400");
+        assert_eq!(args.result_target.request_id, "abc123-def456");
         assert!(!args.silent);
         assert_eq!(
             args.result_path,
@@ -1403,6 +1637,10 @@ mod tests {
                 "result.json",
                 "--install-log-path",
                 "install.log",
+                "--result-user-sid",
+                "S-1-12-1-100-200-300-400",
+                "--result-request-id",
+                "123abc-456def",
                 "--silent",
             ]
             .into_iter()
@@ -1425,6 +1663,10 @@ mod tests {
                 "result.json",
                 "--install-log-path",
                 "install.log",
+                "--result-user-sid",
+                "S-1-5-21-100-200-300-400",
+                "--result-request-id",
+                "abc123-def456",
             ]
             .into_iter()
             .map(OsString::from),
@@ -1432,6 +1674,45 @@ mod tests {
         .unwrap_err();
 
         assert!(error.to_string().contains("SHA-256"));
+    }
+
+    #[test]
+    fn launching_user_result_path_accepts_only_user_sid_shapes() {
+        assert_eq!(
+            user_update_result_registry_path("S-1-5-21-100-200-300-400").unwrap(),
+            r"S-1-5-21-100-200-300-400\Software\Azookey"
+        );
+        assert!(user_update_result_registry_path(r"S-1-5-21-100\..\Microsoft\Windows").is_err());
+        assert!(user_update_result_registry_path("S-1-5-32-544").is_err());
+    }
+
+    #[test]
+    fn protected_result_must_match_launching_user_request() {
+        let result = UpdateInstallResult {
+            status: "success".to_string(),
+            exit_code: Some(3010),
+            needs_restart: true,
+            message: "updated".to_string(),
+            completed_at: "unix:1".to_string(),
+            installer_path: None,
+            install_log_path: None,
+        };
+        let data = serde_json::to_string(&ProtectedUpdateResult {
+            request_id: "current-request".to_string(),
+            result: result.clone(),
+        })
+        .unwrap();
+
+        let selected = select_protected_update_result(&data, "current-request")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<UpdateInstallResult>(&selected).unwrap(),
+            result
+        );
+        assert!(select_protected_update_result(&data, "stale-request")
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/installer/Azookey Startup.xml
+++ b/installer/Azookey Startup.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
     <Date>2025-03-28T20:02:06</Date>
@@ -39,8 +38,8 @@
   </Settings>
   <Actions Context="Author">
     <Exec>
-      <Command>wscript.exe</Command>
-      <Arguments>PATH_TO_VBS</Arguments>
+      <Command>PATH_TO_LAUNCHER</Command>
+      <WorkingDirectory>PATH_TO_WORKING_DIRECTORY</WorkingDirectory>
     </Exec>
   </Actions>
 </Task>

--- a/installer/Installer.iss
+++ b/installer/Installer.iss
@@ -8,6 +8,7 @@
 #define MyAppURL "https://github.com/batao9/azooKey-Windows/"
 #define MySettingsAppName "frontend.exe"
 #define MyLegacyNsisUninstallKey "Software\Microsoft\Windows\CurrentVersion\Uninstall\Azookey"
+#define MyInnoUninstallKey "Software\Microsoft\Windows\CurrentVersion\Uninstall\{80B746D4-D74D-4345-8F81-47E06BCAB515}_is1"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -20,7 +21,9 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
-DefaultDirName={userappdata}\{#MyAppName}
+DefaultDirName={autopf}\{#MyAppName}
+UsePreviousAppDir=no
+DisableDirPage=yes
 ; "ArchitecturesAllowed=x64compatible" specifies that Setup cannot run
 ; on anything but x64 and Windows 11 on Arm.
 ArchitecturesAllowed=x64compatible
@@ -37,7 +40,7 @@ OutputBaseFilename=azookey-setup
 SolidCompression=yes
 WizardStyle=modern
 PrivilegesRequired=admin
-CloseApplications=yes
+CloseApplications=no
 RestartApplications=no
 
 [Languages]
@@ -54,8 +57,9 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Source: "../build/azookey_windows.dll"; DestDir: "{app}"; DestName: "azookey.dll"; Flags: ignoreversion regserver 64bit restartreplace uninsrestartdelete
 Source: "../build/x86/azookey_windows.dll"; DestDir: "{app}"; DestName: "azookey32.dll"; Flags: ignoreversion regserver 32bit restartreplace uninsrestartdelete
 Source: "../build/{#MySettingsAppName}"; DestDir: "{app}"; Flags: ignoreversion restartreplace uninsrestartdelete
-Source: "../build/*"; DestDir: "{app}"; Excludes: "{#MySettingsAppName}"; Flags: ignoreversion recursesubdirs createallsubdirs restartreplace uninsrestartdelete
-Source: "./Azookey Startup.xml"; Flags: dontcopy noencryption
+Source: "../build/{#MySettingsAppName}"; DestDir: "{app}"; DestName: "azookey-updater-helper.exe"; Flags: ignoreversion restartreplace uninsrestartdelete
+Source: "../build/*"; DestDir: "{app}"; Excludes: "{#MySettingsAppName},azookey-updater-helper.exe"; Flags: ignoreversion recursesubdirs createallsubdirs restartreplace uninsrestartdelete
+Source: "./Azookey Startup.xml"; DestDir: "{app}"; DestName: ".azookey-startup-task.xml"; Flags: ignoreversion deleteafterinstall
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
@@ -63,45 +67,16 @@ Name: "{userdesktop}\{#MyAppName}"; Filename: "{app}\{#MySettingsAppName}"; Work
 
 [InstallDelete]
 Type: files; Name: "{app}\uninstall.exe"
+Type: files; Name: "{app}\launch.vbs"
+Type: files; Name: "{app}\.azookey-updater-integration-test"
+Type: files; Name: "{app}\.legacy-user-sid-*.ps1"
+Type: files; Name: "{app}\.legacy-user-sid-*.txt"
 
 [Registry]
 Root: HKCU; Subkey: "{#MyLegacyNsisUninstallKey}"; Flags: deletekey
 Root: HKLM; Subkey: "{#MyLegacyNsisUninstallKey}"; Flags: deletekey
 Root: HKLM32; Subkey: "{#MyLegacyNsisUninstallKey}"; Flags: deletekey
 Root: HKLM64; Subkey: "{#MyLegacyNsisUninstallKey}"; Flags: deletekey
-
-[Run]
-Filename: "icacls"; \
-  Parameters: "{app}\azookey.dll /grant ""*S-1-15-2-1:(RX)"""; \
-  Description: "Grant Permission"; \
-  Flags: runhidden postinstall runascurrentuser
-Filename: "icacls"; \
-  Parameters: "{app}\azookey32.dll /grant ""*S-1-15-2-1:(RX)"""; \
-  Description: "Grant Permission"; \
-  Flags: runhidden postinstall runascurrentuser
-
-[UninstallRun]
-Filename: "taskkill"; \
-  Parameters: "/F /IM ""frontend.exe"""; \
-  RunOnceId: "StopFrontend"; \
-  Flags: runhidden
-; Stop launcher before server so the watchdog cannot respawn it during uninstall.
-Filename: "taskkill"; \
-  Parameters: "/F /T /IM ""launcher.exe"""; \
-  RunOnceId: "StopLauncher"; \
-  Flags: runhidden
-Filename: "taskkill"; \
-  Parameters: "/F /T /IM ""azookey-server.exe"""; \
-  RunOnceId: "StopAzookeyServer"; \
-  Flags: runhidden
-Filename: "taskkill"; \
-  Parameters: "/F /T /IM ""ui.exe"""; \
-  RunOnceId: "StopUi"; \
-  Flags: runhidden
-Filename: "schtasks"; \
-  Parameters: "/Delete /TN ""Azookey Startup"" /F"; \
-  RunOnceId: "DeleteStartupTask"; \
-  Flags: runhidden runascurrentuser
 
 [UninstallDelete]
 Type: files; Name: "{app}\*.dll"
@@ -117,8 +92,61 @@ Type: filesandordirs; Name: "{app}\logs"
 Type: filesandordirs; Name: "{app}\EngineRuntime"
 Type: filesandordirs; Name: "{app}\frontend.exe.WebView2"
 Type: filesandordirs; Name: "{app}\ui.exe.WebView2"
+Type: filesandordirs; Name: "{app}\.legacy-migration-*"
+Type: files; Name: "{app}\.legacy-user-sid-*.ps1"
+Type: files; Name: "{app}\.legacy-user-sid-*.txt"
+Type: filesandordirs; Name: "{app}\.azookey-updater-staging"
+Type: filesandordirs; Name: "{userappdata}\Azookey\logs"
+Type: filesandordirs; Name: "{userappdata}\Azookey\EngineRuntime"
+Type: filesandordirs; Name: "{userappdata}\Azookey\frontend.exe.WebView2"
+Type: filesandordirs; Name: "{userappdata}\Azookey\ui.exe.WebView2"
+Type: files; Name: "{userappdata}\Azookey\*.dll"
+Type: files; Name: "{userappdata}\Azookey\*.exe"
+Type: files; Name: "{userappdata}\Azookey\*.vbs"
+Type: files; Name: "{userappdata}\Azookey\*.gguf"
+Type: filesandordirs; Name: "{userappdata}\Azookey\Dictionary"
+Type: filesandordirs; Name: "{userappdata}\Azookey\EmojiDictionary"
+Type: filesandordirs; Name: "{userappdata}\Azookey\llama_cpu"
+Type: filesandordirs; Name: "{userappdata}\Azookey\llama_cuda"
+Type: filesandordirs; Name: "{userappdata}\Azookey\llama_vulkan"
+Type: filesandordirs; Name: "{userappdata}\Azookey\backend"
+Type: filesandordirs; Name: "{localappdata}\Azookey\ui-webview"
+Type: filesandordirs; Name: "{localappdata}\com.azookey.app"
 
 [Code]
+const
+  StartupTaskName = 'Azookey Startup';
+  TaskCreateFailureTestParam = '/AZOOKEY_TEST_FAIL_TASK_CREATE';
+  TaskRunFailureTestParam = '/AZOOKEY_TEST_FAIL_TASK_RUN';
+  LegacyRegistryDeleteFailureTestParam = '/AZOOKEY_TEST_FAIL_LEGACY_REGISTRY_DELETE';
+  UpdaterDownloadStagingPrefix = 'azookey-update-';
+  PostInstallFailureExitCode = 4;
+  PreviousInnoV010Batao10Version = '0.1.0-batao.10';
+  PreviousInnoV010Batao10UninstallerSha256 = 'b8cfe3b8491cf2dd39bc223a2858c003af42e4f4bee49b7f38ff77bd5f36648e';
+  SettingsBackupPrefix = 'settings.json.broken-';
+  ProcessRedirectionTrustPolicy = 16;
+  EnforceRedirectionTrust = 1;
+
+var
+  MigrationNeedsRestart: Boolean;
+  SetupFailureExitCode: Integer;
+
+function GetCurrentProcess(): THandle;
+  external 'GetCurrentProcess@kernel32.dll stdcall';
+function GetProcessMitigationPolicy(
+  ProcessHandle: THandle;
+  MitigationPolicy: Integer;
+  var Buffer: Cardinal;
+  BufferLength: Cardinal
+): Boolean;
+  external 'GetProcessMitigationPolicy@kernel32.dll stdcall delayload';
+
+<event('GetCustomSetupExitCode')>
+function Azookey_GetCustomSetupExitCode(): Integer;
+begin
+  Result := SetupFailureExitCode;
+end;
+
 function RemoveSurroundingQuotes(Value: String): String;
 begin
   Result := Trim(Value);
@@ -170,12 +198,6 @@ begin
 end;
 
 function UninstallLegacyNsisFromRoot(RootKey: Integer; RootName: String): Boolean;
-var
-  InstallLocation: String;
-  UninstallString: String;
-  UninstallExe: String;
-  UninstallParams: String;
-  ResultCode: Integer;
 begin
   Result := True;
 
@@ -184,62 +206,17 @@ begin
     Exit;
   end;
 
-  if not RegQueryStringValue(RootKey, '{#MyLegacyNsisUninstallKey}', 'UninstallString', UninstallString) then
-  begin
-    SuppressibleMsgBox('旧バージョンのアンインストール情報が壊れているため、更新を続行できません。旧バージョンを手動でアンインストールしてから再度実行してください。', mbError, MB_OK, IDOK);
-    Result := False;
-    Exit;
-  end;
-
-  UninstallExe := '';
-  InstallLocation := '';
-
-  if RegQueryStringValue(RootKey, '{#MyLegacyNsisUninstallKey}', 'InstallLocation', InstallLocation) then
-  begin
-    InstallLocation := RemoveSurroundingQuotes(InstallLocation);
-    if InstallLocation <> '' then
-    begin
-      UninstallExe := InstallLocation + '\uninstall.exe';
-      if not FileExists(UninstallExe) then
-      begin
-        UninstallExe := '';
-      end;
-    end;
-  end;
-
-  if UninstallExe = '' then
-  begin
-    UninstallExe := ExtractExecutablePath(UninstallString);
-  end;
-
-  if (UninstallExe = '') or (not FileExists(UninstallExe)) then
-  begin
-    Log('Legacy NSIS uninstaller was registered but not found under ' + RootName + ': ' + UninstallString);
-    SuppressibleMsgBox('旧バージョンのアンインストーラーが見つからないため、更新を続行できません: ' + UninstallString, mbError, MB_OK, IDOK);
-    Result := False;
-    Exit;
-  end;
-
-  UninstallParams := '/S';
-  if InstallLocation <> '' then
-  begin
-    UninstallParams := UninstallParams + ' _?=' + InstallLocation;
-  end;
-
-  Log('Running legacy NSIS uninstaller from ' + RootName + ': ' + UninstallExe + ' ' + UninstallParams);
-  if not Exec(UninstallExe, UninstallParams, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
-  begin
-    SuppressibleMsgBox('旧バージョンのアンインストーラーを実行できませんでした: ' + UninstallExe, mbError, MB_OK, IDOK);
-    Result := False;
-    Exit;
-  end;
-
-  if ResultCode <> 0 then
-  begin
-    SuppressibleMsgBox('旧バージョンのアンインストールに失敗しました。終了コード: ' + IntToStr(ResultCode), mbError, MB_OK, IDOK);
-    Result := False;
-    Exit;
-  end;
+  // Legacy NSIS payloads live in a user-writable directory and have no
+  // release-specific trust metadata. Never execute their uninstallers from
+  // this elevated installer.
+  Log('Legacy NSIS install detected under ' + RootName + '; refusing to execute its untrusted uninstaller.');
+  SuppressibleMsgBox(
+    '安全に検証できない旧 NSIS 版がインストールされています。Windows の「インストールされているアプリ」から旧版を手動でアンインストールしてから、再度実行してください。',
+    mbError,
+    MB_OK,
+    IDOK
+  );
+  Result := False;
 end;
 
 function UninstallLegacyNsisInstall(): Boolean;
@@ -278,36 +255,173 @@ begin
   end;
   Parameters := Parameters + '/IM "' + ImageName + '"';
 
-  Exec('taskkill', Parameters, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-  if ResultCode = 0 then
+  if not Exec(ExpandConstant('{sys}\taskkill.exe'), Parameters, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
   begin
-    Log('Stopped Azookey process before install: ' + ImageName);
+    Log('Failed to execute taskkill for Azookey process: ' + ImageName);
+  end
+  else if ResultCode = 0 then
+  begin
+    Log('Stopped Azookey process: ' + ImageName);
   end
   else
   begin
-    Log('Azookey process was not running before install: ' + ImageName + ' (taskkill exit code ' + IntToStr(ResultCode) + ')');
+    Log('Azookey process was not running: ' + ImageName + ' (taskkill exit code ' + IntToStr(ResultCode) + ')');
   end;
 end;
 
-procedure StopAzookeyProcessesBeforeInstall();
+procedure StopAzookeyProcesses();
 begin
   StopAzookeyProcess('frontend.exe', False);
-  // Stop launcher before server so the watchdog cannot respawn it during install/update.
+  // Stop launcher before server so the watchdog cannot respawn it during install/update/uninstall.
   StopAzookeyProcess('launcher.exe', True);
   StopAzookeyProcess('azookey-server.exe', True);
   StopAzookeyProcess('ui.exe', True);
 end;
 
-<event('PrepareToInstall')>
-function Azookey_PrepareToInstall(var NeedsRestart: Boolean): String;
+function QueryStartupTaskExists(var QueryExecuted: Boolean): Boolean;
+var
+  ResultCode: Integer;
 begin
-  StopAzookeyProcessesBeforeInstall();
-  Result := '';
+  QueryExecuted := Exec(
+    ExpandConstant('{sys}\schtasks.exe'),
+    '/Query /TN "' + StartupTaskName + '"',
+    '',
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  );
+  Result := QueryExecuted and (ResultCode = 0);
+  if QueryExecuted then
+  begin
+    Log('Startup task query exit code: ' + IntToStr(ResultCode));
+  end
+  else
+  begin
+    Log('Failed to execute schtasks while querying startup task.');
+  end;
 end;
 
-function UninstallNeedRestart(): Boolean;
+function StartupTaskStorageFileExists(): Boolean;
 begin
+  Result := FileExists(ExpandConstant('{sys}\Tasks\' + StartupTaskName));
+end;
+
+function DeleteStartupTask(): Boolean;
+var
+  QueryExecuted: Boolean;
+  ResultCode: Integer;
+begin
+  Result := False;
+  if not QueryStartupTaskExists(QueryExecuted) then
+  begin
+    if QueryExecuted and (not StartupTaskStorageFileExists()) then
+    begin
+      Log('Startup task is not present; no deletion is needed.');
+      Result := True;
+    end;
+    if StartupTaskStorageFileExists() then
+    begin
+      Log('Startup task storage file exists even though schtasks query failed.');
+    end;
+    Exit;
+  end;
+
+  if Exec(
+    ExpandConstant('{sys}\schtasks.exe'),
+    '/End /TN "' + StartupTaskName + '"',
+    '',
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  ) then
+  begin
+    Log('Startup task end exit code: ' + IntToStr(ResultCode));
+  end;
+
+  if not Exec(
+    ExpandConstant('{sys}\schtasks.exe'),
+    '/Delete /TN "' + StartupTaskName + '" /F',
+    '',
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  ) then
+  begin
+    Log('Failed to execute schtasks while deleting startup task.');
+    Exit;
+  end;
+
+  if ResultCode <> 0 then
+  begin
+    Log('Failed to delete startup task. schtasks exit code: ' + IntToStr(ResultCode));
+    Exit;
+  end;
+
+  if QueryStartupTaskExists(QueryExecuted) then
+  begin
+    Log('Startup task still exists after schtasks /Delete.');
+    Exit;
+  end;
+
+  if not QueryExecuted then
+  begin
+    Exit;
+  end;
+
+  if StartupTaskStorageFileExists() then
+  begin
+    Log('Startup task storage file still exists after schtasks /Delete.');
+    Exit;
+  end;
+
+  Log('Startup task was deleted and its absence was verified.');
   Result := True;
+end;
+
+function DisableStartupTaskIfPresent(): Boolean;
+var
+  QueryExecuted: Boolean;
+  ResultCode: Integer;
+begin
+  Result := False;
+  if not QueryStartupTaskExists(QueryExecuted) then
+  begin
+    if QueryExecuted and (not StartupTaskStorageFileExists()) then
+    begin
+      Result := True;
+    end;
+    Exit;
+  end;
+
+  if not Exec(
+    ExpandConstant('{sys}\schtasks.exe'),
+    '/Change /TN "' + StartupTaskName + '" /DISABLE',
+    '',
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  ) then
+  begin
+    Log('Failed to execute schtasks while disabling startup task.');
+    Exit;
+  end;
+
+  Result := ResultCode = 0;
+  if not Result then
+  begin
+    Log('Failed to disable startup task. schtasks exit code: ' + IntToStr(ResultCode));
+  end;
+end;
+
+function CleanupStartupTaskAfterFailure(): Boolean;
+begin
+  // Make a partially-created task inert before deletion. Verified absence is
+  // the final safety condition, so deletion can still succeed if /DISABLE does not.
+  if not DisableStartupTaskIfPresent() then
+  begin
+    Log('Could not disable startup task before failure cleanup; deletion will still be attempted.');
+  end;
+  Result := DeleteStartupTask();
 end;
 
 function CmdLineContains(Param: String): Boolean;
@@ -324,45 +438,1051 @@ begin
     end;
   end;
 end;
-procedure UpdateTaskXml();
-var
-  TaskXmlPath: string;
-  TaskXmlContentAnsi: AnsiString;
-  TaskXmlContent: String;
-  Dummy: Integer;
+
+function SamePath(LeftPath: String; RightPath: String): Boolean;
 begin
-  ExtractTemporaryFile('Azookey Startup.xml'); // ファイル展開
-  TaskXmlPath := ExpandConstant('{tmp}\Azookey Startup.xml');
-
-  LoadStringFromFile(TaskXmlPath, TaskXmlContentAnsi)
-
-  TaskXmlContent := String(TaskXmlContentAnsi);
-
-  StringChange(TaskXmlContent, 'PATH_TO_VBS', ExpandConstant('{app}\launch.vbs'));
-  TaskXmlContentAnsi := AnsiString(TaskXmlContent);
-  SaveStringToFile(TaskXmlPath, TaskXmlContentAnsi, False);
-
-  ShellExec('', 'schtasks', '/Create /F /TN "Azookey Startup" /XML "' + TaskXmlPath + '"', '', SW_HIDE, ewWaitUntilTerminated, Dummy);
-  ShellExec('', 'schtasks', '/Run /TN "Azookey Startup"', '', SW_HIDE, ewWaitUntilTerminated, Dummy);
+  Result := CompareText(
+    RemoveBackslashUnlessRoot(RemoveSurroundingQuotes(LeftPath)),
+    RemoveBackslashUnlessRoot(RemoveSurroundingQuotes(RightPath))
+  ) = 0;
 end;
 
-procedure CreateVbsFile();
+function ValidatePreviousInnoUninstaller(
+  DisplayVersion: String;
+  UninstallExe: String
+): String;
 var
-  VbsFile: string;
-  VbsContent: AnsiString;
+  UninstallData: String;
+  UninstallerHash: String;
 begin
-  VbsFile := ExpandConstant('{app}\launch.vbs');
-  VbsContent :=
-    'Set objShell = CreateObject("WScript.Shell")' + #13#10 +
-    'objShell.Run "' + ExpandConstant('{app}\launcher.exe') + '", 0, False' + #13#10;
-
-  if SaveStringToFile(VbsFile, VbsContent, False) then
+  Result := '';
+  UninstallData := ChangeFileExt(UninstallExe, '.dat');
+  if not FileExists(UninstallData) then
   begin
-    Log('VBS file created: ' + VbsFile);
+    Result := '旧バージョンのアンインストールデータが見つからないため、更新を中止しました: ' + UninstallData;
+    Exit;
+  end;
+
+  try
+    UninstallerHash := Lowercase(GetSHA256OfFile(UninstallExe));
+  except
+    Result := '旧バージョンのアンインストーラーを安全に検証できないため、更新を中止しました: ' + GetExceptionMessage;
+    Exit;
+  end;
+
+  Log(
+    'Previous Inno trust metadata: version=' + DisplayVersion +
+    ', exe_sha256=' + UninstallerHash
+  );
+  if (CompareText(DisplayVersion, PreviousInnoV010Batao10Version) <> 0) or
+     (CompareText(UninstallerHash, PreviousInnoV010Batao10UninstallerSha256) <> 0) then
+  begin
+    Result := '旧バージョンのアンインストーラーが既知の正規リリースと一致しないため、自動更新を中止しました。旧バージョンを手動でアンインストールしてから再度実行してください。';
+  end;
+end;
+
+function IsSettingsBackupName(FileName: String): Boolean;
+var
+  Suffix: String;
+  I: Integer;
+begin
+  Result := False;
+  if Pos(SettingsBackupPrefix, Lowercase(FileName)) <> 1 then
+  begin
+    Exit;
+  end;
+
+  Suffix := Copy(FileName, Length(SettingsBackupPrefix) + 1, MaxInt);
+  if Length(Suffix) <> 14 then
+  begin
+    Exit;
+  end;
+
+  for I := 1 to Length(Suffix) do
+  begin
+    if (Suffix[I] < '0') or (Suffix[I] > '9') then
+    begin
+      Exit;
+    end;
+  end;
+  Result := True;
+end;
+
+function PathIsReparsePoint(Path: String; var Inspected: Boolean): Boolean;
+var
+  FindRec: TFindRec;
+begin
+  Inspected := FindFirst(RemoveBackslashUnlessRoot(Path), FindRec);
+  Result := Inspected and ((FindRec.Attributes and FILE_ATTRIBUTE_REPARSE_POINT) <> 0);
+  if Inspected then
+  begin
+    FindClose(FindRec);
+  end;
+end;
+
+procedure RestorePreservedUserData(
+  PreserveRoot: String;
+  MigrationRoot: String;
+  PreservedNames: TStringList
+);
+var
+  I: Integer;
+begin
+  for I := 0 to PreservedNames.Count - 1 do
+  begin
+    if not RenameFile(
+      AddBackslash(PreserveRoot) + PreservedNames[I],
+      AddBackslash(MigrationRoot) + PreservedNames[I]
+    ) then
+    begin
+      Log('Failed to restore preserved legacy user data: ' + PreservedNames[I]);
+    end;
+  end;
+end;
+
+function RunMigrationIcacls(Path: String; Arguments: String): Boolean;
+var
+  ResultCode: Integer;
+begin
+  ResultCode := -1;
+  Result := Exec(
+    ExpandConstant('{sys}\icacls.exe'),
+    '"' + Path + '" ' + Arguments + ' /L /Q',
+    ExpandConstant('{app}'),
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  ) and (ResultCode = 0);
+  if not Result then
+  begin
+    Log('Migration icacls failed. exit=' + IntToStr(ResultCode) + ', path=' + Path + ', arguments=' + Arguments);
+  end;
+end;
+
+function ApplyMigrationDirectoryAcl(Path: String; WritableUserSid: String): Boolean;
+var
+  Grants: String;
+begin
+  // A directory moved from AppData keeps its old owner and explicit ACEs.
+  // Reset the root against its protected Program Files parent before installing
+  // the final non-inherited ACL; merely disabling inheritance would leave
+  // user-writable explicit ACEs behind. Descendants are intentionally not
+  // reopened here: a loaded legacy DLL may be exclusively locked, while the
+  // protected root ACL is sufficient to prevent new untrusted traversal.
+  Result := RunMigrationIcacls(Path, '/setowner "*S-1-5-32-544"');
+  if not Result then
+  begin
+    Exit;
+  end;
+  Result := RunMigrationIcacls(Path, '/reset');
+  if not Result then
+  begin
+    Exit;
+  end;
+
+  Grants := '/inheritance:r /grant:r ' +
+    '"*S-1-5-18:(OI)(CI)F" "*S-1-5-32-544:(OI)(CI)F"';
+  if WritableUserSid <> '' then
+  begin
+    Grants := Grants + ' "*' + WritableUserSid + ':(OI)(CI)M"';
+  end;
+  Result := RunMigrationIcacls(Path, Grants);
+end;
+
+function IsExpectedUserSid(Value: String): Boolean;
+var
+  I: Integer;
+  Character: String;
+begin
+  Value := Trim(Value);
+  Result := (Pos('S-1-5-21-', Value) = 1) or (Pos('S-1-12-1-', Value) = 1);
+  if not Result then
+  begin
+    Exit;
+  end;
+
+  for I := 1 to Length(Value) do
+  begin
+    Character := Copy(Value, I, 1);
+    if ((Character < '0') or (Character > '9')) and
+       (Character <> 'S') and (Character <> '-') then
+    begin
+      Result := False;
+      Exit;
+    end;
+  end;
+end;
+
+function IsDecimalNonce(Value: String): Boolean;
+var
+  I: Integer;
+begin
+  Result := Value <> '';
+  if not Result then
+  begin
+    Exit;
+  end;
+  for I := 1 to Length(Value) do
+  begin
+    if (Value[I] < '0') or (Value[I] > '9') then
+    begin
+      Result := False;
+      Exit;
+    end;
+  end;
+end;
+
+procedure CleanupOwnedUpdaterDownloadStaging();
+var
+  TempRoot: String;
+  FindRec: TFindRec;
+  Candidate: String;
+  Nonce: String;
+  Inspected: Boolean;
+begin
+  TempRoot := RemoveBackslashUnlessRoot(GetEnv('TEMP'));
+  if (TempRoot = '') or PathIsReparsePoint(TempRoot, Inspected) or (not Inspected) then
+  begin
+    Log('Updater download staging cleanup skipped because TEMP is missing, inaccessible, or a reparse point.');
+    Exit;
+  end;
+
+  if FindFirst(AddBackslash(TempRoot) + UpdaterDownloadStagingPrefix + '*', FindRec) then
+  begin
+    try
+      repeat
+        Nonce := Copy(
+          FindRec.Name,
+          Length(UpdaterDownloadStagingPrefix) + 1,
+          Length(FindRec.Name)
+        );
+        if ((FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY) <> 0) and
+           ((FindRec.Attributes and FILE_ATTRIBUTE_REPARSE_POINT) = 0) and
+           IsDecimalNonce(Nonce) then
+        begin
+          Candidate := AddBackslash(TempRoot) + FindRec.Name;
+          if SamePath(Candidate, ExtractFileDir(ExpandConstant('{srcexe}'))) then
+          begin
+            Log('Updater download staging cleanup deferred for the currently running setup source: ' + Candidate);
+          end
+          else if not DelTree(Candidate, True, True, True) then
+          begin
+            Log('Updater download staging cleanup could not remove: ' + Candidate);
+          end
+          else
+          begin
+            Log('Removed updater download staging: ' + Candidate);
+          end;
+        end;
+      until not FindNext(FindRec);
+    finally
+      FindClose(FindRec);
+    end;
+  end;
+end;
+
+function ReadMigrationUserSid(
+  Timestamp: String;
+  var UserSid: String
+): Boolean;
+var
+  ScriptPath: String;
+  SidPath: String;
+  ScriptBody: String;
+  ResultCode: Integer;
+  UserSidBytes: AnsiString;
+begin
+  Result := False;
+  UserSid := '';
+  ScriptPath := ExpandConstant('{app}\.legacy-user-sid-' + Timestamp + '.ps1');
+  SidPath := ExpandConstant('{app}\.legacy-user-sid-' + Timestamp + '.txt');
+  if (Pos('"', SidPath) > 0) or
+     FileExists(ScriptPath) or FileExists(SidPath) or
+     DirExists(ScriptPath) or DirExists(SidPath) then
+  begin
+    Log('Migration user SID helper paths are unsafe or already exist.');
+    Exit;
+  end;
+
+  ScriptBody :=
+    '$ErrorActionPreference = "Stop"' + #13#10 +
+    '$sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value' + #13#10 +
+    '[System.IO.File]::WriteAllText("' + SidPath + '", $sid, ' +
+      '[System.Text.Encoding]::ASCII)' + #13#10;
+
+  try
+    if not SaveStringToFile(ScriptPath, ScriptBody, False) then
+    begin
+      Log('Failed to create protected migration user SID helper.');
+      Exit;
+    end;
+    ResultCode := -1;
+    if not Exec(
+      ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'),
+      '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "' + ScriptPath + '"',
+      ExpandConstant('{app}'),
+      SW_HIDE,
+      ewWaitUntilTerminated,
+      ResultCode
+    ) or (ResultCode <> 0) then
+    begin
+      Log('Failed to resolve migration user SID. exit=' + IntToStr(ResultCode));
+      Exit;
+    end;
+    if not LoadStringFromFile(SidPath, UserSidBytes) then
+    begin
+      Log('Migration user SID output is missing.');
+      Exit;
+    end;
+    UserSid := Trim(String(UserSidBytes));
+    if not IsExpectedUserSid(UserSid) then
+    begin
+      Log('Migration user SID is not an expected local, domain, or Entra user SID: ' + UserSid);
+      UserSid := '';
+      Exit;
+    end;
+    Result := True;
+  finally
+    DeleteFile(ScriptPath);
+    DeleteFile(SidPath);
+  end;
+end;
+
+procedure ScheduleProtectedTreeForDeletion(Root: String);
+var
+  FindRec: TFindRec;
+  ChildPath: String;
+begin
+  if FindFirst(AddBackslash(Root) + '*', FindRec) then
+  begin
+    try
+      repeat
+        if (FindRec.Name <> '.') and (FindRec.Name <> '..') then
+        begin
+          ChildPath := AddBackslash(Root) + FindRec.Name;
+          if ((FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY) <> 0) and
+             ((FindRec.Attributes and FILE_ATTRIBUTE_REPARSE_POINT) = 0) then
+          begin
+            ScheduleProtectedTreeForDeletion(ChildPath);
+          end
+          else
+          begin
+            RestartReplace(ChildPath, '');
+          end;
+        end;
+      until not FindNext(FindRec);
+    finally
+      FindClose(FindRec);
+    end;
+  end;
+  RestartReplace(Root, '');
+end;
+
+function IsRedirectionGuardEnforced(): Boolean;
+var
+  PolicyFlags: Cardinal;
+begin
+  PolicyFlags := 0;
+  try
+    Result := GetProcessMitigationPolicy(
+      GetCurrentProcess(),
+      ProcessRedirectionTrustPolicy,
+      PolicyFlags,
+      SizeOf(PolicyFlags)
+    ) and ((PolicyFlags and EnforceRedirectionTrust) <> 0);
+  except
+    Log('Failed to query RedirectionGuard process mitigation: ' + GetExceptionMessage);
+    Result := False;
+  end;
+end;
+
+function IsPreservedPreviousInnoRootEntry(Name: String; Attributes: Integer): Boolean;
+begin
+  Result := False;
+  if (Attributes and FILE_ATTRIBUTE_REPARSE_POINT) <> 0 then
+  begin
+    Exit;
+  end;
+
+  if (Attributes and FILE_ATTRIBUTE_DIRECTORY) <> 0 then
+  begin
+    Result := CompareText(Name, 'LearningMemory') = 0;
   end
   else
   begin
-    Log('Failed to create VBS file: ' + VbsFile);
+    Result := (CompareText(Name, 'settings.json') = 0) or IsSettingsBackupName(Name);
+  end;
+end;
+
+function RemovePreviousInnoPayloadInPlace(InstallLocation: String): String;
+var
+  FindRec: TFindRec;
+  ChildPath: String;
+  Inspected: Boolean;
+  QueuedForRestart: Boolean;
+begin
+  Result := '';
+  QueuedForRestart := False;
+  if not IsRedirectionGuardEnforced() then
+  begin
+    Result := 'RedirectionGuard を強制できないため、ロック中の旧バージョンを安全に更新できません。Windows を更新または再起動してから再度実行してください。';
+    Exit;
+  end;
+  if PathIsReparsePoint(InstallLocation, Inspected) or (not Inspected) then
+  begin
+    Result := '旧バージョンのインストール先を安全に検査できないため、更新を中止しました。';
+    Exit;
+  end;
+
+  if FindFirst(AddBackslash(InstallLocation) + '*', FindRec) then
+  begin
+    try
+      repeat
+        if (FindRec.Name <> '.') and (FindRec.Name <> '..') and
+           (not IsPreservedPreviousInnoRootEntry(FindRec.Name, FindRec.Attributes)) then
+        begin
+          ChildPath := AddBackslash(InstallLocation) + FindRec.Name;
+          if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY) <> 0 then
+          begin
+            if not DelTree(ChildPath, True, True, True) then
+            begin
+              try
+                if (FindRec.Attributes and FILE_ATTRIBUTE_REPARSE_POINT) <> 0 then
+                begin
+                  RestartReplace(ChildPath, '');
+                end
+                else
+                begin
+                  ScheduleProtectedTreeForDeletion(ChildPath);
+                end;
+                QueuedForRestart := True;
+              except
+                Result := '旧バージョンのロック中ディレクトリを再起動後に安全に削除する設定ができません: ' + GetExceptionMessage;
+                Exit;
+              end;
+            end;
+          end
+          else if not DelTree(ChildPath, False, True, False) then
+          begin
+            try
+              RestartReplace(ChildPath, '');
+              QueuedForRestart := True;
+            except
+              Result := '旧バージョンのロック中ファイルを再起動後に安全に削除する設定ができません: ' + GetExceptionMessage;
+              Exit;
+            end;
+          end;
+        end;
+      until not FindNext(FindRec);
+    finally
+      FindClose(FindRec);
+    end;
+  end;
+
+  if QueuedForRestart then
+  begin
+    MigrationNeedsRestart := True;
+    Log('Locked previous payload was queued for deletion in place with RedirectionGuard enforced.');
+  end;
+  Log('Previous Inno payload was cleaned in place while preserving settings and learning data.');
+end;
+
+function PreservePreviousInnoUserData(
+  InstallLocation: String;
+  PreserveRoot: String;
+  PreservedNames: TStringList
+): String;
+var
+  FindRec: TFindRec;
+  NamesToPreserve: TStringList;
+  SourcePath: String;
+  DestinationPath: String;
+  I: Integer;
+begin
+  Result := '';
+  NamesToPreserve := TStringList.Create;
+  try
+    if FileExists(AddBackslash(InstallLocation) + 'settings.json') then
+    begin
+      NamesToPreserve.Add('settings.json');
+    end;
+    if DirExists(AddBackslash(InstallLocation) + 'LearningMemory') then
+    begin
+      NamesToPreserve.Add('LearningMemory');
+    end;
+
+    if FindFirst(AddBackslash(InstallLocation) + 'settings.json.broken-*', FindRec) then
+    begin
+      try
+        repeat
+          if ((FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY) = 0) and
+             IsSettingsBackupName(FindRec.Name) then
+          begin
+            NamesToPreserve.Add(FindRec.Name);
+          end;
+        until not FindNext(FindRec);
+      finally
+        FindClose(FindRec);
+      end;
+    end;
+
+    if not ForceDirectories(PreserveRoot) then
+    begin
+      Result := '旧バージョンの設定・学習データの一時保存先を作成できないため、更新を中止しました。';
+      Exit;
+    end;
+
+    for I := 0 to NamesToPreserve.Count - 1 do
+    begin
+      SourcePath := AddBackslash(InstallLocation) + NamesToPreserve[I];
+      DestinationPath := AddBackslash(PreserveRoot) + NamesToPreserve[I];
+      if not RenameFile(SourcePath, DestinationPath) then
+      begin
+        Result := '旧バージョンの設定・学習データを安全に保持できないため、更新を中止しました: ' + NamesToPreserve[I];
+        RestorePreservedUserData(PreserveRoot, InstallLocation, PreservedNames);
+        Exit;
+      end;
+      PreservedNames.Add(NamesToPreserve[I]);
+    end;
+  finally
+    NamesToPreserve.Free;
+  end;
+end;
+
+function RemovePreviousInnoPayload(InstallLocation: String): String;
+var
+  MigrationRoot: String;
+  PreserveRoot: String;
+  PreservedNames: TStringList;
+  Inspected: Boolean;
+  Timestamp: String;
+  UserSid: String;
+begin
+  Result := '';
+  if PathIsReparsePoint(InstallLocation, Inspected) or (not Inspected) then
+  begin
+    Result := '旧バージョンのインストール先を安全に検査できないため、更新を中止しました。';
+    Log('Previous Inno install root is missing, inaccessible, or a reparse point: ' + InstallLocation);
+    Exit;
+  end;
+
+  if not ForceDirectories(ExpandConstant('{app}')) then
+  begin
+    Result := '保護された移行先を作成できないため、更新を中止しました。';
+    Exit;
+  end;
+  if PathIsReparsePoint(ExpandConstant('{app}'), Inspected) or (not Inspected) then
+  begin
+    Result := '保護された移行先を安全に検査できないため、更新を中止しました。';
+    Exit;
+  end;
+
+  Timestamp := GetDateTimeString('yyyymmddhhnnsszzz', #0, #0);
+  MigrationRoot := ExpandConstant('{app}\.legacy-migration-' + Timestamp);
+  PreserveRoot := ExpandConstant('{app}\.legacy-preserve-' + Timestamp);
+  if FileExists(MigrationRoot) or DirExists(MigrationRoot) or
+     FileExists(PreserveRoot) or DirExists(PreserveRoot) then
+  begin
+    Result := '保護された移行用の一時パスが既に存在するため、更新を中止しました。';
+    Exit;
+  end;
+
+  // Move the directory entry itself into Program Files before any privileged
+  // mutation. If the user races the initial inspection with a junction swap,
+  // RenameFile moves the junction object; the post-move reparse check rejects it.
+  if not RenameFile(InstallLocation, MigrationRoot) then
+  begin
+    Log('Previous Inno root could not be moved atomically; using the RedirectionGuard-protected locked-file fallback.');
+    Result := RemovePreviousInnoPayloadInPlace(InstallLocation);
+    Exit;
+  end;
+  if PathIsReparsePoint(MigrationRoot, Inspected) or (not Inspected) then
+  begin
+    if not RenameFile(MigrationRoot, InstallLocation) then
+    begin
+      RemoveDir(MigrationRoot);
+    end;
+    Result := '旧バージョンのインストール先が移行中に reparse point へ変更されたため、更新を中止しました。';
+    Exit;
+  end;
+  if not ReadMigrationUserSid(Timestamp, UserSid) then
+  begin
+    if not RenameFile(MigrationRoot, InstallLocation) then
+    begin
+      Log('Failed to restore previous install root after user SID validation failed.');
+    end;
+    Result := '旧バージョンの設定ユーザーを安全に確認できないため、更新を中止しました。';
+    Exit;
+  end;
+  if not ApplyMigrationDirectoryAcl(MigrationRoot, '') then
+  begin
+    ApplyMigrationDirectoryAcl(MigrationRoot, UserSid);
+    RenameFile(MigrationRoot, InstallLocation);
+    Result := '旧バージョンの移行元を保護できないため、更新を中止しました。';
+    Exit;
+  end;
+
+  if not ForceDirectories(PreserveRoot) or
+     (not ApplyMigrationDirectoryAcl(PreserveRoot, '')) then
+  begin
+    DelTree(PreserveRoot, True, True, True);
+    ApplyMigrationDirectoryAcl(MigrationRoot, UserSid);
+    RenameFile(MigrationRoot, InstallLocation);
+    Result := '旧バージョンの設定・学習データの保護領域を作成できないため、更新を中止しました。';
+    Exit;
+  end;
+
+  PreservedNames := TStringList.Create;
+  try
+    Result := PreservePreviousInnoUserData(
+      MigrationRoot,
+      PreserveRoot,
+      PreservedNames
+    );
+    if Result <> '' then
+    begin
+      RestorePreservedUserData(PreserveRoot, MigrationRoot, PreservedNames);
+      RemoveDir(PreserveRoot);
+      ApplyMigrationDirectoryAcl(MigrationRoot, UserSid);
+      RenameFile(MigrationRoot, InstallLocation);
+      Exit;
+    end;
+
+    // Restore the allowlisted data by atomically moving one directory entry
+    // back to AppData. Never write through a user-replaceable destination path.
+    // The ACL is relaxed while the directory is still under the protected
+    // parent; only the user's own preserved data can be modified at this point.
+    if not ApplyMigrationDirectoryAcl(PreserveRoot, UserSid) then
+    begin
+      RestorePreservedUserData(PreserveRoot, MigrationRoot, PreservedNames);
+      RemoveDir(PreserveRoot);
+      ApplyMigrationDirectoryAcl(MigrationRoot, UserSid);
+      RenameFile(MigrationRoot, InstallLocation);
+      Result := '保持した旧バージョンの設定・学習データのアクセス権を復元できませんでした。一時保存先: ' + PreserveRoot;
+      Exit;
+    end;
+    if not RenameFile(PreserveRoot, InstallLocation) then
+    begin
+      ApplyMigrationDirectoryAcl(PreserveRoot, '');
+      RestorePreservedUserData(PreserveRoot, MigrationRoot, PreservedNames);
+      RemoveDir(PreserveRoot);
+      ApplyMigrationDirectoryAcl(MigrationRoot, UserSid);
+      RenameFile(MigrationRoot, InstallLocation);
+      Result := '保持した旧バージョンの設定・学習データを安全に復元できませんでした。一時保存先: ' + PreserveRoot;
+      Exit;
+    end;
+
+    // Inno's DelTree removes reparse points without following them. Moving the
+    // explicit user-data allowlist out first lets us remove every old payload,
+    // including the machine-specific uninstaller .dat, without executing it.
+    if not DelTree(MigrationRoot, True, True, True) then
+    begin
+      try
+        ScheduleProtectedTreeForDeletion(MigrationRoot);
+        MigrationNeedsRestart := True;
+        Log('Locked previous payload was queued for deletion from protected Program Files staging.');
+      except
+        Result := '旧バージョンのロック中ファイルを再起動後に安全に削除する設定ができないため、更新を中止しました: ' + GetExceptionMessage;
+        Exit;
+      end;
+    end;
+  finally
+    PreservedNames.Free;
+  end;
+end;
+
+<event('InitializeWizard')>
+procedure Azookey_InitializeWizard();
+begin
+  // DisableDirPage does not make /DIR harmless by itself. Always overwrite the
+  // wizard value so silent installs and updater launches use the protected path.
+  WizardForm.DirEdit.Text := ExpandConstant('{autopf}\{#MyAppName}');
+end;
+
+function MigratePreviousInnoFromRoot(
+  RootKey: Integer;
+  RootName: String;
+  var Found: Boolean
+): String;
+var
+  InstallLocation: String;
+  DisplayVersion: String;
+  UninstallString: String;
+  UninstallExe: String;
+begin
+  Result := '';
+  Found := RegKeyExists(RootKey, '{#MyInnoUninstallKey}');
+  if not Found then
+  begin
+    Exit;
+  end;
+
+  if not RegQueryStringValue(RootKey, '{#MyInnoUninstallKey}', 'InstallLocation', InstallLocation) then
+  begin
+    Result := '旧バージョンのインストール先情報が壊れているため、更新を続行できません。旧バージョンを手動でアンインストールしてから再度実行してください。';
+    Log('Previous Inno InstallLocation is missing under ' + RootName + '.');
+    Exit;
+  end;
+
+  InstallLocation := RemoveSurroundingQuotes(InstallLocation);
+  if InstallLocation = '' then
+  begin
+    Result := '旧バージョンのインストール先情報が空のため、更新を続行できません。旧バージョンを手動でアンインストールしてから再度実行してください。';
+    Log('Previous Inno InstallLocation is empty under ' + RootName + '.');
+    Exit;
+  end;
+
+  if SamePath(InstallLocation, ExpandConstant('{app}')) then
+  begin
+    Log('Previous Inno install already uses the protected install directory: ' + InstallLocation);
+    Exit;
+  end;
+
+  if not SamePath(InstallLocation, ExpandConstant('{userappdata}\{#MyAppName}')) then
+  begin
+    Result := '旧バージョンが標準外の場所にインストールされているため、自動更新を中止しました。旧バージョンを手動でアンインストールしてから再度実行してください: ' + InstallLocation;
+    Log('Previous Inno install uses an unexpected unprotected directory: ' + InstallLocation);
+    Exit;
+  end;
+
+  if not RegQueryStringValue(RootKey, '{#MyInnoUninstallKey}', 'UninstallString', UninstallString) then
+  begin
+    Result := '旧バージョンのアンインストール情報が壊れているため、更新を続行できません。旧バージョンを手動でアンインストールしてから再度実行してください。';
+    Log('Previous Inno UninstallString is missing under ' + RootName + '.');
+    Exit;
+  end;
+
+  if not RegQueryStringValue(RootKey, '{#MyInnoUninstallKey}', 'DisplayVersion', DisplayVersion) then
+  begin
+    Result := '旧バージョンのバージョン情報が壊れているため、更新を続行できません。旧バージョンを手動でアンインストールしてから再度実行してください。';
+    Log('Previous Inno DisplayVersion is missing under ' + RootName + '.');
+    Exit;
+  end;
+
+  UninstallExe := ExtractExecutablePath(UninstallString);
+  if (UninstallExe = '') or (not FileExists(UninstallExe)) then
+  begin
+    Result := '旧バージョンのアンインストーラーが見つからないため、更新を続行できません: ' + UninstallString;
+    Log('Previous Inno uninstaller was registered but not found under ' + RootName + ': ' + UninstallString);
+    Exit;
+  end;
+
+  if not SamePath(ExtractFileDir(UninstallExe), InstallLocation) then
+  begin
+    Result := '旧バージョンのアンインストーラーがインストール先の外を指しているため、更新を中止しました: ' + UninstallExe;
+    Log('Previous Inno uninstaller is outside InstallLocation: ' + UninstallExe);
+    Exit;
+  end;
+
+  if (Pos('unins', Lowercase(ExtractFileName(UninstallExe))) <> 1) or
+     (CompareText(ExtractFileExt(UninstallExe), '.exe') <> 0) then
+  begin
+    Result := '旧バージョンのアンインストーラー名が不正なため、更新を中止しました: ' + UninstallExe;
+    Log('Previous Inno uninstaller filename is unexpected: ' + UninstallExe);
+    Exit;
+  end;
+
+  Result := ValidatePreviousInnoUninstaller(DisplayVersion, UninstallExe);
+  if Result <> '' then
+  begin
+    Log('Previous Inno uninstaller trust validation failed: ' + Result);
+    Exit;
+  end;
+
+  // Establish that the stale uninstall metadata can be removed before making
+  // any destructive payload change. If this operation fails, the old files
+  // and metadata remain available for a safe retry.
+  if CmdLineContains(LegacyRegistryDeleteFailureTestParam) then
+  begin
+    Log('Injecting previous Inno uninstall registry deletion failure for installer verification.');
+    Result := '旧バージョンのアンインストール情報を削除できないため、更新を中止しました。';
+    Exit;
+  end;
+  if not RegDeleteKeyIncludingSubkeys(RootKey, '{#MyInnoUninstallKey}') then
+  begin
+    Result := '旧バージョンのアンインストール情報を削除できないため、更新を中止しました。';
+    Exit;
+  end;
+  Log('Previous Inno uninstall metadata was deleted before payload migration.');
+
+  Log('Migrating previous Inno install without executing its user-writable uninstall data: ' + InstallLocation);
+  Result := RemovePreviousInnoPayload(InstallLocation);
+  if Result <> '' then
+  begin
+    Log('Previous Inno controlled payload migration failed: ' + Result);
+    if not (
+      RegWriteStringValue(RootKey, '{#MyInnoUninstallKey}', 'InstallLocation', InstallLocation) and
+      RegWriteStringValue(RootKey, '{#MyInnoUninstallKey}', 'DisplayVersion', DisplayVersion) and
+      RegWriteStringValue(RootKey, '{#MyInnoUninstallKey}', 'UninstallString', UninstallString)
+    ) then
+    begin
+      Log('Failed to restore retry metadata after previous Inno payload migration failure.');
+      Result := Result + ' 旧バージョンの再試行情報も復元できませんでした。';
+    end
+    else
+    begin
+      Log('Previous Inno retry metadata was restored after payload migration failure.');
+    end;
+    Exit;
+  end;
+
+  // v0.1.0-batao.10 always requested a reboot when uninstalled. Preserve that
+  // upgrade contract even though its user-writable uninstaller is not run.
+  MigrationNeedsRestart := True;
+  Log('Previous Inno payload migration completed and requested restart (3010).');
+end;
+
+function MigratePreviousInnoInstall(): String;
+var
+  Found: Boolean;
+begin
+  Result := MigratePreviousInnoFromRoot(HKLM64, 'HKLM64', Found);
+  if Found then
+  begin
+    Exit;
+  end;
+
+  Result := MigratePreviousInnoFromRoot(HKLM32, 'HKLM32', Found);
+  if Found then
+  begin
+    Exit;
+  end;
+
+  Result := MigratePreviousInnoFromRoot(HKCU, 'HKCU', Found);
+end;
+
+<event('PrepareToInstall')>
+function Azookey_PrepareToInstall(var NeedsRestart: Boolean): String;
+begin
+  CleanupOwnedUpdaterDownloadStaging();
+  StopAzookeyProcesses();
+  if not DeleteStartupTask() then
+  begin
+    Result := '既存の Azookey 起動タスクを安全に削除できないため、インストールを中止しました。';
+    Exit;
+  end;
+
+  if not SamePath(ExpandConstant('{app}'), ExpandConstant('{autopf}\{#MyAppName}')) then
+  begin
+    Result := '安全でないインストール先が指定されたため、インストールを中止しました。Azookey は Program Files にのみインストールできます。';
+    Log('Rejected non-protected install directory: ' + ExpandConstant('{app}'));
+    Exit;
+  end;
+
+  Result := MigratePreviousInnoInstall();
+end;
+
+<event('NeedRestart')>
+function Azookey_NeedRestart(): Boolean;
+begin
+  Result := MigrationNeedsRestart;
+end;
+
+function UninstallNeedRestart(): Boolean;
+begin
+  Result := True;
+end;
+
+function XmlEscape(Value: String): String;
+begin
+  Result := Value;
+  StringChangeEx(Result, '&', '&amp;', True);
+  StringChangeEx(Result, '<', '&lt;', True);
+  StringChangeEx(Result, '>', '&gt;', True);
+  StringChangeEx(Result, '"', '&quot;', True);
+  StringChangeEx(Result, '''', '&apos;', True);
+end;
+
+function RenderStartupTaskXml(TaskXmlPath: String): Boolean;
+var
+  Lines: TArrayOfString;
+  I: Integer;
+  LauncherReplacementCount: Integer;
+  WorkingDirectoryReplacementCount: Integer;
+begin
+  Result := False;
+  if not LoadStringsFromFile(TaskXmlPath, Lines) then
+  begin
+    Log('Failed to load startup task XML template: ' + TaskXmlPath);
+    Exit;
+  end;
+
+  LauncherReplacementCount := 0;
+  WorkingDirectoryReplacementCount := 0;
+  for I := 0 to GetArrayLength(Lines) - 1 do
+  begin
+    LauncherReplacementCount := LauncherReplacementCount + StringChangeEx(
+      Lines[I],
+      'PATH_TO_LAUNCHER',
+      XmlEscape(ExpandConstant('{app}\launcher.exe')),
+      True
+    );
+    WorkingDirectoryReplacementCount := WorkingDirectoryReplacementCount + StringChangeEx(
+      Lines[I],
+      'PATH_TO_WORKING_DIRECTORY',
+      XmlEscape(ExpandConstant('{app}')),
+      True
+    );
+  end;
+
+  if (LauncherReplacementCount <> 1) or (WorkingDirectoryReplacementCount <> 1) then
+  begin
+    Log(
+      'Startup task XML placeholder count is invalid. launcher=' +
+      IntToStr(LauncherReplacementCount) + ', workingDirectory=' +
+      IntToStr(WorkingDirectoryReplacementCount)
+    );
+    Exit;
+  end;
+
+  if not SaveStringsToUTF8FileWithoutBOM(TaskXmlPath, Lines, False) then
+  begin
+    Log('Failed to save UTF-8 startup task XML: ' + TaskXmlPath);
+    Exit;
+  end;
+
+  Result := True;
+end;
+
+procedure GrantAppContainerReadExecute(FilePath: String);
+var
+  ResultCode: Integer;
+begin
+  if not Exec(
+    ExpandConstant('{sys}\icacls.exe'),
+    '"' + FilePath + '" /grant "*S-1-15-2-1:(RX)"',
+    ExpandConstant('{app}'),
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  ) then
+  begin
+    MigrationNeedsRestart := False;
+    SetupFailureExitCode := PostInstallFailureExitCode;
+    RaiseException('AppContainer 用の読み取り権限を設定できませんでした: ' + FilePath);
+  end;
+
+  if ResultCode <> 0 then
+  begin
+    MigrationNeedsRestart := False;
+    SetupFailureExitCode := PostInstallFailureExitCode;
+    RaiseException(
+      'AppContainer 用の読み取り権限設定に失敗しました。終了コード: ' +
+      IntToStr(ResultCode) + ' (' + FilePath + ')'
+    );
+  end;
+end;
+
+procedure ConfigureStartupTask();
+var
+  TaskXmlPath: String;
+  CreateParameters: String;
+  RunParameters: String;
+  ResultCode: Integer;
+begin
+  TaskXmlPath := ExpandConstant('{app}\.azookey-startup-task.xml');
+  ResultCode := -1;
+  if not RenderStartupTaskXml(TaskXmlPath) then
+  begin
+    DeleteFile(TaskXmlPath);
+    if not CleanupStartupTaskAfterFailure() then
+    begin
+      MigrationNeedsRestart := False;
+      SetupFailureExitCode := PostInstallFailureExitCode;
+      RaiseException(
+        '起動タスク定義の生成に失敗し、起動タスクの安全な後始末にも失敗しました。インストーラーのログを確認してください。'
+      );
+    end;
+    MigrationNeedsRestart := False;
+    SetupFailureExitCode := PostInstallFailureExitCode;
+    RaiseException('Azookey 起動タスクの定義ファイルを安全に生成できませんでした。');
+  end;
+
+  CreateParameters := '/Create /F /TN "' + StartupTaskName + '" /XML "' + TaskXmlPath + '"';
+  if CmdLineContains(TaskCreateFailureTestParam) then
+  begin
+    Log('Injecting startup task creation failure for installer verification.');
+    CreateParameters := CreateParameters + ' /AZOOKEY_INVALID_PARAMETER';
+  end;
+
+  if (not Exec(
+    ExpandConstant('{sys}\schtasks.exe'),
+    CreateParameters,
+    ExpandConstant('{app}'),
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  )) or (ResultCode <> 0) then
+  begin
+    Log('Startup task creation failed. schtasks exit code: ' + IntToStr(ResultCode));
+    DeleteFile(TaskXmlPath);
+    if not CleanupStartupTaskAfterFailure() then
+    begin
+      MigrationNeedsRestart := False;
+      SetupFailureExitCode := PostInstallFailureExitCode;
+      RaiseException(
+        '起動タスクの作成に失敗し、部分的な起動タスクの安全な後始末にも失敗しました。インストーラーのログを確認してください。'
+      );
+    end;
+    MigrationNeedsRestart := False;
+    SetupFailureExitCode := PostInstallFailureExitCode;
+    RaiseException(
+      'Azookey 起動タスクの作成に失敗しました。終了コード: ' + IntToStr(ResultCode)
+    );
+  end;
+
+  RunParameters := '/Run /TN "' + StartupTaskName + '"';
+  if CmdLineContains(TaskRunFailureTestParam) then
+  begin
+    Log('Injecting startup task run failure after successful creation for installer verification.');
+    RunParameters := RunParameters + ' /AZOOKEY_INVALID_PARAMETER';
+  end;
+
+  if (not Exec(
+    ExpandConstant('{sys}\schtasks.exe'),
+    RunParameters,
+    ExpandConstant('{app}'),
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  )) or (ResultCode <> 0) then
+  begin
+    Log('Startup task run failed. schtasks exit code: ' + IntToStr(ResultCode));
+    DeleteFile(TaskXmlPath);
+    if not CleanupStartupTaskAfterFailure() then
+    begin
+      MigrationNeedsRestart := False;
+      SetupFailureExitCode := PostInstallFailureExitCode;
+      RaiseException(
+        '起動タスクの開始に失敗し、起動タスクの安全な後始末にも失敗しました。インストーラーのログを確認してください。'
+      );
+    end;
+    MigrationNeedsRestart := False;
+    SetupFailureExitCode := PostInstallFailureExitCode;
+    RaiseException(
+      'Azookey 起動タスクを開始できませんでした。終了コード: ' + IntToStr(ResultCode)
+    );
+  end;
+
+  DeleteFile(TaskXmlPath);
+  Log('Startup task was created and started successfully.');
+end;
+
+procedure ConfigureInstalledPayload();
+begin
+  GrantAppContainerReadExecute(ExpandConstant('{app}\azookey.dll'));
+  GrantAppContainerReadExecute(ExpandConstant('{app}\azookey32.dll'));
+  ConfigureStartupTask();
+end;
+
+procedure DeleteStartupTaskBeforeUninstall();
+begin
+  StopAzookeyProcesses();
+  if not DeleteStartupTask() then
+  begin
+    RaiseException(
+      'Azookey 起動タスクを削除できないため、ファイルを残したままアンインストールを中止しました。'
+    );
   end;
 end;
 
@@ -386,9 +1506,16 @@ procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep = ssPostInstall then
   begin
+    ConfigureInstalledPayload();
     WriteInstallMetadata();
-    CreateVbsFile();
-    UpdateTaskXml();
+  end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usUninstall then
+  begin
+    DeleteStartupTaskBeforeUninstall();
   end;
 end;
 

--- a/scripts/vm_stage_for_manual_test.sh
+++ b/scripts/vm_stage_for_manual_test.sh
@@ -16,6 +16,16 @@ UNINSTALL_AFTER_INSTALL="${UNINSTALL_AFTER_INSTALL:-0}"
 VERIFY_LEGACY_NSIS_MIGRATION="${VERIFY_LEGACY_NSIS_MIGRATION:-0}"
 VERIFY_MISSING_LEGACY_NSIS_UNINSTALLER="${VERIFY_MISSING_LEGACY_NSIS_UNINSTALLER:-0}"
 VERIFY_LOCKED_FILE_UPGRADE="${VERIFY_LOCKED_FILE_UPGRADE:-0}"
+VERIFY_PREVIOUS_INNO_MIGRATION="${VERIFY_PREVIOUS_INNO_MIGRATION:-0}"
+VERIFY_LOCKED_PREVIOUS_INNO_MIGRATION="${VERIFY_LOCKED_PREVIOUS_INNO_MIGRATION:-0}"
+PREVIOUS_INNO_INSTALLER="${PREVIOUS_INNO_INSTALLER:-}"
+VERIFY_MISSING_PREVIOUS_INNO_UNINSTALLER="${VERIFY_MISSING_PREVIOUS_INNO_UNINSTALLER:-0}"
+VERIFY_TAMPERED_PREVIOUS_INNO_UNINSTALLER="${VERIFY_TAMPERED_PREVIOUS_INNO_UNINSTALLER:-0}"
+VERIFY_TAMPERED_PREVIOUS_INNO_DATA="${VERIFY_TAMPERED_PREVIOUS_INNO_DATA:-0}"
+VERIFY_PREVIOUS_INNO_REGISTRY_DELETE_FAILURE="${VERIFY_PREVIOUS_INNO_REGISTRY_DELETE_FAILURE:-0}"
+VERIFY_SAFE_REINSTALL="${VERIFY_SAFE_REINSTALL:-0}"
+VERIFY_TASK_CREATION_FAILURE="${VERIFY_TASK_CREATION_FAILURE:-0}"
+VERIFY_TASK_RUN_FAILURE="${VERIFY_TASK_RUN_FAILURE:-0}"
 
 if [[ -z "$VBOX_MANAGE" ]]; then
   if command -v VBoxManage >/dev/null 2>&1; then
@@ -45,11 +55,13 @@ REMOTE_INSTALLER_WIN="$REMOTE_TMP_WIN\\azookey-setup-under-test.exe"
 REMOTE_PS_WIN="$REMOTE_TMP_WIN\\azookey-install-under-test.ps1"
 REMOTE_INSTALL_LOG_WIN="$REMOTE_TMP_WIN\\azookey-install-under-test.log"
 REMOTE_UNINSTALL_LOG_WIN="$REMOTE_TMP_WIN\\azookey-uninstall-under-test.log"
+REMOTE_PREVIOUS_INSTALLER_WIN="$REMOTE_TMP_WIN\\azookey-previous-inno-setup.exe"
 
 REMOTE_INSTALLER_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-setup-under-test.exe"
 REMOTE_PS_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-install-under-test.ps1"
 REMOTE_INSTALL_LOG_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-install-under-test.log"
 REMOTE_UNINSTALL_LOG_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-uninstall-under-test.log"
+REMOTE_PREVIOUS_INSTALLER_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-previous-inno-setup.exe"
 
 SESSION_KNOWN_HOSTS="$(mktemp /tmp/vm-stage-known-hosts.XXXXXX)"
 TMP_REMOTE_PS=""
@@ -213,6 +225,10 @@ ensure_preconditions() {
     log "スナップショットが見つかりません: $SNAPSHOT_NAME"
     exit 1
   fi
+  if { [[ "${VERIFY_PREVIOUS_INNO_MIGRATION,,}" =~ ^(1|true|yes|on)$ ]] || [[ "${VERIFY_LOCKED_PREVIOUS_INNO_MIGRATION,,}" =~ ^(1|true|yes|on)$ ]] || [[ "${VERIFY_MISSING_PREVIOUS_INNO_UNINSTALLER,,}" =~ ^(1|true|yes|on)$ ]] || [[ "${VERIFY_TAMPERED_PREVIOUS_INNO_UNINSTALLER,,}" =~ ^(1|true|yes|on)$ ]] || [[ "${VERIFY_TAMPERED_PREVIOUS_INNO_DATA,,}" =~ ^(1|true|yes|on)$ ]] || [[ "${VERIFY_PREVIOUS_INNO_REGISTRY_DELETE_FAILURE,,}" =~ ^(1|true|yes|on)$ ]]; } && [[ ! -f "$PREVIOUS_INNO_INSTALLER" ]]; then
+    log "旧 Inno installer が見つかりません。PREVIOUS_INNO_INSTALLER を設定してください: ${PREVIOUS_INNO_INSTALLER:-<unset>}"
+    exit 1
+  fi
 }
 
 restore_snapshot_and_boot() {
@@ -249,6 +265,16 @@ param(
   [switch]$VerifyLegacyNsisMigration,
   [switch]$VerifyMissingLegacyNsisUninstaller,
   [switch]$VerifyLockedFileUpgrade,
+  [switch]$VerifyPreviousInnoMigration,
+  [switch]$VerifyLockedPreviousInnoMigration,
+  [string]$PreviousInnoInstallerPath,
+  [switch]$VerifyMissingPreviousInnoUninstaller,
+  [switch]$VerifyTamperedPreviousInnoUninstaller,
+  [switch]$VerifyTamperedPreviousInnoData,
+  [switch]$VerifyPreviousInnoRegistryDeleteFailure,
+  [switch]$VerifySafeReinstall,
+  [switch]$VerifyTaskCreationFailure,
+  [switch]$VerifyTaskRunFailure,
   [switch]$UninstallAfterInstall
 )
 
@@ -371,36 +397,26 @@ public static class Program {
   Write-Host "created fake legacy NSIS install: $legacyRoot"
 }
 
-function Assert-FakeLegacyNsisMigrated {
+function Assert-FakeLegacyNsisInstallRejectedSafely {
   $legacyRoot = Join-Path $env:LOCALAPPDATA "Azookey"
   $legacyUninstallKey = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Azookey"
   $legacyStateKey = "HKCU:\SOFTWARE\batao9\Azookey"
   $sentinelPath = Join-Path $env:TEMP "azookey-legacy-nsis-uninstalled.txt"
 
-  $deadline = (Get-Date).AddSeconds(30)
-  while ((Test-Path -LiteralPath $legacyRoot) -and ((Get-Date) -lt $deadline)) {
-    Start-Sleep -Seconds 1
+  if (!(Test-Path -LiteralPath $legacyRoot)) {
+    throw "Untrusted legacy NSIS install directory was removed."
+  }
+  if (!(Test-Path -LiteralPath $legacyUninstallKey)) {
+    throw "Untrusted legacy NSIS uninstall key was removed."
+  }
+  if (!(Test-Path -LiteralPath $legacyStateKey)) {
+    throw "Untrusted legacy NSIS state key was removed."
+  }
+  if (Test-Path -LiteralPath $sentinelPath) {
+    throw "Untrusted legacy NSIS uninstaller was executed."
   }
 
-  if (Test-Path -LiteralPath $legacyRoot) {
-    throw "Legacy NSIS install directory remains after migration: $legacyRoot"
-  }
-  if (Test-Path -LiteralPath $legacyUninstallKey) {
-    throw "Legacy NSIS uninstall key remains after migration: $legacyUninstallKey"
-  }
-  if (Test-Path -LiteralPath $legacyStateKey) {
-    throw "Legacy NSIS state key remains after migration: $legacyStateKey"
-  }
-  if (!(Test-Path -LiteralPath $sentinelPath)) {
-    throw "Legacy NSIS uninstaller was not executed."
-  }
-
-  $sentinel = Get-Content -LiteralPath $sentinelPath -Raw
-  if ($sentinel -notmatch "(^|\s)/S(\s|$)") {
-    throw "Legacy NSIS uninstaller was not invoked silently: $sentinel"
-  }
-
-  Write-Host "legacy NSIS install migrated before new install"
+  Write-Host "untrusted legacy NSIS install was rejected without executing user-writable code"
 }
 
 function Install-BrokenLegacyNsisInstall {
@@ -441,17 +457,155 @@ function Assert-BrokenLegacyNsisInstallPreserved {
   Write-Host "broken legacy NSIS install preserved after migration failure"
 }
 
+function Install-PreviousInnoVersion {
+  param(
+    [Parameter(Mandatory = $true)][string]$PreviousInstallerPath,
+    [Parameter(Mandatory = $true)][int]$TimeoutSec
+  )
+
+  if (!(Test-Path -LiteralPath $PreviousInstallerPath)) {
+    throw "Previous Inno installer not found: $PreviousInstallerPath"
+  }
+
+  $previousLogPath = Join-Path $env:TEMP "azookey-previous-inno-install.log"
+  $previousProc = Start-Process -FilePath $PreviousInstallerPath -ArgumentList @(
+    "/SP-",
+    "/VERYSILENT",
+    "/SUPPRESSMSGBOXES",
+    "/NORESTART",
+    "/RESTARTEXITCODE=3010",
+    "/LOG=$previousLogPath"
+  ) -PassThru
+  if (-not $previousProc.WaitForExit($TimeoutSec * 1000)) {
+    Stop-ProcessTree -RootPid $previousProc.Id
+    throw "Previous Inno installer timed out."
+  }
+  if (($previousProc.ExitCode -ne 0) -and ($previousProc.ExitCode -ne 3010)) {
+    throw "Previous Inno installer failed. ExitCode=$($previousProc.ExitCode)"
+  }
+
+  $entries = @(Get-AzookeyUninstallEntries)
+  if ($entries.Count -ne 1) {
+    throw "Expected one previous Inno uninstall entry, found $($entries.Count)."
+  }
+  $legacyInstallLocation = Normalize-RegistryPath -Path $entries[0].InstallLocation
+  $expectedLegacyLocation = Join-Path $env:APPDATA "Azookey"
+  if (![string]::Equals($legacyInstallLocation, $expectedLegacyLocation, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Previous Inno install did not use the expected APPDATA location: $legacyInstallLocation"
+  }
+
+  $legacyTask = Get-ScheduledTask -TaskName "Azookey Startup" -ErrorAction Stop
+  $legacyAction = "$($legacyTask.Actions[0].Execute) $($legacyTask.Actions[0].Arguments)".ToLowerInvariant()
+  if (!$legacyAction.Contains("wscript") -or !$legacyAction.Contains(".vbs")) {
+    throw "Previous Inno task does not reproduce the legacy VBS action: $legacyAction"
+  }
+
+  $learningRoot = Join-Path $legacyInstallLocation "LearningMemory"
+  New-Item -ItemType Directory -Force -Path $learningRoot | Out-Null
+  $settingsPath = Join-Path $legacyInstallLocation "settings.json"
+  $settingsSentinel = '{"version":"0.1.2","zenzai":{"enable":false,"profile":"","backend":"cpu"},"general":{"punctuation_commit":true}}'
+  [System.IO.File]::WriteAllText($settingsPath, $settingsSentinel, [System.Text.UTF8Encoding]::new($false))
+  Set-Content -LiteralPath (Join-Path $legacyInstallLocation "settings.json.broken-20260720123456") -Encoding UTF8 -Value "settings backup sentinel"
+  Set-Content -LiteralPath (Join-Path $learningRoot "migration-sentinel.txt") -Encoding UTF8 -Value "learning preserved"
+
+  Write-Host "installed previous Inno version and created migration sentinels"
+}
+
+function Assert-PreviousInnoMigrated {
+  param(
+    [Parameter(Mandatory = $true)][string]$InstallLogPath,
+    [switch]$AllowScheduledLegacyDll
+  )
+
+  $appDataRoot = Join-Path $env:APPDATA "Azookey"
+  $settingsPath = Join-Path $appDataRoot "settings.json"
+  $settingsBackupPath = Join-Path $appDataRoot "settings.json.broken-20260720123456"
+  $learningPath = Join-Path $appDataRoot "LearningMemory\migration-sentinel.txt"
+  foreach ($path in @($settingsPath, $settingsBackupPath, $learningPath)) {
+    if (!(Test-Path -LiteralPath $path)) {
+      throw "Migration did not preserve user data: $path"
+    }
+  }
+  $settings = Get-Content -LiteralPath $settingsPath -Raw | ConvertFrom-Json
+  if ($settings.general.punctuation_commit -ne $true) {
+    throw "Migration did not preserve the settings semantic sentinel."
+  }
+
+  $legacyPayload = @(
+    Get-ChildItem -LiteralPath $appDataRoot -Recurse -Force -ErrorAction SilentlyContinue |
+      Where-Object {
+        $isScheduledLockedDll = $AllowScheduledLegacyDll -and
+          [string]::Equals($_.FullName, (Join-Path $appDataRoot "azookey.dll"), [System.StringComparison]::OrdinalIgnoreCase)
+        ((!$_.PSIsContainer -and $_.Extension -in @(".exe", ".dll", ".vbs", ".gguf") -and !$isScheduledLockedDll) -or
+        ($_.PSIsContainer -and $_.Name -in @("Dictionary", "EmojiDictionary", "llama_cpu", "llama_cuda", "llama_vulkan", "backend")))
+      }
+  )
+  if ($legacyPayload.Count -gt 0) {
+    throw "Legacy executable payload remains under APPDATA: $($legacyPayload.FullName -join ', ')"
+  }
+
+  $broadSids = @("S-1-1-0", "S-1-5-11", "S-1-5-32-545")
+  $writeRights = [System.Security.AccessControl.FileSystemRights]::WriteData -bor
+    [System.Security.AccessControl.FileSystemRights]::AppendData -bor
+    [System.Security.AccessControl.FileSystemRights]::WriteExtendedAttributes -bor
+    [System.Security.AccessControl.FileSystemRights]::WriteAttributes -bor
+    [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+    [System.Security.AccessControl.FileSystemRights]::Delete -bor
+    [System.Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+    [System.Security.AccessControl.FileSystemRights]::TakeOwnership
+  # The running frontend can create and atomically remove settings.json.tmp-* while
+  # this assertion is executing.  Check only the stable paths whose ACLs are part
+  # of the migration contract so a harmless atomic-save race cannot fail the VM
+  # test between Get-ChildItem and Get-Acl.
+  $migratedPaths = @(
+    Get-Item -LiteralPath $appDataRoot -Force
+    Get-Item -LiteralPath (Join-Path $appDataRoot "LearningMemory") -Force
+    Get-Item -LiteralPath $settingsPath -Force
+    Get-Item -LiteralPath $settingsBackupPath -Force
+    Get-Item -LiteralPath $learningPath -Force
+  )
+  foreach ($migratedPath in $migratedPaths) {
+    $broadWriteRules = @(
+      (Get-Acl -LiteralPath $migratedPath.FullName).Access | Where-Object {
+        try {
+          $identitySid = $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value
+        } catch {
+          $identitySid = $_.IdentityReference.Value
+        }
+        $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+        $broadSids -contains $identitySid -and
+        (($_.FileSystemRights -band $writeRights) -ne 0)
+      }
+    )
+    if ($broadWriteRules.Count -gt 0) {
+      throw "Migrated user data grants write access to a broad local identity: path=$($migratedPath.FullName) rules=$($broadWriteRules | Out-String)"
+    }
+  }
+  $aclWriteSentinel = Join-Path $appDataRoot ".migration-acl-write-sentinel"
+  Set-Content -LiteralPath $aclWriteSentinel -Encoding ASCII -Value "current user can write"
+  Remove-Item -LiteralPath $aclWriteSentinel -Force
+
+  $installLog = Get-Content -LiteralPath $InstallLogPath -Raw
+  $taskDeleteIndex = $installLog.IndexOf("Startup task was deleted and its absence was verified.")
+  $migrationIndex = $installLog.IndexOf("Migrating previous Inno install without executing its user-writable uninstall data")
+  if (($taskDeleteIndex -lt 0) -or ($migrationIndex -lt 0) -or ($taskDeleteIndex -gt $migrationIndex)) {
+    throw "Installer log does not prove that the legacy task was deleted before migration."
+  }
+
+  Write-Host "previous Inno payload migrated with private writable ACL while settings/backup/learning were preserved"
+}
+
 function Assert-RequiredInstallFiles {
   param([Parameter(Mandatory = $true)][string]$InstallLocation)
 
   $requiredPaths = @(
     "frontend.exe",
+    "azookey-updater-helper.exe",
     "azookey-server.exe",
     "ui.exe",
     "launcher.exe",
     "azookey.dll",
     "azookey32.dll",
-    "launch.vbs",
     "Dictionary",
     "EmojiDictionary",
     "zenz.gguf",
@@ -471,6 +625,214 @@ function Assert-RequiredInstallFiles {
   if ($missing.Count -gt 0) {
     throw "Required installed files are missing: $($missing -join ', ')"
   }
+
+  foreach ($forbiddenPath in @("launch.vbs", ".azookey-startup-task.xml")) {
+    if (Test-Path -LiteralPath (Join-Path $InstallLocation $forbiddenPath)) {
+      throw "Forbidden startup helper remains in install location: $forbiddenPath"
+    }
+  }
+  $userSidHelpers = @(Get-ChildItem -LiteralPath $InstallLocation -Filter ".legacy-user-sid-*" -Force -ErrorAction SilentlyContinue)
+  if ($userSidHelpers.Count -gt 0) {
+    throw "Protected migration user SID helper was not cleaned up: $($userSidHelpers.FullName -join ', ')"
+  }
+}
+
+function Assert-NoUntrustedWriteAccess {
+  param([Parameter(Mandatory = $true)][string]$Path)
+  $unsafeSids = @(
+    "S-1-1-0",
+    "S-1-5-11",
+    "S-1-5-32-545",
+    [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+  )
+  # Do not OR composite rights such as FullControl into this mask: FullControl
+  # also contains ReadAndExecute/Synchronize and would classify the normal
+  # BUILTIN\Users read-only Program Files ACL as writable.
+  $writeRights = [System.Security.AccessControl.FileSystemRights]::WriteData -bor
+    [System.Security.AccessControl.FileSystemRights]::AppendData -bor
+    [System.Security.AccessControl.FileSystemRights]::WriteExtendedAttributes -bor
+    [System.Security.AccessControl.FileSystemRights]::WriteAttributes -bor
+    [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+    [System.Security.AccessControl.FileSystemRights]::Delete -bor
+    [System.Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+    [System.Security.AccessControl.FileSystemRights]::TakeOwnership
+  $unsafeRules = @(
+    (Get-Acl -LiteralPath $Path).Access | Where-Object {
+      try {
+        $identitySid = $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value
+      } catch {
+        $identitySid = $_.IdentityReference.Value
+      }
+      $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+      $unsafeSids -contains $identitySid -and
+      (($_.FileSystemRights -band $writeRights) -ne 0)
+    }
+  )
+  if ($unsafeRules.Count -gt 0) {
+    throw "Protected path grants write access to an untrusted identity: path=$Path rules=$($unsafeRules | Out-String)"
+  }
+}
+
+function Assert-ProtectedInstallLocation {
+  param([Parameter(Mandatory = $true)][string]$InstallLocation)
+
+  $expected = Join-Path ([Environment]::GetFolderPath([Environment+SpecialFolder]::ProgramFiles)) "Azookey"
+  if (![string]::Equals(
+      [System.IO.Path]::GetFullPath($InstallLocation).TrimEnd("\"),
+      [System.IO.Path]::GetFullPath($expected).TrimEnd("\"),
+      [System.StringComparison]::OrdinalIgnoreCase
+  )) {
+    throw "Install location is not fixed to Program Files: actual=$InstallLocation expected=$expected"
+  }
+
+  Assert-NoUntrustedWriteAccess -Path $InstallLocation
+
+  Write-Host "install location is fixed and protected: $InstallLocation"
+}
+
+function Assert-BackgroundExecutablesUseGuiSubsystem {
+  param([Parameter(Mandatory = $true)][string]$InstallLocation)
+
+  foreach ($executableName in @("launcher.exe", "azookey-server.exe", "ui.exe")) {
+    $executablePath = Join-Path $InstallLocation $executableName
+    $bytes = [System.IO.File]::ReadAllBytes($executablePath)
+    if ($bytes.Length -lt 256) {
+      throw "$executableName is too small to contain a valid PE header."
+    }
+    $peOffset = [BitConverter]::ToInt32($bytes, 0x3c)
+    $subsystemOffset = $peOffset + 24 + 68
+    if (($subsystemOffset + 2) -gt $bytes.Length) {
+      throw "$executableName has an invalid PE optional header."
+    }
+    $subsystem = [BitConverter]::ToUInt16($bytes, $subsystemOffset)
+    if ($subsystem -ne 2) {
+      throw "release background executable is not built as Windows GUI subsystem: name=$executableName subsystem=$subsystem"
+    }
+  }
+
+  Write-Host "release launcher/server/ui use Windows GUI subsystem"
+}
+
+function Assert-SecureStartupTask {
+  param([Parameter(Mandatory = $true)][string]$InstallLocation)
+
+  $task = Get-ScheduledTask -TaskName "Azookey Startup" -ErrorAction Stop
+  if ($task.Principal.RunLevel -ne "Highest") {
+    throw "Startup task is not HighestAvailable: $($task.Principal.RunLevel)"
+  }
+  try {
+    if ($task.Principal.GroupId -match '^S-\d-') {
+      $principalSid = $task.Principal.GroupId
+    } else {
+      $principalSid = ([System.Security.Principal.NTAccount]$task.Principal.GroupId).
+        Translate([System.Security.Principal.SecurityIdentifier]).Value
+    }
+  } catch {
+    throw "Startup task principal could not be resolved: $($task.Principal.GroupId): $($_.Exception.Message)"
+  }
+  if ($principalSid -ne "S-1-5-32-544") {
+    throw "Startup task principal is not Administrators: $($task.Principal.GroupId) ($principalSid)"
+  }
+  if ($task.Actions.Count -ne 1) {
+    throw "Startup task must contain exactly one action: $($task.Actions.Count)"
+  }
+
+  $action = $task.Actions[0]
+  $expectedLauncher = Join-Path $InstallLocation "launcher.exe"
+  if (![string]::Equals($action.Execute.Trim('"'), $expectedLauncher, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Startup task does not execute launcher.exe directly: $($action.Execute)"
+  }
+  if (![string]::Equals($action.WorkingDirectory, $InstallLocation, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Startup task working directory is unexpected: $($action.WorkingDirectory)"
+  }
+  $serializedAction = "$($action.Execute) $($action.Arguments)".ToLowerInvariant()
+  if ($serializedAction.Contains("wscript") -or $serializedAction.Contains(".vbs")) {
+    throw "Startup task still uses wscript/VBS: $serializedAction"
+  }
+
+  Write-Host "startup task directly executes protected launcher.exe"
+}
+
+function Assert-ProcessRedirectionGuard {
+  param([Parameter(Mandatory = $true)][string]$ProcessName)
+
+  if ($null -eq ("AzookeyVm.ProcessMitigation" -as [type])) {
+    Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+namespace AzookeyVm {
+  public static class ProcessMitigation {
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool GetProcessMitigationPolicy(
+      IntPtr process,
+      int mitigationPolicy,
+      out uint buffer,
+      UIntPtr length);
+  }
+}
+"@
+  }
+
+  $process = Get-Process -Name $ProcessName -ErrorAction Stop | Select-Object -First 1
+  $flags = [uint32]0
+  $ok = [AzookeyVm.ProcessMitigation]::GetProcessMitigationPolicy(
+    $process.Handle,
+    16,
+    [ref]$flags,
+    [UIntPtr]::new([uint64]4)
+  )
+  if (!$ok -or (($flags -band 1) -eq 0)) {
+    $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    throw "RedirectionGuard is not enforced for $ProcessName (flags=$flags win32=$errorCode)."
+  }
+}
+
+function Assert-AzookeyProcessesStarted {
+  $requiredProcesses = @("launcher", "azookey-server", "ui")
+  $deadline = (Get-Date).AddSeconds(45)
+  do {
+    $missing = @($requiredProcesses | Where-Object {
+      $null -eq (Get-Process -Name $_ -ErrorAction SilentlyContinue)
+    })
+    if ($missing.Count -eq 0) {
+      foreach ($processName in $requiredProcesses) {
+        Assert-ProcessRedirectionGuard -ProcessName $processName
+      }
+      Write-Host "launcher/server/ui processes are running with RedirectionGuard enforced"
+      return
+    }
+    Start-Sleep -Seconds 1
+  } while ((Get-Date) -lt $deadline)
+
+  throw "Azookey processes did not start: $($missing -join ', ')"
+}
+
+function Assert-MutableDataOutsideInstallLocation {
+  param([Parameter(Mandatory = $true)][string]$InstallLocation)
+
+  foreach ($relativePath in @("EngineRuntime", "logs", "ui-webview", "frontend.exe.WebView2", "ui.exe.WebView2")) {
+    if (Test-Path -LiteralPath (Join-Path $InstallLocation $relativePath)) {
+      throw "Mutable runtime data was created under Program Files: $relativePath"
+    }
+  }
+
+  $runtimePath = Join-Path $env:APPDATA "Azookey\EngineRuntime"
+  $uiWebViewPath = Join-Path $env:LOCALAPPDATA "Azookey\ui-webview"
+  if (Test-Path -LiteralPath $runtimePath) {
+    Write-Host "EngineRuntime is outside Program Files: $runtimePath"
+  } else {
+    # EngineRuntime is initialized lazily when the IME engine first handles
+    # input, so launcher/server/UI startup alone does not require it to exist.
+    Write-Host "EngineRuntime has not been initialized before IME input (expected lazy behavior)"
+  }
+  if (Test-Path -LiteralPath $uiWebViewPath) {
+    Write-Host "UI WebView data is outside Program Files: $uiWebViewPath"
+  } else {
+    # The candidate UI creates its WebView lazily when it is first shown.
+    Write-Host "UI WebView data has not been initialized before candidate UI display (expected lazy behavior)"
+  }
+
+  Write-Host "no mutable runtime or UI WebView data was created under Program Files"
 }
 
 function Test-WebView2RuntimeInstalled {
@@ -488,7 +850,7 @@ function Test-WebView2RuntimeInstalled {
   return $false
 }
 
-function Assert-OnlySettingsRemainAfterUninstall {
+function Assert-InstallPayloadRemovedAfterUninstall {
   param([Parameter(Mandatory = $true)][string]$InstallLocation)
 
   if (!(Test-Path -LiteralPath $InstallLocation)) {
@@ -496,10 +858,8 @@ function Assert-OnlySettingsRemainAfterUninstall {
     return
   }
 
-  $allowedSettingsPath = Join-Path $InstallLocation "settings.json"
   $remaining = @(
-    Get-ChildItem -LiteralPath $InstallLocation -Force -Recurse -ErrorAction SilentlyContinue |
-      Where-Object { $_.FullName -ne $allowedSettingsPath }
+    Get-ChildItem -LiteralPath $InstallLocation -Force -Recurse -ErrorAction SilentlyContinue
   )
 
   if ($remaining.Count -gt 0) {
@@ -509,7 +869,7 @@ function Assert-OnlySettingsRemainAfterUninstall {
     throw "Unexpected files remain after uninstall: $($sample -join ', ')"
   }
 
-  Write-Host "install directory contains only settings.json after uninstall"
+  Write-Host "Program Files payload was removed after uninstall"
 }
 
 function Wait-ForUninstallerSelfCleanup {
@@ -530,56 +890,72 @@ function Wait-ForUninstallerSelfCleanup {
   } while ((Get-Date) -lt $deadline)
 }
 
-function Ensure-SettingsFileForUninstallVerification {
-  param([Parameter(Mandatory = $true)][string]$InstallLocation)
-
-  $settingsPath = Join-Path $InstallLocation "settings.json"
-  if (!(Test-Path -LiteralPath $settingsPath)) {
-    Set-Content -LiteralPath $settingsPath -Encoding UTF8 -Value '{"createdBy":"vm_stage_for_manual_test"}'
-    Write-Host "created settings.json sentinel for uninstall verification"
-  }
+function Ensure-PreservedUserDataSentinels {
+  $appDataRoot = Join-Path $env:APPDATA "Azookey"
+  $learningRoot = Join-Path $appDataRoot "LearningMemory"
+  New-Item -ItemType Directory -Force -Path $learningRoot | Out-Null
+  $settingsPath = Join-Path $appDataRoot "settings.json"
+  $settingsSentinel = '{"version":"0.1.2","zenzai":{"enable":false,"profile":"","backend":"cpu"},"general":{"punctuation_commit":true}}'
+  [System.IO.File]::WriteAllText($settingsPath, $settingsSentinel, [System.Text.UTF8Encoding]::new($false))
+  Set-Content -LiteralPath (Join-Path $appDataRoot "settings.json.broken-vm-sentinel") -Encoding UTF8 -Value "settings backup sentinel"
+  Set-Content -LiteralPath (Join-Path $learningRoot "learning-sentinel.txt") -Encoding UTF8 -Value "learning sentinel"
+  Write-Host "created settings, backup, and learning sentinels"
 }
 
 function Ensure-GeneratedAppDataForUninstallVerification {
-  param([Parameter(Mandatory = $true)][string]$InstallLocation)
-
-  foreach ($relativePath in @(
-    "EngineRuntime",
-    "frontend.exe.WebView2",
-    "logs",
-    "ui.exe.WebView2"
+  foreach ($dir in @(
+    (Join-Path $env:APPDATA "Azookey\EngineRuntime"),
+    (Join-Path $env:APPDATA "Azookey\logs"),
+    (Join-Path $env:APPDATA "Azookey\frontend.exe.WebView2"),
+    (Join-Path $env:APPDATA "Azookey\ui.exe.WebView2"),
+    (Join-Path $env:LOCALAPPDATA "Azookey\ui-webview"),
+    (Join-Path $env:LOCALAPPDATA "com.azookey.app")
   )) {
-    $dir = Join-Path $InstallLocation $relativePath
     New-Item -ItemType Directory -Force -Path $dir | Out-Null
     Set-Content -LiteralPath (Join-Path $dir "uninstall-sentinel.txt") -Encoding UTF8 -Value "generated app data cleanup sentinel"
   }
 
+  $appDataRoot = Join-Path $env:APPDATA "Azookey"
+  Set-Content -LiteralPath (Join-Path $appDataRoot "legacy-payload.exe") -Encoding UTF8 -Value "legacy executable sentinel"
+  $legacyDictionary = Join-Path $appDataRoot "Dictionary"
+  New-Item -ItemType Directory -Force -Path $legacyDictionary | Out-Null
+  Set-Content -LiteralPath (Join-Path $legacyDictionary "legacy-dictionary.txt") -Encoding UTF8 -Value "legacy dictionary sentinel"
+
   Write-Host "created generated app data sentinels for uninstall verification"
 }
 
-function Assert-NoExternalAzookeyDirectoriesAfterUninstall {
-  param([Parameter(Mandatory = $true)][string]$InstallLocation)
-
-  $candidateRoots = @()
-  if (![string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
-    $candidateRoots += Join-Path $env:LOCALAPPDATA "Azookey"
-  }
-  foreach ($tempRoot in @($env:TEMP, $env:TMP)) {
-    if (![string]::IsNullOrWhiteSpace($tempRoot)) {
-      $candidateRoots += Join-Path $tempRoot "Azookey"
+function Assert-UninstallDataPolicy {
+  $appDataRoot = Join-Path $env:APPDATA "Azookey"
+  foreach ($path in @(
+    (Join-Path $appDataRoot "settings.json"),
+    (Join-Path $appDataRoot "settings.json.broken-vm-sentinel"),
+    (Join-Path $appDataRoot "LearningMemory\learning-sentinel.txt")
+  )) {
+    if (!(Test-Path -LiteralPath $path)) {
+      throw "Preserved user data was removed during uninstall: $path"
     }
   }
 
-  foreach ($path in @($candidateRoots | Select-Object -Unique)) {
-    if ($path -eq $InstallLocation) {
-      continue
-    }
+  foreach ($path in @(
+    (Join-Path $appDataRoot "EngineRuntime"),
+    (Join-Path $appDataRoot "logs"),
+    (Join-Path $appDataRoot "frontend.exe.WebView2"),
+    (Join-Path $appDataRoot "ui.exe.WebView2"),
+    (Join-Path $appDataRoot "legacy-payload.exe"),
+    (Join-Path $appDataRoot "Dictionary"),
+    (Join-Path $env:LOCALAPPDATA "Azookey\ui-webview"),
+    (Join-Path $env:LOCALAPPDATA "com.azookey.app")
+  )) {
     if (Test-Path -LiteralPath $path) {
-      throw "Unexpected external Azookey directory remains after uninstall: $path"
+      throw "Generated cache/log remains after uninstall: $path"
     }
   }
 
-  Write-Host "no external Azookey directories remain after uninstall"
+  if (Get-ScheduledTask -TaskName "Azookey Startup" -ErrorAction SilentlyContinue) {
+    throw "Startup task remains after uninstall."
+  }
+
+  Write-Host "uninstall preserved settings/learning and removed generated cache/log/task"
 }
 
 function Start-ExclusiveFileLock {
@@ -615,13 +991,13 @@ try {
     "-ExecutionPolicy",
     "Bypass",
     "-File",
-    $lockScriptPath,
+    ('"{0}"' -f $lockScriptPath),
     "-Path",
-    $Path,
+    ('"{0}"' -f $Path),
     "-ReadyPath",
-    $readyPath,
+    ('"{0}"' -f $readyPath),
     "-ReleasePath",
-    $releasePath
+    ('"{0}"' -f $releasePath)
   ) -PassThru
 
   $deadline = (Get-Date).AddSeconds(30)
@@ -706,23 +1082,185 @@ if ($VerifyLegacyNsisMigration) {
 if ($VerifyMissingLegacyNsisUninstaller) {
   Install-BrokenLegacyNsisInstall
 }
+$previousInnoLock = $null
+if ($VerifyPreviousInnoMigration) {
+  Install-PreviousInnoVersion -PreviousInstallerPath $PreviousInnoInstallerPath -TimeoutSec $InstallerTimeoutSec
+}
+if ($VerifyPreviousInnoRegistryDeleteFailure) {
+  Install-PreviousInnoVersion -PreviousInstallerPath $PreviousInnoInstallerPath -TimeoutSec $InstallerTimeoutSec
+}
+if ($VerifyLockedPreviousInnoMigration) {
+  Install-PreviousInnoVersion -PreviousInstallerPath $PreviousInnoInstallerPath -TimeoutSec $InstallerTimeoutSec
+  $previousInnoLock = Start-ExclusiveFileLock -Path (Join-Path $env:APPDATA "Azookey\azookey.dll")
+  Write-Host "locked previous AppData TSF DLL before migration"
+}
+if ($VerifyMissingPreviousInnoUninstaller) {
+  Install-PreviousInnoVersion -PreviousInstallerPath $PreviousInnoInstallerPath -TimeoutSec $InstallerTimeoutSec
+  $previousEntry = @(Get-AzookeyUninstallEntries)[0]
+  $previousUninstaller = Normalize-RegistryPath -Path $previousEntry.UninstallString
+  $previousUninstallerHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $previousUninstaller).Hash.ToLowerInvariant()
+  Write-Host "previous Inno uninstaller SHA-256: $previousUninstallerHash"
+  $previousUninstallerData = [System.IO.Path]::ChangeExtension($previousUninstaller, ".dat")
+  $previousUninstallerDataHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $previousUninstallerData).Hash.ToLowerInvariant()
+  Write-Host "previous Inno uninstaller data SHA-256: $previousUninstallerDataHash"
+  Move-Item -LiteralPath $previousUninstaller -Destination "$previousUninstaller.missing" -Force
+  Write-Host "removed previous Inno uninstaller to inject migration failure"
+}
+if ($VerifyTamperedPreviousInnoData) {
+  Install-PreviousInnoVersion -PreviousInstallerPath $PreviousInnoInstallerPath -TimeoutSec $InstallerTimeoutSec
+  $previousEntry = @(Get-AzookeyUninstallEntries)[0]
+  $previousUninstaller = Normalize-RegistryPath -Path $previousEntry.UninstallString
+  $previousUninstallerData = [System.IO.Path]::ChangeExtension($previousUninstaller, ".dat")
+  $stream = [System.IO.File]::Open($previousUninstallerData, [System.IO.FileMode]::Append, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+  try {
+    $stream.WriteByte(0)
+  } finally {
+    $stream.Dispose()
+  }
+  Write-Host "tampered machine-specific previous Inno data; controlled migration must not execute it"
+}
+if ($VerifyTamperedPreviousInnoUninstaller) {
+  Install-PreviousInnoVersion -PreviousInstallerPath $PreviousInnoInstallerPath -TimeoutSec $InstallerTimeoutSec
+  $previousEntry = @(Get-AzookeyUninstallEntries)[0]
+  $previousUninstaller = Normalize-RegistryPath -Path $previousEntry.UninstallString
+  $stream = [System.IO.File]::Open($previousUninstaller, [System.IO.FileMode]::Append, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+  try {
+    $stream.WriteByte(0)
+  } finally {
+    $stream.Dispose()
+  }
+  Write-Host "tampered previous Inno uninstaller executable to inject trust-validation failure"
+}
 
 $args = @(
   "/SP-",
   "/VERYSILENT",
   "/SUPPRESSMSGBOXES",
   "/NORESTART",
+  "/RESTARTEXITCODE=3010",
+  "/DIR=$(Join-Path $env:LOCALAPPDATA 'Azookey-unsafe-install-override')",
   "/LOG=$InstallLogPath"
 )
+if ($VerifyTaskCreationFailure) {
+  $args += "/AZOOKEY_TEST_FAIL_TASK_CREATE"
+}
+if ($VerifyTaskRunFailure) {
+  $args += "/AZOOKEY_TEST_FAIL_TASK_RUN"
+}
+if ($VerifyPreviousInnoRegistryDeleteFailure) {
+  $args += "/AZOOKEY_TEST_FAIL_LEGACY_REGISTRY_DELETE"
+}
 
 Write-Host "installing: $InstallerPath"
 Write-Host "timeout(sec): $InstallerTimeoutSec"
 $proc = Start-Process -FilePath $InstallerPath -ArgumentList $args -PassThru
 if (-not $proc.WaitForExit($InstallerTimeoutSec * 1000)) {
+  if ($null -ne $previousInnoLock) {
+    Stop-ExclusiveFileLock -Lock $previousInnoLock
+  }
   Stop-ProcessTree -RootPid $proc.Id
   throw "Installer timed out."
 }
 Write-Host "installer exit code: $($proc.ExitCode)"
+if ($null -ne $previousInnoLock) {
+  Stop-ExclusiveFileLock -Lock $previousInnoLock
+}
+
+$setupLogText = Get-Content -LiteralPath $InstallLogPath -Raw
+if ($setupLogText.IndexOf("RedirectionGuard status for current process: Enabled in enforcing mode") -lt 0) {
+  throw "Installer did not run with RedirectionGuard enabled in enforcing mode."
+}
+Write-Host "installer RedirectionGuard is enabled in enforcing mode"
+
+if ($VerifyMissingPreviousInnoUninstaller -or $VerifyTamperedPreviousInnoUninstaller) {
+  if ($proc.ExitCode -eq 0) {
+    throw "Installer succeeded even though the previous Inno uninstaller is missing or untrusted."
+  }
+  $previousEntries = @(Get-AzookeyUninstallEntries)
+  if ($previousEntries.Count -ne 1) {
+    throw "Previous Inno uninstall metadata was removed after failed migration."
+  }
+  $previousLocation = Normalize-RegistryPath -Path $previousEntries[0].InstallLocation
+  foreach ($path in @(
+    (Join-Path $previousLocation "launcher.exe"),
+    (Join-Path $previousLocation "settings.json"),
+    (Join-Path $previousLocation "LearningMemory\migration-sentinel.txt")
+  )) {
+    if (!(Test-Path -LiteralPath $path)) {
+      throw "Previous Inno payload/data was manually removed after failed migration: $path"
+    }
+  }
+  if (Get-ScheduledTask -TaskName "Azookey Startup" -ErrorAction SilentlyContinue) {
+    throw "Unsafe previous startup task remains after failed migration."
+  }
+  Write-Host "missing or untrusted previous Inno uninstaller aborted migration without payload deletion"
+  exit 0
+}
+
+if ($VerifyPreviousInnoRegistryDeleteFailure) {
+  if (($proc.ExitCode -eq 0) -or ($proc.ExitCode -eq 3010)) {
+    throw "Installer reported success even though previous uninstall metadata deletion failure was injected."
+  }
+  $previousEntries = @(Get-AzookeyUninstallEntries)
+  if ($previousEntries.Count -ne 1) {
+    throw "Previous Inno uninstall metadata was removed after the injected preflight failure."
+  }
+  $previousLocation = Normalize-RegistryPath -Path $previousEntries[0].InstallLocation
+  foreach ($path in @(
+    (Join-Path $previousLocation "launcher.exe"),
+    (Join-Path $previousLocation "settings.json"),
+    (Join-Path $previousLocation "LearningMemory\migration-sentinel.txt")
+  )) {
+    if (!(Test-Path -LiteralPath $path)) {
+      throw "Previous Inno payload/data was removed after the injected registry preflight failure: $path"
+    }
+  }
+  if (Get-ScheduledTask -TaskName "Azookey Startup" -ErrorAction SilentlyContinue) {
+    throw "Unsafe previous startup task remains after the injected registry preflight failure."
+  }
+  $failureLog = Get-Content -LiteralPath $InstallLogPath -Raw
+  if ($failureLog.IndexOf("Injecting previous Inno uninstall registry deletion failure for installer verification.") -lt 0) {
+    throw "Installer log does not prove that uninstall metadata deletion failed before migration."
+  }
+  if ($failureLog.IndexOf("Migrating previous Inno install without executing its user-writable uninstall data") -ge 0) {
+    throw "Installer began destructive payload migration after uninstall metadata deletion failed."
+  }
+  Write-Host "previous Inno registry deletion failure aborted before payload migration and preserved retry state"
+  exit 0
+}
+
+if ($VerifyTaskCreationFailure) {
+  if (($proc.ExitCode -eq 0) -or ($proc.ExitCode -eq 3010)) {
+    throw "Installer reported success/restart even though task creation failure was injected: $($proc.ExitCode)"
+  }
+  if (Get-ScheduledTask -TaskName "Azookey Startup" -ErrorAction SilentlyContinue) {
+    throw "Partial startup task remains after injected creation failure."
+  }
+  $failureLog = Get-Content -LiteralPath $InstallLogPath -Raw
+  if ($failureLog.IndexOf("Injecting startup task creation failure for installer verification.") -lt 0) {
+    throw "Installer log does not prove that task creation reached the injected failure path."
+  }
+  Write-Host "task creation failure aborted install without leaving a partial task"
+  exit 0
+}
+
+if ($VerifyTaskRunFailure) {
+  if (($proc.ExitCode -eq 0) -or ($proc.ExitCode -eq 3010)) {
+    throw "Installer reported success/restart even though task run failure was injected: $($proc.ExitCode)"
+  }
+  if (Get-ScheduledTask -TaskName "Azookey Startup" -ErrorAction SilentlyContinue) {
+    throw "Created startup task remains after injected run failure."
+  }
+  $failureLog = Get-Content -LiteralPath $InstallLogPath -Raw
+  $injectionIndex = $failureLog.IndexOf("Injecting startup task run failure after successful creation for installer verification.")
+  $runFailureIndex = $failureLog.IndexOf("Startup task run failed.", $injectionIndex + 1)
+  $cleanupIndex = $failureLog.IndexOf("Startup task was deleted and its absence was verified.", $runFailureIndex + 1)
+  if (($injectionIndex -lt 0) -or ($runFailureIndex -le $injectionIndex) -or ($cleanupIndex -le $runFailureIndex)) {
+    throw "Installer log does not prove create-success, run-failure, and verified cleanup ordering."
+  }
+  Write-Host "task run failure removed the already-created partial task"
+  exit 0
+}
 
 if ($VerifyMissingLegacyNsisUninstaller) {
   if ($proc.ExitCode -eq 0) {
@@ -733,12 +1271,45 @@ if ($VerifyMissingLegacyNsisUninstaller) {
   exit 0
 }
 
-if ($proc.ExitCode -ne 0) {
+if ($VerifyLegacyNsisMigration) {
+  if ($proc.ExitCode -eq 0) {
+    throw "Installer executed or ignored an untrusted legacy NSIS install."
+  }
+  Assert-FakeLegacyNsisInstallRejectedSafely
+  exit 0
+}
+
+if (($proc.ExitCode -ne 0) -and ($proc.ExitCode -ne 3010)) {
   throw "Installer failed. ExitCode=$($proc.ExitCode)"
 }
 
-if ($VerifyLegacyNsisMigration) {
-  Assert-FakeLegacyNsisMigrated
+if (($VerifyPreviousInnoMigration -or $VerifyLockedPreviousInnoMigration -or $VerifyTamperedPreviousInnoData) -and ($proc.ExitCode -ne 3010)) {
+  throw "Previous Inno migration did not propagate restart as exit code 3010: $($proc.ExitCode)"
+}
+
+if ($VerifyPreviousInnoMigration -or $VerifyLockedPreviousInnoMigration -or $VerifyTamperedPreviousInnoData) {
+  Assert-PreviousInnoMigrated -InstallLogPath $InstallLogPath -AllowScheduledLegacyDll:$VerifyLockedPreviousInnoMigration
+}
+
+if ($VerifyLockedPreviousInnoMigration) {
+  $migrationLog = Get-Content -LiteralPath $InstallLogPath -Raw
+  if ($migrationLog.IndexOf("Locked previous payload was queued for deletion in place with RedirectionGuard enforced.") -lt 0) {
+    throw "Locked previous DLL was not queued by the RedirectionGuard-protected fallback."
+  }
+  $lockedLegacyDll = Join-Path $env:APPDATA "Azookey\azookey.dll"
+  if (!(Test-Path -LiteralPath $lockedLegacyDll)) {
+    throw "Locked legacy DLL unexpectedly disappeared before its locking handle was released."
+  }
+  $pendingRename = @(
+    (Get-ItemPropertyValue `
+      -LiteralPath "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager" `
+      -Name "PendingFileRenameOperations" `
+      -ErrorAction SilentlyContinue)
+  )
+  if (-not ($pendingRename | Where-Object { $_ -like "*$lockedLegacyDll*" })) {
+    throw "Locked legacy DLL is not present in PendingFileRenameOperations: $lockedLegacyDll"
+  }
+  Write-Host "locked previous AppData DLL is the only remaining payload and is queued for restart deletion"
 }
 
 $entries = @(Get-AzookeyUninstallEntries)
@@ -760,6 +1331,11 @@ if ($entry.MainBinaryName -ne "frontend.exe") {
 
 $installLocation = Normalize-RegistryPath -Path $entry.InstallLocation
 Assert-RequiredInstallFiles -InstallLocation $installLocation
+Assert-ProtectedInstallLocation -InstallLocation $installLocation
+Assert-BackgroundExecutablesUseGuiSubsystem -InstallLocation $installLocation
+Assert-SecureStartupTask -InstallLocation $installLocation
+Assert-AzookeyProcessesStarted
+Assert-MutableDataOutsideInstallLocation -InstallLocation $installLocation
 if (-not (Test-WebView2RuntimeInstalled)) {
   throw "WebView2 Runtime is missing after install."
 }
@@ -767,6 +1343,38 @@ if (-not (Test-WebView2RuntimeInstalled)) {
 Write-Host "install complete. entry found: $($entry.PSChildName)"
 Write-Host "install location: $installLocation"
 Write-Host "WebView2 Runtime installed"
+
+if ($VerifySafeReinstall) {
+  Ensure-PreservedUserDataSentinels
+  $learningHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $env:APPDATA "Azookey\LearningMemory\learning-sentinel.txt")).Hash
+  $reinstallLogPath = [System.IO.Path]::ChangeExtension($InstallLogPath, ".safe-reinstall.log")
+  $reinstallProc = Start-Process -FilePath $InstallerPath -ArgumentList @(
+    "/SP-",
+    "/VERYSILENT",
+    "/SUPPRESSMSGBOXES",
+    "/NORESTART",
+    "/RESTARTEXITCODE=3010",
+    "/LOG=$reinstallLogPath"
+  ) -PassThru
+  if (-not $reinstallProc.WaitForExit($InstallerTimeoutSec * 1000)) {
+    Stop-ProcessTree -RootPid $reinstallProc.Id
+    throw "Safe-layout reinstall timed out."
+  }
+  if (($reinstallProc.ExitCode -ne 0) -and ($reinstallProc.ExitCode -ne 3010)) {
+    throw "Safe-layout reinstall failed. ExitCode=$($reinstallProc.ExitCode)"
+  }
+  $settingsAfterReinstall = Get-Content -LiteralPath (Join-Path $env:APPDATA "Azookey\settings.json") -Raw | ConvertFrom-Json
+  if ($settingsAfterReinstall.general.punctuation_commit -ne $true) {
+    throw "Safe-layout reinstall did not preserve the settings semantic sentinel."
+  }
+  if ((Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $env:APPDATA "Azookey\LearningMemory\learning-sentinel.txt")).Hash -ne $learningHash) {
+    throw "Safe-layout reinstall changed learning data."
+  }
+  Assert-SecureStartupTask -InstallLocation $installLocation
+  Assert-AzookeyProcessesStarted
+  Assert-MutableDataOutsideInstallLocation -InstallLocation $installLocation
+  Write-Host "safe-layout to safe-layout update preserved data and recreated the protected task"
+}
 
 if ($VerifyLockedFileUpgrade) {
   if ($UninstallAfterInstall) {
@@ -776,8 +1384,8 @@ if ($VerifyLockedFileUpgrade) {
 }
 
 if ($UninstallAfterInstall) {
-  Ensure-SettingsFileForUninstallVerification -InstallLocation $installLocation
-  Ensure-GeneratedAppDataForUninstallVerification -InstallLocation $installLocation
+  Ensure-PreservedUserDataSentinels
+  Ensure-GeneratedAppDataForUninstallVerification
   $uninstallCommand = $entry.UninstallString
 
   if ([string]::IsNullOrWhiteSpace($uninstallCommand)) {
@@ -810,7 +1418,7 @@ if ($UninstallAfterInstall) {
   }
 
   Wait-ForUninstallerSelfCleanup -InstallLocation $installLocation
-  Assert-NoExternalAzookeyDirectoriesAfterUninstall -InstallLocation $installLocation
+  Assert-UninstallDataPolicy
   foreach ($relativePath in @("frontend.exe", "azookey.dll", "azookey32.dll", "launcher.exe")) {
     $path = Join-Path $installLocation $relativePath
     if (Test-Path $path) {
@@ -818,7 +1426,7 @@ if ($UninstallAfterInstall) {
     }
   }
 
-  Assert-OnlySettingsRemainAfterUninstall -InstallLocation $installLocation
+  Assert-InstallPayloadRemovedAfterUninstall -InstallLocation $installLocation
   Write-Host "uninstall complete. entries found: 0"
 }
 PS1
@@ -836,6 +1444,10 @@ main() {
 
   log "インストーラーを VM に転送します: $(basename "$installer")"
   scp_to_vm "$installer" "$REMOTE_INSTALLER_SCP"
+  if [[ "${VERIFY_PREVIOUS_INNO_MIGRATION,,}" =~ ^(1|true|yes|on)$ ]] || [[ "${VERIFY_LOCKED_PREVIOUS_INNO_MIGRATION,,}" =~ ^(1|true|yes|on)$ ]] || [[ "${VERIFY_MISSING_PREVIOUS_INNO_UNINSTALLER,,}" =~ ^(1|true|yes|on)$ ]] || [[ "${VERIFY_TAMPERED_PREVIOUS_INNO_UNINSTALLER,,}" =~ ^(1|true|yes|on)$ ]] || [[ "${VERIFY_TAMPERED_PREVIOUS_INNO_DATA,,}" =~ ^(1|true|yes|on)$ ]] || [[ "${VERIFY_PREVIOUS_INNO_REGISTRY_DELETE_FAILURE,,}" =~ ^(1|true|yes|on)$ ]]; then
+    log "旧 Inno installer を VM に転送します: $(basename "$PREVIOUS_INNO_INSTALLER")"
+    scp_to_vm "$PREVIOUS_INNO_INSTALLER" "$REMOTE_PREVIOUS_INSTALLER_SCP"
+  fi
   scp_to_vm "$TMP_REMOTE_PS" "$REMOTE_PS_SCP"
 
   log "VM でインストーラーを実行します（サイレント）"
@@ -844,6 +1456,15 @@ main() {
   local legacy_nsis_switch=""
   local missing_legacy_nsis_uninstaller_switch=""
   local locked_file_upgrade_switch=""
+  local previous_inno_migration_switch=""
+  local locked_previous_inno_migration_switch=""
+  local missing_previous_inno_uninstaller_switch=""
+  local tampered_previous_inno_uninstaller_switch=""
+  local tampered_previous_inno_data_switch=""
+  local previous_inno_registry_delete_failure_switch=""
+  local safe_reinstall_switch=""
+  local task_creation_failure_switch=""
+  local task_run_failure_switch=""
   case "${UNINSTALL_AFTER_INSTALL,,}" in
     1|true|yes|on)
       uninstall_switch="-UninstallAfterInstall"
@@ -864,7 +1485,52 @@ main() {
       locked_file_upgrade_switch="-VerifyLockedFileUpgrade"
       ;;
   esac
-  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -InstallerPath \"$REMOTE_INSTALLER_WIN\" -InstallLogPath \"$REMOTE_INSTALL_LOG_WIN\" -UninstallLogPath \"$REMOTE_UNINSTALL_LOG_WIN\" -InstallerTimeoutSec $INSTALL_TIMEOUT_SEC $legacy_nsis_switch $missing_legacy_nsis_uninstaller_switch $locked_file_upgrade_switch $uninstall_switch" || install_rc=$?
+  case "${VERIFY_PREVIOUS_INNO_MIGRATION,,}" in
+    1|true|yes|on)
+      previous_inno_migration_switch="-VerifyPreviousInnoMigration -PreviousInnoInstallerPath \"$REMOTE_PREVIOUS_INSTALLER_WIN\""
+      ;;
+  esac
+  case "${VERIFY_LOCKED_PREVIOUS_INNO_MIGRATION,,}" in
+    1|true|yes|on)
+      locked_previous_inno_migration_switch="-VerifyLockedPreviousInnoMigration -PreviousInnoInstallerPath \"$REMOTE_PREVIOUS_INSTALLER_WIN\""
+      ;;
+  esac
+  case "${VERIFY_MISSING_PREVIOUS_INNO_UNINSTALLER,,}" in
+    1|true|yes|on)
+      missing_previous_inno_uninstaller_switch="-VerifyMissingPreviousInnoUninstaller -PreviousInnoInstallerPath \"$REMOTE_PREVIOUS_INSTALLER_WIN\""
+      ;;
+  esac
+  case "${VERIFY_TAMPERED_PREVIOUS_INNO_UNINSTALLER,,}" in
+    1|true|yes|on)
+      tampered_previous_inno_uninstaller_switch="-VerifyTamperedPreviousInnoUninstaller -PreviousInnoInstallerPath \"$REMOTE_PREVIOUS_INSTALLER_WIN\""
+      ;;
+  esac
+  case "${VERIFY_TAMPERED_PREVIOUS_INNO_DATA,,}" in
+    1|true|yes|on)
+      tampered_previous_inno_data_switch="-VerifyTamperedPreviousInnoData -PreviousInnoInstallerPath \"$REMOTE_PREVIOUS_INSTALLER_WIN\""
+      ;;
+  esac
+  case "${VERIFY_PREVIOUS_INNO_REGISTRY_DELETE_FAILURE,,}" in
+    1|true|yes|on)
+      previous_inno_registry_delete_failure_switch="-VerifyPreviousInnoRegistryDeleteFailure -PreviousInnoInstallerPath \"$REMOTE_PREVIOUS_INSTALLER_WIN\""
+      ;;
+  esac
+  case "${VERIFY_SAFE_REINSTALL,,}" in
+    1|true|yes|on)
+      safe_reinstall_switch="-VerifySafeReinstall"
+      ;;
+  esac
+  case "${VERIFY_TASK_CREATION_FAILURE,,}" in
+    1|true|yes|on)
+      task_creation_failure_switch="-VerifyTaskCreationFailure"
+      ;;
+  esac
+  case "${VERIFY_TASK_RUN_FAILURE,,}" in
+    1|true|yes|on)
+      task_run_failure_switch="-VerifyTaskRunFailure"
+      ;;
+  esac
+  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -InstallerPath \"$REMOTE_INSTALLER_WIN\" -InstallLogPath \"$REMOTE_INSTALL_LOG_WIN\" -UninstallLogPath \"$REMOTE_UNINSTALL_LOG_WIN\" -InstallerTimeoutSec $INSTALL_TIMEOUT_SEC $legacy_nsis_switch $missing_legacy_nsis_uninstaller_switch $locked_file_upgrade_switch $previous_inno_migration_switch $locked_previous_inno_migration_switch $missing_previous_inno_uninstaller_switch $tampered_previous_inno_uninstaller_switch $tampered_previous_inno_data_switch $previous_inno_registry_delete_failure_switch $safe_reinstall_switch $task_creation_failure_switch $task_run_failure_switch $uninstall_switch" || install_rc=$?
   if [[ "$install_rc" -ne 0 ]]; then
     log "インストーラー実行が失敗しました。ログ回収と VM 後処理を継続します: exit=$install_rc"
   fi

--- a/scripts/vm_test_updater.sh
+++ b/scripts/vm_test_updater.sh
@@ -443,11 +443,15 @@ function Invoke-ProductionFrontendUpdater {
   $frontendPath = Join-Path $installLocation "frontend.exe"
   $markerPath = Join-Path $installLocation ".azookey-updater-integration-test"
   $resultPath = Join-Path $env:APPDATA "Azookey\update-result.json"
-  $resultRegistryPath = "HKCU:\Software\Azookey"
+  $launchingUserSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+  $resultRegistryPath = "Registry::HKEY_USERS\$launchingUserSid\Software\Azookey"
   $resultRegistryName = "UpdateResultJson"
+  $requestRegistryPath = "HKCU:\Software\Azookey"
+  $requestRegistryName = "PendingUpdateRequestId"
   Set-Content -LiteralPath $markerPath -Encoding ASCII -Value "VM-only protected updater integration marker"
   Remove-Item -LiteralPath $resultPath -Force -ErrorAction SilentlyContinue
   Remove-ItemProperty -LiteralPath $resultRegistryPath -Name $resultRegistryName -ErrorAction SilentlyContinue
+  Remove-ItemProperty -LiteralPath $requestRegistryPath -Name $requestRegistryName -ErrorAction SilentlyContinue
 
   $previousReleaseApiUrl = $env:AZOOKEY_UPDATE_RELEASE_API_URL
   $previousCurrentVersion = $env:AZOOKEY_UPDATE_CURRENT_VERSION
@@ -479,21 +483,27 @@ function Invoke-ProductionFrontendUpdater {
     }
     # The installer deliberately stops frontend.exe after the protected helper
     # has been launched, so this launcher process may be terminated before a
-    # stable exit code is observable. The helper's atomic result file below is
-    # the authoritative completion signal.
+    # stable exit code is observable. The helper's explicit user-hive result
+    # below is the authoritative completion signal.
     Write-Host "production updater launcher exited: exit=$frontendExitCode stderr=$stderr"
 
     $deadline = (Get-Date).AddSeconds($TimeoutSec)
-    $resultJson = $null
-    while (($null -eq $resultJson) -and ((Get-Date) -lt $deadline)) {
-      $resultJson = Get-OptionalRegistryValue -Path $resultRegistryPath -Name $resultRegistryName
+    $resultEnvelopeJson = $null
+    while (($null -eq $resultEnvelopeJson) -and ((Get-Date) -lt $deadline)) {
+      $resultEnvelopeJson = Get-OptionalRegistryValue -Path $resultRegistryPath -Name $resultRegistryName
       Start-Sleep -Seconds 1
     }
-    if ($null -eq $resultJson) {
+    if ($null -eq $resultEnvelopeJson) {
       throw "Production frontend updater did not publish its protected registry result. launcher_exit=$frontendExitCode stderr=$stderr"
     }
 
-    $result = $resultJson | ConvertFrom-Json
+    $pendingRequestId = Get-OptionalRegistryValue -Path $requestRegistryPath -Name $requestRegistryName
+    $resultEnvelope = $resultEnvelopeJson | ConvertFrom-Json
+    if ([string]::IsNullOrWhiteSpace($pendingRequestId) -or
+        $resultEnvelope.request_id -ne $pendingRequestId) {
+      throw "Explicit launching-user hive result was not bound to its pending request."
+    }
+    $result = $resultEnvelope.result
     if ($result.status -ne "success") {
       throw "Production frontend updater reported failure: $($result | ConvertTo-Json -Compress)"
     }
@@ -504,14 +514,16 @@ function Invoke-ProductionFrontendUpdater {
 
     # A GUI process launched over SSH runs outside the logged-on desktop and
     # cannot reliably initialize WebView2. The Rust one-shot reader is covered
-    # by unit tests; here verify that the protected transport can be removed
-    # and cannot leave a stale success for the next updater run.
+    # by unit tests; here remove the explicit user-hive result and request
+    # after verifying their correlation.
     Remove-ItemProperty -LiteralPath $resultRegistryPath -Name $resultRegistryName -ErrorAction Stop
+    Remove-ItemProperty -LiteralPath $requestRegistryPath -Name $requestRegistryName -ErrorAction Stop
     $remainingResult = Get-OptionalRegistryValue -Path $resultRegistryPath -Name $resultRegistryName
-    if ($null -ne $remainingResult) {
-      throw "Protected updater result could not be removed after verification."
+    $remainingRequest = Get-OptionalRegistryValue -Path $requestRegistryPath -Name $requestRegistryName
+    if (($null -ne $remainingResult) -or ($null -ne $remainingRequest)) {
+      throw "Protected updater result/request could not be removed after verification."
     }
-    Write-Host "protected updater result was removed without leaving stale success state"
+    Write-Host "updater result was published to the explicit launching-user hive and removed without stale state"
   } finally {
     $env:AZOOKEY_UPDATE_RELEASE_API_URL = $previousReleaseApiUrl
     $env:AZOOKEY_UPDATE_CURRENT_VERSION = $previousCurrentVersion
@@ -533,10 +545,14 @@ function Assert-CopiedFrontendCannotElevateHelper {
   Set-Content -LiteralPath (Join-Path $copiedRoot ".azookey-updater-integration-test") -Encoding ASCII -Value "untrusted copied marker"
 
   $resultPath = Join-Path $env:APPDATA "Azookey\update-result.json"
-  $resultRegistryPath = "HKCU:\Software\Azookey"
+  $launchingUserSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+  $resultRegistryPath = "Registry::HKEY_USERS\$launchingUserSid\Software\Azookey"
   $resultRegistryName = "UpdateResultJson"
+  $requestRegistryPath = "HKCU:\Software\Azookey"
+  $requestRegistryName = "PendingUpdateRequestId"
   Remove-Item -LiteralPath $resultPath -Force -ErrorAction SilentlyContinue
   Remove-ItemProperty -LiteralPath $resultRegistryPath -Name $resultRegistryName -ErrorAction SilentlyContinue
+  Remove-ItemProperty -LiteralPath $requestRegistryPath -Name $requestRegistryName -ErrorAction SilentlyContinue
   $previousReleaseApiUrl = $env:AZOOKEY_UPDATE_RELEASE_API_URL
   $previousCurrentVersion = $env:AZOOKEY_UPDATE_CURRENT_VERSION
   try {
@@ -567,7 +583,8 @@ function Assert-CopiedFrontendCannotElevateHelper {
       throw "Copied frontend failed for an unexpected reason: exit=$($frontend.ExitCode) stderr=$stderr"
     }
     if ((Test-Path -LiteralPath $resultPath) -or
-        ($null -ne (Get-OptionalRegistryValue -Path $resultRegistryPath -Name $resultRegistryName))) {
+        ($null -ne (Get-OptionalRegistryValue -Path $resultRegistryPath -Name $resultRegistryName)) -or
+        ($null -ne (Get-OptionalRegistryValue -Path $requestRegistryPath -Name $requestRegistryName))) {
       throw "Copied frontend unexpectedly launched the elevated updater helper."
     }
     Write-Host "copied frontend cannot elevate a helper outside Program Files"

--- a/scripts/vm_test_updater.sh
+++ b/scripts/vm_test_updater.sh
@@ -12,6 +12,8 @@ SSH_KEY="${SSH_KEY:-}"
 VBOX_MANAGE="${VBOX_MANAGE:-}"
 PSEUDO_RELEASE_PORT="${PSEUDO_RELEASE_PORT:-$((18000 + RANDOM % 1000))}"
 SHUTDOWN_AFTER_TEST="${SHUTDOWN_AFTER_TEST:-1}"
+UPDATER_TIMEOUT_SEC="${UPDATER_TIMEOUT_SEC:-1200}"
+UPDATER_BASE_INSTALLER="${UPDATER_BASE_INSTALLER:-}"
 
 if [[ -z "$VBOX_MANAGE" ]]; then
   if command -v VBoxManage >/dev/null 2>&1; then
@@ -42,6 +44,8 @@ LOG_FILE="$LOG_DIR/vm-updater-$TIMESTAMP.log"
 REMOTE_TMP_WIN="C:\\Users\\$SSH_USER\\AppData\\Local\\Temp"
 REMOTE_PS_WIN="$REMOTE_TMP_WIN\\azookey-updater-smoke.ps1"
 REMOTE_PS_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-updater-smoke.ps1"
+REMOTE_TARGET_INSTALLER_WIN="$REMOTE_TMP_WIN\\azookey-updater-target.exe"
+REMOTE_TARGET_INSTALLER_SCP="/C:/Users/$SSH_USER/AppData/Local/Temp/azookey-updater-target.exe"
 TMP_REMOTE_PS=""
 
 SSH_OPTS=(-i "$SSH_KEY" -p "$SSH_PORT" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=8)
@@ -175,7 +179,9 @@ create_smoke_ps1() {
 param(
   [Parameter(Mandatory = $true)][string]$LocalInstallerPath,
   [Parameter(Mandatory = $true)][int]$PseudoReleasePort,
-  [Parameter(Mandatory = $true)][string]$WorkDir
+  [Parameter(Mandatory = $true)][string]$WorkDir,
+  [Parameter(Mandatory = $true)][int]$UpdaterTimeoutSec,
+  [switch]$RequirePayloadChange
 )
 
 $ErrorActionPreference = "Stop"
@@ -257,12 +263,14 @@ function Start-LocalPseudoRelease {
   $pseudoSha = Join-Path $pseudoDir "SHA256SUMS.txt"
   $pseudoJson = Join-Path $pseudoDir "latest.json"
 
+  # Serve the actual installer so the production helper directly exercises
+  # its hash/lock/elevation/argument/result behavior without a wrapper process.
   Copy-Item -LiteralPath $InstallerPath -Destination $pseudoInstaller -Force
   $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $pseudoInstaller).Hash.ToLowerInvariant()
   Set-Content -LiteralPath $pseudoSha -Encoding ASCII -Value "$hash  azookey-setup.exe"
 
   $baseUrl = "http://127.0.0.1:$Port"
-  @"
+  $pseudoReleaseJson = @"
 {
   "tag_name": "v999.0.0-updater-smoke",
   "name": "Updater smoke release",
@@ -278,11 +286,20 @@ function Start-LocalPseudoRelease {
     }
   ]
 }
-"@ | Set-Content -LiteralPath $pseudoJson -Encoding UTF8
+"@
+  [System.IO.File]::WriteAllText(
+    $pseudoJson,
+    $pseudoReleaseJson,
+    [System.Text.UTF8Encoding]::new($false)
+  )
 
   $job = Start-Job -ArgumentList $pseudoDir, $Port -ScriptBlock {
     param([string]$Root, [int]$ListenPort)
-    $maxRequests = 4
+    # One readiness probe plus release metadata, checksum, and installer
+    # requests from both the adversarial copy and the production frontend.
+    # The copied frontend completes download verification before rejecting its
+    # helper outside the protected install root.
+    $maxRequests = 7
     $servedRequests = 0
     $listener = [System.Net.HttpListener]::new()
     $listener.Prefixes.Add("http://127.0.0.1:$ListenPort/")
@@ -335,11 +352,253 @@ function Start-LocalPseudoRelease {
   }
 }
 
+function Get-AzookeyInstallLocation {
+  $uninstallKeyName = "{80B746D4-D74D-4345-8F81-47E06BCAB515}_is1"
+  $entry = @(
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$uninstallKeyName",
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$uninstallKeyName"
+  ) | ForEach-Object {
+    Get-ItemProperty -LiteralPath $_ -ErrorAction SilentlyContinue
+  } | Select-Object -First 1
+
+  if ($null -eq $entry -or [string]::IsNullOrWhiteSpace($entry.InstallLocation)) {
+    throw "Azookey install location was not found after updater install."
+  }
+  $location = $entry.InstallLocation.Trim().Trim('"')
+  Write-Host "located protected install metadata: $location"
+  $location
+}
+
+function Get-OptionalRegistryValue {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+
+  $item = Get-ItemProperty -LiteralPath $Path -ErrorAction SilentlyContinue
+  if ($null -eq $item) {
+    return $null
+  }
+  $property = $item.PSObject.Properties[$Name]
+  if ($null -eq $property) {
+    return $null
+  }
+  return $property.Value
+}
+
+function Assert-UpdatedProtectedInstall {
+  $settingsPath = Join-Path $env:APPDATA "Azookey\settings.json"
+  $learningPath = Join-Path $env:APPDATA "Azookey\LearningMemory\updater-sentinel.txt"
+  $settings = Get-Content -LiteralPath $settingsPath -Raw | ConvertFrom-Json
+  if ($settings.general.punctuation_commit -ne $true) {
+    throw "Updater install did not preserve the settings semantic sentinel."
+  }
+  if (!(Test-Path -LiteralPath $learningPath)) {
+    throw "Updater install removed learning data."
+  }
+
+  $installLocation = Get-AzookeyInstallLocation
+  $expected = Join-Path ([Environment]::GetFolderPath([Environment+SpecialFolder]::ProgramFiles)) "Azookey"
+  if (![string]::Equals($installLocation.TrimEnd("\"), $expected.TrimEnd("\"), [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Updater changed the protected install location: $installLocation"
+  }
+  $task = Get-ScheduledTask -TaskName "Azookey Startup" -ErrorAction Stop
+  $expectedLauncher = Join-Path $installLocation "launcher.exe"
+  if (![string]::Equals($task.Actions[0].Execute.Trim('"'), $expectedLauncher, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Updater did not recreate the protected launcher task: $($task.Actions[0].Execute)"
+  }
+  if ($task.Principal.RunLevel -ne "Highest") {
+    throw "Updater changed the startup task run level: $($task.Principal.RunLevel)"
+  }
+  if (Test-Path -LiteralPath (Join-Path $installLocation ".azookey-updater-staging")) {
+    throw "Successful updater run left protected installer staging behind."
+  }
+  $newDownloadStaging = @(
+    Get-ChildItem -LiteralPath $env:TEMP -Directory -Filter "azookey-update-*" -ErrorAction SilentlyContinue |
+      Where-Object { $script:downloadStagingBefore -notcontains $_.FullName }
+  )
+  if ($newDownloadStaging.Count -gt 0) {
+    throw "Updater left its original downloaded installer staging behind: $($newDownloadStaging.FullName -join ', ')"
+  }
+
+  $frontendHashAfterUpdate = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $installLocation "frontend.exe")).Hash
+  if ($RequirePayloadChange -and $frontendHashAfterUpdate -eq $script:frontendHashBeforeUpdate) {
+    throw "Updater completed without replacing the distinct frontend payload."
+  }
+
+  if ($RequirePayloadChange) {
+    Write-Host "updater install preserved data, cleaned staging, recreated the protected task, and replaced the distinct payload"
+  } else {
+    Write-Host "updater install preserved data, cleaned staging, and recreated the protected task"
+  }
+}
+
+function Invoke-ProductionFrontendUpdater {
+  param(
+    [Parameter(Mandatory = $true)][string]$ReleaseApiUrl,
+    [Parameter(Mandatory = $true)][int]$TimeoutSec
+  )
+
+  $installLocation = Get-AzookeyInstallLocation
+  $frontendPath = Join-Path $installLocation "frontend.exe"
+  $markerPath = Join-Path $installLocation ".azookey-updater-integration-test"
+  $resultPath = Join-Path $env:APPDATA "Azookey\update-result.json"
+  $resultRegistryPath = "HKCU:\Software\Azookey"
+  $resultRegistryName = "UpdateResultJson"
+  Set-Content -LiteralPath $markerPath -Encoding ASCII -Value "VM-only protected updater integration marker"
+  Remove-Item -LiteralPath $resultPath -Force -ErrorAction SilentlyContinue
+  Remove-ItemProperty -LiteralPath $resultRegistryPath -Name $resultRegistryName -ErrorAction SilentlyContinue
+
+  $previousReleaseApiUrl = $env:AZOOKEY_UPDATE_RELEASE_API_URL
+  $previousCurrentVersion = $env:AZOOKEY_UPDATE_CURRENT_VERSION
+  try {
+    $env:AZOOKEY_UPDATE_RELEASE_API_URL = $ReleaseApiUrl
+    $env:AZOOKEY_UPDATE_CURRENT_VERSION = "0.0.1"
+    $stdoutPath = Join-Path $WorkDir "production-updater-stdout.log"
+    $stderrPath = Join-Path $WorkDir "production-updater-stderr.log"
+    Remove-Item -LiteralPath $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
+    $frontend = Start-Process -FilePath $frontendPath `
+      -ArgumentList "--azookey-updater-integration-test" `
+      -RedirectStandardOutput $stdoutPath `
+      -RedirectStandardError $stderrPath `
+      -PassThru
+    if (-not $frontend.WaitForExit(120000)) {
+      Stop-Process -Id $frontend.Id -Force -ErrorAction SilentlyContinue
+      throw "Production frontend updater entry point timed out."
+    }
+    # With redirected GUI-subsystem processes, PowerShell may leave ExitCode
+    # unset after the timed WaitForExit overload until handles are drained and
+    # the Process object is refreshed.
+    $frontend.WaitForExit()
+    $frontend.Refresh()
+    $frontendExitCode = $frontend.ExitCode
+    $stderr = if (Test-Path -LiteralPath $stderrPath) {
+      Get-Content -LiteralPath $stderrPath -Raw
+    } else {
+      "<stderr unavailable>"
+    }
+    # The installer deliberately stops frontend.exe after the protected helper
+    # has been launched, so this launcher process may be terminated before a
+    # stable exit code is observable. The helper's atomic result file below is
+    # the authoritative completion signal.
+    Write-Host "production updater launcher exited: exit=$frontendExitCode stderr=$stderr"
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    $resultJson = $null
+    while (($null -eq $resultJson) -and ((Get-Date) -lt $deadline)) {
+      $resultJson = Get-OptionalRegistryValue -Path $resultRegistryPath -Name $resultRegistryName
+      Start-Sleep -Seconds 1
+    }
+    if ($null -eq $resultJson) {
+      throw "Production frontend updater did not publish its protected registry result. launcher_exit=$frontendExitCode stderr=$stderr"
+    }
+
+    $result = $resultJson | ConvertFrom-Json
+    if ($result.status -ne "success") {
+      throw "Production frontend updater reported failure: $($result | ConvertTo-Json -Compress)"
+    }
+    if (($result.exit_code -ne 0) -and ($result.exit_code -ne 3010)) {
+      throw "Production frontend updater returned an unexpected installer exit code: $($result.exit_code)"
+    }
+    Write-Host "production frontend updater completed: exit=$($result.exit_code) restart=$($result.needs_restart)"
+
+    # A GUI process launched over SSH runs outside the logged-on desktop and
+    # cannot reliably initialize WebView2. The Rust one-shot reader is covered
+    # by unit tests; here verify that the protected transport can be removed
+    # and cannot leave a stale success for the next updater run.
+    Remove-ItemProperty -LiteralPath $resultRegistryPath -Name $resultRegistryName -ErrorAction Stop
+    $remainingResult = Get-OptionalRegistryValue -Path $resultRegistryPath -Name $resultRegistryName
+    if ($null -ne $remainingResult) {
+      throw "Protected updater result could not be removed after verification."
+    }
+    Write-Host "protected updater result was removed without leaving stale success state"
+  } finally {
+    $env:AZOOKEY_UPDATE_RELEASE_API_URL = $previousReleaseApiUrl
+    $env:AZOOKEY_UPDATE_CURRENT_VERSION = $previousCurrentVersion
+    Remove-Item -LiteralPath $markerPath -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Assert-CopiedFrontendCannotElevateHelper {
+  param(
+    [Parameter(Mandatory = $true)][string]$ReleaseApiUrl
+  )
+
+  $installLocation = Get-AzookeyInstallLocation
+  $copiedRoot = Join-Path $WorkDir "copied-frontend"
+  New-Item -ItemType Directory -Force -Path $copiedRoot | Out-Null
+  foreach ($name in @("frontend.exe", "azookey-updater-helper.exe")) {
+    Copy-Item -LiteralPath (Join-Path $installLocation $name) -Destination (Join-Path $copiedRoot $name) -Force
+  }
+  Set-Content -LiteralPath (Join-Path $copiedRoot ".azookey-updater-integration-test") -Encoding ASCII -Value "untrusted copied marker"
+
+  $resultPath = Join-Path $env:APPDATA "Azookey\update-result.json"
+  $resultRegistryPath = "HKCU:\Software\Azookey"
+  $resultRegistryName = "UpdateResultJson"
+  Remove-Item -LiteralPath $resultPath -Force -ErrorAction SilentlyContinue
+  Remove-ItemProperty -LiteralPath $resultRegistryPath -Name $resultRegistryName -ErrorAction SilentlyContinue
+  $previousReleaseApiUrl = $env:AZOOKEY_UPDATE_RELEASE_API_URL
+  $previousCurrentVersion = $env:AZOOKEY_UPDATE_CURRENT_VERSION
+  try {
+    $env:AZOOKEY_UPDATE_RELEASE_API_URL = $ReleaseApiUrl
+    $env:AZOOKEY_UPDATE_CURRENT_VERSION = "0.0.1"
+    $stdoutPath = Join-Path $WorkDir "copied-updater-stdout.log"
+    $stderrPath = Join-Path $WorkDir "copied-updater-stderr.log"
+    $frontend = Start-Process -FilePath (Join-Path $copiedRoot "frontend.exe") `
+      -ArgumentList "--azookey-updater-integration-test" `
+      -RedirectStandardOutput $stdoutPath `
+      -RedirectStandardError $stderrPath `
+      -PassThru
+    if (-not $frontend.WaitForExit(120000)) {
+      Stop-Process -Id $frontend.Id -Force -ErrorAction SilentlyContinue
+      throw "Copied frontend updater rejection timed out."
+    }
+    $frontend.WaitForExit()
+    $frontend.Refresh()
+    if ($frontend.ExitCode -eq 0) {
+      throw "Copied frontend was allowed to launch an updater helper from a user-writable directory."
+    }
+    $stderr = if (Test-Path -LiteralPath $stderrPath) {
+      Get-Content -LiteralPath $stderrPath -Raw
+    } else {
+      ""
+    }
+    if ($stderr.IndexOf("outside the protected install directory") -lt 0) {
+      throw "Copied frontend failed for an unexpected reason: exit=$($frontend.ExitCode) stderr=$stderr"
+    }
+    if ((Test-Path -LiteralPath $resultPath) -or
+        ($null -ne (Get-OptionalRegistryValue -Path $resultRegistryPath -Name $resultRegistryName))) {
+      throw "Copied frontend unexpectedly launched the elevated updater helper."
+    }
+    Write-Host "copied frontend cannot elevate a helper outside Program Files"
+  } finally {
+    $env:AZOOKEY_UPDATE_RELEASE_API_URL = $previousReleaseApiUrl
+    $env:AZOOKEY_UPDATE_CURRENT_VERSION = $previousCurrentVersion
+  }
+}
+
 Test-ReleaseDownload -ReleaseApiUrl "https://api.github.com/repos/batao9/azooKey-Windows/releases/latest" -Prefix "official"
+$script:downloadStagingBefore = @(
+  Get-ChildItem -LiteralPath $env:TEMP -Directory -Filter "azookey-update-*" -ErrorAction SilentlyContinue |
+    ForEach-Object FullName
+)
+$initialInstallLocation = Get-AzookeyInstallLocation
+$script:frontendHashBeforeUpdate = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $initialInstallLocation "frontend.exe")).Hash
+$appDataRoot = Join-Path $env:APPDATA "Azookey"
+$learningRoot = Join-Path $appDataRoot "LearningMemory"
+New-Item -ItemType Directory -Force -Path $learningRoot | Out-Null
+$settingsPath = Join-Path $appDataRoot "settings.json"
+$settingsSentinel = '{"version":"0.1.2","zenzai":{"enable":false,"profile":"","backend":"cpu"},"general":{"punctuation_commit":true}}'
+[System.IO.File]::WriteAllText($settingsPath, $settingsSentinel, [System.Text.UTF8Encoding]::new($false))
+Set-Content -LiteralPath (Join-Path $learningRoot "updater-sentinel.txt") -Encoding UTF8 -Value "preserve learning"
 $pseudo = Start-LocalPseudoRelease -InstallerPath $LocalInstallerPath -Port $PseudoReleasePort
 try {
-  Test-ReleaseDownload -ReleaseApiUrl $pseudo.ApiUrl -Prefix "pseudo" -RunInstaller
+  Assert-CopiedFrontendCannotElevateHelper -ReleaseApiUrl $pseudo.ApiUrl
+  Invoke-ProductionFrontendUpdater -ReleaseApiUrl $pseudo.ApiUrl -TimeoutSec $UpdaterTimeoutSec
+  Assert-UpdatedProtectedInstall
 } finally {
+  Wait-Job -Job $pseudo.Job -Timeout 10 -ErrorAction SilentlyContinue | Out-Null
+  Stop-Job -Job $pseudo.Job -ErrorAction SilentlyContinue
   Remove-Job -Job $pseudo.Job -Force -ErrorAction SilentlyContinue
 }
 PS1
@@ -353,13 +612,21 @@ main() {
 
   local installer
   installer="$(find_installer "${1:-latest}")"
+  local base_installer="$installer"
+  local payload_change_switch=""
+  if [[ -n "$UPDATER_BASE_INSTALLER" ]]; then
+    base_installer="$(find_installer "$UPDATER_BASE_INSTALLER")"
+    if ! cmp -s "$base_installer" "$installer"; then
+      payload_change_switch="-RequirePayloadChange"
+    fi
+  fi
   ensure_preconditions
   trap cleanup EXIT
 
   log "疑似 release は VM 内 localhost に準備します: $(basename "$installer")"
 
-  log "検証用 VM にインストーラーを事前インストールします"
-  SHUTDOWN_AFTER_INSTALL=0 "$REPO_ROOT/scripts/vm_stage_for_manual_test.sh" "$installer"
+  log "検証用 VM にベースインストーラーを事前インストールします: $(basename "$base_installer")"
+  SHUTDOWN_AFTER_INSTALL=0 "$REPO_ROOT/scripts/vm_stage_for_manual_test.sh" "$base_installer"
   if ! wait_for_ssh; then
     log "VM への SSH 接続に失敗しました"
     exit 1
@@ -368,10 +635,11 @@ main() {
   TMP_REMOTE_PS="$(mktemp /tmp/azookey-updater-smoke.XXXXXX.ps1)"
   create_smoke_ps1 "$TMP_REMOTE_PS"
   scp_to_vm "$TMP_REMOTE_PS" "$REMOTE_PS_SCP"
+  scp_to_vm "$installer" "$REMOTE_TARGET_INSTALLER_SCP"
 
   local remote_work_dir="$REMOTE_TMP_WIN\\azookey-updater-smoke-$TIMESTAMP"
   log "VM 上で official latest download/hash と疑似 release install を検証します"
-  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -LocalInstallerPath \"$REMOTE_TMP_WIN\\azookey-setup-under-test.exe\" -PseudoReleasePort $PSEUDO_RELEASE_PORT -WorkDir \"$remote_work_dir\""
+  ssh_run "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -LocalInstallerPath \"$REMOTE_TARGET_INSTALLER_WIN\" -PseudoReleasePort $PSEUDO_RELEASE_PORT -WorkDir \"$remote_work_dir\" -UpdaterTimeoutSec $UPDATER_TIMEOUT_SEC $payload_change_switch"
   log "updater smoke が完了しました"
 }
 

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -342,11 +342,38 @@ private func elapsedPerformanceMilliseconds(since start: TimeInterval) -> Int {
     Int((performanceNow() - start) * 1000)
 }
 
-private func settingsPath() -> URL? {
-    guard let appDataPath = ProcessInfo.processInfo.environment["APPDATA"] else {
-        return nil
+func applicationDataDirectoryURL(
+    appDataPath: String?,
+    temporaryDirectoryURL: URL
+) -> URL {
+    if let appDataPath,
+       !appDataPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        return URL(filePath: appDataPath)
+            .appendingPathComponent("Azookey", isDirectory: true)
     }
-    return URL(filePath: appDataPath).appendingPathComponent("Azookey/settings.json")
+
+    return temporaryDirectoryURL.appendingPathComponent("Azookey", isDirectory: true)
+}
+
+private func applicationDataDirectoryURL() -> URL {
+    applicationDataDirectoryURL(
+        appDataPath: ProcessInfo.processInfo.environment["APPDATA"],
+        temporaryDirectoryURL: FileManager.default.temporaryDirectory
+    )
+}
+
+func engineRuntimeDirectoryURL(
+    appDataPath: String?,
+    temporaryDirectoryURL: URL
+) -> URL {
+    applicationDataDirectoryURL(
+        appDataPath: appDataPath,
+        temporaryDirectoryURL: temporaryDirectoryURL
+    ).appendingPathComponent("EngineRuntime", isDirectory: true)
+}
+
+private func settingsPath() -> URL {
+    applicationDataDirectoryURL().appendingPathComponent("settings.json")
 }
 
 private func readAppSettings(at path: URL) throws -> AppSettings {
@@ -366,7 +393,25 @@ private func readAppSettings(at path: URL) throws -> AppSettings {
 }
 
 @MainActor private func converterRuntimeDirectoryURL() -> URL {
-    execURL.appendingPathComponent("EngineRuntime", isDirectory: true)
+    engineRuntimeDirectoryURL(
+        appDataPath: ProcessInfo.processInfo.environment["APPDATA"],
+        temporaryDirectoryURL: FileManager.default.temporaryDirectory
+    )
+}
+
+@MainActor private func ensureConverterRuntimeDirectory() {
+    let runtimeDirectoryURL = converterRuntimeDirectoryURL()
+    do {
+        try FileManager.default.createDirectory(
+            at: runtimeDirectoryURL,
+            withIntermediateDirectories: true
+        )
+    } catch {
+        serverLog(
+            "WARN",
+            "Failed to create engine runtime directory \(runtimeDirectoryURL.path): \(error)"
+        )
+    }
 }
 
 func normalizedZenzaiBackend(_ backend: String?) -> String {
@@ -397,13 +442,7 @@ private func shouldOffloadZenzaiToGpu(zenzaiEnabled: Bool, backend: String?) -> 
             .appendingPathComponent("LearningMemory", isDirectory: true)
     }
 
-    if let appDataPath = ProcessInfo.processInfo.environment["APPDATA"] {
-        return URL(filePath: appDataPath)
-            .appendingPathComponent("Azookey", isDirectory: true)
-            .appendingPathComponent("LearningMemory", isDirectory: true)
-    }
-
-    return converterRuntimeDirectoryURL()
+    return applicationDataDirectoryURL()
         .appendingPathComponent("LearningMemory", isDirectory: true)
 }
 
@@ -1884,13 +1923,11 @@ func cursorPrefixBoundaryFirstClauseResults(
     let loadedSettingsPath = settingsPath()
     var loadedSettings: AppSettings?
     var settingsLoadError: Error?
-    if let loadedSettingsPath {
-        do {
-            let settings = try readAppSettings(at: loadedSettingsPath)
-            loadedSettings = settings
-        } catch {
-            settingsLoadError = error
-        }
+    do {
+        let settings = try readAppSettings(at: loadedSettingsPath)
+        loadedSettings = settings
+    } catch {
+        settingsLoadError = error
     }
 
     serverLog("INFO", "LoadConfig: start")
@@ -1919,9 +1956,7 @@ func cursorPrefixBoundaryFirstClauseResults(
     currentLearningMemoryDirectoryURL = learningMemoryDirectoryURL(settingsPath: loadedSettingsPath)
 
     if let settings = loadedSettings {
-        if let loadedSettingsPath {
-            serverLog("INFO", "LoadConfig: reading settingsPath=\(loadedSettingsPath.path)")
-        }
+        serverLog("INFO", "LoadConfig: reading settingsPath=\(loadedSettingsPath.path)")
 
         if let zenzai = settings.zenzai {
             if let enableValue = zenzai.enable {
@@ -2031,6 +2066,7 @@ func cursorPrefixBoundaryFirstClauseResults(
     execURL = URL(filePath: path)
     converterDictionaryURL = execURL.appendingPathComponent("Dictionary")
     converterPreloadDictionary = true
+    ensureConverterRuntimeDirectory()
     rebuildConverter()
     clearLearningCandidateCache()
 

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -35,6 +35,30 @@ private func packageRootURL() -> URL {
         .deletingLastPathComponent()
 }
 
+@Test func engineRuntimeDirectoryUsesAppData() {
+    let directory = engineRuntimeDirectoryURL(
+        appDataPath: #"C:\Users\test\AppData\Roaming"#,
+        temporaryDirectoryURL: URL(filePath: #"C:\Users\test\AppData\Local\Temp"#)
+    )
+
+    #expect(directory.lastPathComponent == "EngineRuntime")
+    #expect(directory.deletingLastPathComponent().lastPathComponent == "Azookey")
+    #expect(directory.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent == "Roaming")
+}
+
+@Test func engineRuntimeDirectoryFallsBackOutsideInstallDirectory() {
+    let installDirectory = URL(filePath: #"C:\Program Files\Azookey"#)
+    let directory = engineRuntimeDirectoryURL(
+        appDataPath: "  ",
+        temporaryDirectoryURL: URL(filePath: #"C:\Users\test\AppData\Local\Temp"#)
+    )
+
+    #expect(directory.lastPathComponent == "EngineRuntime")
+    #expect(directory.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent == "Temp")
+    #expect(directory.path != installDirectory.path)
+    #expect(!directory.path.hasPrefix(installDirectory.path + "/"))
+}
+
 private func testConvertRequestOptions(memoryURL: URL) -> ConvertRequestOptions {
     let packageRoot = packageRootURL()
     return ConvertRequestOptions(


### PR DESCRIPTION
## Summary
- 起動タスクが実行するpayloadを固定の`C:\Program Files\Azookey`へ移し、一般ユーザーが変更できるファイルを`HighestAvailable`で実行しない構成にします。
- VBS経由の起動を廃止し、保護された`launcher.exe`をタスクから直接起動します。
- 旧Inno版、再更新、frontend updater、失敗時cleanupを含む移行・回帰検証を追加します。

## Background
- Issue: #129
- Issue close: 対象リリース公開・成果物確認後
- 従来は管理者権限で作成した起動タスクが、ログオンユーザーの書き換え可能な`%APPDATA%\Azookey\launch.vbs`と実行ファイルを`HighestAvailable`で起動していました。この権限境界を解消しつつ、現行のUIAccess挙動と既存ユーザーデータを維持します。

## Changes
- installer: install先を`{autopf}\Azookey`へ固定し、directory選択とprevious directory再利用を無効化
- startup task: UTF-8 XMLをProgram Files内で生成し、`launcher.exe`を直接実行。create/run/stop/deleteの結果を検査し、失敗時は部分taskを削除してinstallerを失敗させる
- migration/uninstall: `v0.1.0-batao.10`の既知Inno installを検証して移行し、設定backup・`LearningMemory`を保持。旧payload、task、cache/logの削除と3010伝播を実装
- runtime data: 設定・学習・ログ・`EngineRuntime`を`%APPDATA%\Azookey`、UI WebView2 dataを`%LOCALAPPDATA%\Azookey\ui-webview`へ分離
- process security: launcher/server/UI/frontend/installerでRedirectionGuardを有効化し、launcherは保護されたinstall root外へのPATH fallbackを拒否
- updater: Program Files内の保護されたhelper/stagingを使い、download hash、install metadata、result registry、reparse pointを検証する更新フローへ変更。昇格前に起動ユーザーのSIDとrequest IDを確定し、昇格helperのHKCUではなく起動ユーザーの明示的な`HKEY_USERS` hiveへ相関済み結果を返す
- release UI: launcher/server/UIをWindows GUI subsystemでビルドし、常駐中のconsole window表示を抑止
- VM tests: install root ACL、task action、GUI subsystem、RedirectionGuard、data path、旧版移行、safe reinstall、locked file、failure injection、uninstall、frontend updaterを検証

## Verification
- [x] GitHub Actions build 成功
  - 初回run成功: https://github.com/batao9/azooKey-Windows/actions/runs/29911176430
  - review follow-up run成功: https://github.com/batao9/azooKey-Windows/actions/runs/29919428676
- [x] Windows VM 確認
  - `.local/vm_build_master.sh fix/129-secure-startup-task`: Swift server、Rust x64/x86 client、Tauri、Inno installerのrelease build成功
  - clean install: `C:\Program Files\Azookey`固定、ACL、task action/working directory、RedirectionGuard、AppData data path、launcher/server/UI起動を確認
  - `v0.1.0-batao.10` → 修正版: 設定・backup・学習sentinelを保持し、旧AppData payloadを除去、taskを置換、終了コード3010を確認
  - 修正版 → 修正版: 設定・学習を保持し、保護taskと3プロセスを再作成できることを確認
  - frontend updater: official release download/hash検査、payload差し替え、staging cleanup、task再作成、3010伝播を確認
  - review follow-up: 最終版installerをベースにproduction frontend updaterを実行し、起動ユーザーの明示`HKEY_USERS` hiveへのrequest相関済み結果返却、消費後にresult/requestが残らないこと、設定・学習保持を確認
  - failure/uninstall: task create/run失敗、旧metadata削除失敗、locked-file移行、uninstall cleanupを注入・確認
  - Notepad / 通常・昇格アプリ: IMEと候補UIが動作し、launcher/server/UIの黒いconsole windowが表示されないことを手動確認
- [x] ローカル確認
  - `cargo fmt --all -- --check`: pass
  - `bash -n scripts/vm_stage_for_manual_test.sh scripts/vm_test_updater.sh`: pass
  - `git diff --check`: pass
  - Windows VM client tests: Rust対象testおよびSwift 56 tests pass
- [x] Read-only review
  - alternate administrator資格情報で昇格した場合にhelper自身のHKCUへ結果が書かれるP2指摘を`e30cce4`で修正
  - follow-up review（`e30cce4`）: major issueなし
  - release GUI subsystem化によるUI stderrの診断性低下は将来のfile logging候補だが、debug buildのconsoleとserver crash traceは維持

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
