### PR TITLE
fix: scope server and UI pipes to logon sessions

### DIFF
--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -9,13 +9,14 @@ use shared::{
 };
 use std::{
     cell::Cell,
+    os::windows::io::IntoRawHandle,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex, OnceLock,
     },
     time::{Duration, Instant},
 };
-use tokio::{net::windows::named_pipe::ClientOptions, time};
+use tokio::{net::windows::named_pipe::NamedPipeClient, time};
 use tonic::transport::{channel::Channel, Endpoint};
 use tower::service_fn;
 use windows::Win32::Foundation::ERROR_PIPE_BUSY;
@@ -33,6 +34,11 @@ static CLIENT_LOG_CONFIG_CACHE: OnceLock<Mutex<ClientLogConfigCache>> = OnceLock
 
 thread_local! {
     static CLIENT_INPUT_TRACE_REQUEST_ID: Cell<Option<u64>> = const { Cell::new(None) };
+}
+
+fn open_named_pipe_client(pipe_name: &str) -> std::io::Result<NamedPipeClient> {
+    let handle = shared::open_named_pipe_client_handle(pipe_name)?;
+    unsafe { NamedPipeClient::from_raw_handle(handle.into_raw_handle()) }
 }
 
 #[derive(Debug, Default)]
@@ -209,13 +215,13 @@ impl IPCService {
         let server_channel = Self::connect_named_pipe_channel(
             &runtime,
             "http://[::]:50051",
-            r"\\.\pipe\azookey_server",
+            shared::SERVER_PIPE_PATH,
             SERVER_PIPE_BUSY_TIMEOUT,
         )?;
         let window_client = match Self::connect_named_pipe_channel(
             &runtime,
             "http://[::]:50052",
-            r"\\.\pipe\azookey_ui",
+            shared::UI_PIPE_PATH,
             UI_PIPE_BUSY_TIMEOUT,
         ) {
             Ok(ui_channel) => Some(WindowServiceClient::new(ui_channel)),
@@ -265,7 +271,7 @@ impl IPCService {
             service_fn(move |_| async move {
                 let busy_started_at = Instant::now();
                 let client = loop {
-                    match ClientOptions::new().open(pipe_name) {
+                    match open_named_pipe_client(pipe_name) {
                         Ok(client) => break client,
                         Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY.0 as i32) => {
                             if busy_started_at.elapsed() >= busy_timeout {
@@ -1089,7 +1095,7 @@ impl IPCService {
             match Self::connect_named_pipe_channel(
                 self.runtime.as_ref(),
                 "http://[::]:50052",
-                r"\\.\pipe\azookey_ui",
+                shared::UI_PIPE_PATH,
                 UI_PIPE_BUSY_TIMEOUT,
             ) {
                 Ok(ui_channel) => {

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -15,6 +15,8 @@ futures-core = "0.3.31"
 [dependencies.windows]
 version = "0.58.0"
 features = [
+    "Win32_Foundation",
+    "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_System_Threading",
 ]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -7,10 +7,18 @@ use tokio::{
 };
 use tonic::transport::server::Connected;
 use windows::{
-    core::w,
-    Win32::Security::{
-        Authorization::{ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION},
-        PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
+    core::{PCWSTR, PWSTR},
+    Win32::{
+        Foundation::{CloseHandle, LocalFree, HLOCAL},
+        Security::{
+            Authorization::{
+                ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW,
+                SDDL_REVISION,
+            },
+            GetTokenInformation, TokenLogonSid, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
+            TOKEN_GROUPS, TOKEN_QUERY,
+        },
+        System::Threading::{GetCurrentProcess, OpenProcessToken},
     },
 };
 
@@ -19,6 +27,31 @@ struct UnsafeSecurityAttributes(SECURITY_ATTRIBUTES);
 
 unsafe impl Send for UnsafeSecurityAttributes {}
 unsafe impl Sync for UnsafeSecurityAttributes {}
+
+impl UnsafeSecurityAttributes {
+    fn as_mut_ptr(&mut self) -> *mut c_void {
+        addr_of_mut!(self.0).cast()
+    }
+}
+
+struct OwnedSecurityDescriptor(PSECURITY_DESCRIPTOR);
+
+unsafe impl Send for OwnedSecurityDescriptor {}
+unsafe impl Sync for OwnedSecurityDescriptor {}
+
+impl OwnedSecurityDescriptor {
+    fn as_ptr(&self) -> *mut c_void {
+        self.0 .0
+    }
+}
+
+impl Drop for OwnedSecurityDescriptor {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = LocalFree(HLOCAL(self.as_ptr()));
+        }
+    }
+}
 
 pub struct TonicNamedPipeServer {
     inner: NamedPipeServer,
@@ -67,46 +100,35 @@ impl AsyncWrite for TonicNamedPipeServer {
 }
 
 impl TonicNamedPipeServer {
-    pub fn new(path: &str) -> impl Stream<Item = io::Result<TonicNamedPipeServer>> {
+    pub fn new(path: &str) -> io::Result<impl Stream<Item = io::Result<TonicNamedPipeServer>>> {
         Self::new_with_first_pipe_callback(path, || {})
     }
 
     pub fn new_with_first_pipe_callback<F>(
         path: &str,
         on_first_pipe_created: F,
-    ) -> impl Stream<Item = io::Result<TonicNamedPipeServer>>
+    ) -> io::Result<impl Stream<Item = io::Result<TonicNamedPipeServer>>>
     where
         F: FnOnce() + Send + 'static,
     {
-        // set security attributes to allow ipc from sandboxed processes
-        // see https://nathancorvussolis.blogspot.com/2018/05/windows-ime-security.html
+        let name = path.to_string();
+        let security_descriptor = create_pipe_security_descriptor()?;
+        let mut security_attributes = UnsafeSecurityAttributes(SECURITY_ATTRIBUTES {
+            nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: security_descriptor.as_ptr(),
+            bInheritHandle: false.into(),
+        });
 
-        let name = format!("\\\\.\\pipe\\{}", path);
-
-        let mut security_descriptor = PSECURITY_DESCRIPTOR::default();
-
-        unsafe {
-            ConvertStringSecurityDescriptorToSecurityDescriptorW(
-                w!("D:(A;;GA;;;AC)(A;;GA;;;RC)(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;BU)S:(ML;;NW;;;LW)"),
-                SDDL_REVISION,
-                &mut security_descriptor,
-                None,
-            )
-            .unwrap();
-
-            let mut security_attributes = UnsafeSecurityAttributes(SECURITY_ATTRIBUTES {
-                nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
-                lpSecurityDescriptor: security_descriptor.0,
-                bInheritHandle: false.into(),
-            });
-
-            stream! {
+        Ok(stream! {
+            // Keep the LocalAlloc-owned descriptor alive for every pipe instance.
+            let _security_descriptor = security_descriptor;
+            unsafe {
                 let mut on_first_pipe_created = Some(on_first_pipe_created);
                 let mut server = ServerOptions::new()
                     .first_pipe_instance(true)
                     .create_with_security_attributes_raw(
                         &name,
-                        addr_of_mut!(security_attributes) as *mut c_void
+                        security_attributes.as_mut_ptr()
                     )?;
                 if let Some(on_first_pipe_created) = on_first_pipe_created.take() {
                     on_first_pipe_created();
@@ -124,10 +146,199 @@ impl TonicNamedPipeServer {
                     server = ServerOptions::new()
                         .create_with_security_attributes_raw(
                             &name,
-                            addr_of_mut!(security_attributes) as *mut c_void
+                            security_attributes.as_mut_ptr()
                         )?;
                 }
             }
+        })
+    }
+}
+
+fn create_pipe_security_descriptor() -> io::Result<OwnedSecurityDescriptor> {
+    let logon_sid = current_logon_sid_string()?;
+    let sddl = pipe_sddl(&logon_sid);
+    let sddl_wide = sddl.encode_utf16().chain(Some(0)).collect::<Vec<_>>();
+    let mut security_descriptor = PSECURITY_DESCRIPTOR::default();
+
+    unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            PCWSTR(sddl_wide.as_ptr()),
+            SDDL_REVISION,
+            &mut security_descriptor,
+            None,
+        )
+        .map_err(|error| {
+            io::Error::other(format!(
+                "failed to create named-pipe security descriptor: {error}"
+            ))
+        })?;
+    }
+
+    Ok(OwnedSecurityDescriptor(security_descriptor))
+}
+
+fn pipe_sddl(logon_sid: &str) -> String {
+    // AppContainer access checks use both the caller identity and restricted
+    // SID sets. The logon SID limits the normal identity to this login session
+    // and lets the trusted server process create subsequent pipe instances.
+    // AC/RC grant only read/write data plus synchronization (0x00100003), so a
+    // sandboxed client can connect but cannot create a competing pipe instance.
+    // Network access is explicitly denied.
+    format!(
+        "D:(D;;GA;;;NU)(A;;GA;;;SY)(A;;GRGW;;;{logon_sid})(A;;0x00100003;;;AC)(A;;0x00100003;;;RC)S:(ML;;NW;;;LW)"
+    )
+}
+
+fn current_logon_sid_string() -> io::Result<String> {
+    unsafe {
+        let mut token = Default::default();
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).map_err(|error| {
+            io::Error::other(format!("failed to open current process token: {error}"))
+        })?;
+
+        let result = logon_sid_string_from_token(token);
+        let _ = CloseHandle(token);
+        result
+    }
+}
+
+fn logon_sid_string_from_token(token: windows::Win32::Foundation::HANDLE) -> io::Result<String> {
+    unsafe {
+        let mut token_info_length = 0;
+        let _ = GetTokenInformation(token, TokenLogonSid, None, 0, &mut token_info_length);
+        if token_info_length < size_of::<TOKEN_GROUPS>() as u32 {
+            return Err(io::Error::other(
+                "failed to get current logon SID buffer size",
+            ));
         }
+
+        let word_count = (token_info_length as usize).div_ceil(size_of::<usize>());
+        let mut token_info = vec![0usize; word_count];
+        GetTokenInformation(
+            token,
+            TokenLogonSid,
+            Some(token_info.as_mut_ptr().cast()),
+            token_info_length,
+            &mut token_info_length,
+        )
+        .map_err(|error| io::Error::other(format!("failed to get current logon SID: {error}")))?;
+
+        let token_groups = &*(token_info.as_ptr() as *const TOKEN_GROUPS);
+        if token_groups.GroupCount != 1 {
+            return Err(io::Error::other(format!(
+                "expected one logon SID, got {}",
+                token_groups.GroupCount
+            )));
+        }
+
+        let mut sid_string = PWSTR::null();
+        ConvertSidToStringSidW(token_groups.Groups[0].Sid, &mut sid_string).map_err(|error| {
+            io::Error::other(format!("failed to convert current logon SID: {error}"))
+        })?;
+        let result = sid_string
+            .to_string()
+            .map_err(|error| io::Error::other(format!("failed to decode logon SID: {error}")));
+        let _ = LocalFree(HLOCAL(sid_string.as_ptr().cast()));
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{create_pipe_security_descriptor, pipe_sddl, UnsafeSecurityAttributes};
+    use std::{
+        os::windows::io::IntoRawHandle,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use tokio::net::windows::named_pipe::{NamedPipeClient, ServerOptions};
+    use windows::{
+        core::w,
+        Win32::{
+            Foundation::{CloseHandle, LocalFree, BOOL, ERROR_ACCESS_DENIED, HLOCAL},
+            Security::{
+                Authorization::ConvertStringSidToSidW, CheckTokenMembership, PSID,
+                SECURITY_ATTRIBUTES, TOKEN_QUERY,
+            },
+            System::Threading::{GetCurrentProcess, OpenProcessToken},
+        },
+    };
+
+    fn current_token_has_network_sid() -> bool {
+        unsafe {
+            let mut token = Default::default();
+            OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).unwrap();
+
+            let mut network_sid = PSID::default();
+            ConvertStringSidToSidW(w!("S-1-5-2"), &mut network_sid).unwrap();
+            let mut is_member = BOOL::default();
+            let membership_result = CheckTokenMembership(token, network_sid, &mut is_member);
+
+            let _ = LocalFree(HLOCAL(network_sid.0));
+            let _ = CloseHandle(token);
+            membership_result.unwrap();
+            is_member.as_bool()
+        }
+    }
+
+    #[test]
+    fn pipe_sddl_is_limited_to_logon_session_and_sandboxed_clients() {
+        let sddl = pipe_sddl("S-1-5-5-42-99");
+
+        assert!(sddl.contains("(D;;GA;;;NU)"));
+        assert!(sddl.contains("(A;;GRGW;;;S-1-5-5-42-99)"));
+        assert!(sddl.contains("(A;;0x00100003;;;AC)"));
+        assert!(sddl.contains("(A;;0x00100003;;;RC)"));
+        assert!(sddl.contains("S:(ML;;NW;;;LW)"));
+        assert!(!sddl.contains(";;;BU)"));
+        assert!(!sddl.contains(";;;BA)"));
+        assert!(!sddl.contains(";;;WD)"));
+    }
+
+    #[tokio::test]
+    async fn secured_session_local_pipe_enforces_network_and_logon_access() {
+        let security_descriptor = create_pipe_security_descriptor().unwrap();
+        let mut security_attributes = UnsafeSecurityAttributes(SECURITY_ATTRIBUTES {
+            nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: security_descriptor.as_ptr(),
+            bInheritHandle: false.into(),
+        });
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let pipe_path = format!(
+            r"\\.\pipe\LOCAL\azookey_security_test_{}_{}",
+            std::process::id(),
+            nonce
+        );
+
+        let server = unsafe {
+            ServerOptions::new()
+                .first_pipe_instance(true)
+                .create_with_security_attributes_raw(&pipe_path, security_attributes.as_mut_ptr())
+                .unwrap()
+        };
+        let client_handle = shared::open_named_pipe_client_handle(&pipe_path);
+        // The VM test runner connects through OpenSSH and therefore carries the
+        // NETWORK SID. Production explicitly denies that token; interactive
+        // and service runners exercise the same-logon success path below.
+        if current_token_has_network_sid() {
+            let error = match client_handle {
+                Ok(_) => panic!("network token unexpectedly connected to local-only pipe"),
+                Err(error) => error,
+            };
+            assert_eq!(error.raw_os_error(), Some(ERROR_ACCESS_DENIED.0 as i32));
+            return;
+        }
+
+        let client_handle = client_handle.unwrap();
+        let _client =
+            unsafe { NamedPipeClient::from_raw_handle(client_handle.into_raw_handle()) }.unwrap();
+        server.connect().await.unwrap();
+
+        assert!(ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(&pipe_path)
+            .is_err());
     }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -11,7 +11,7 @@ use shared::proto::{
     MoveCursorRequest, MoveCursorResponse, PerformanceLogRequest, PerformanceLogResponse,
     RemoveTextRequest, RemoveTextResponse, ShrinkTextRequest, ShrinkTextResponse, Suggestion,
 };
-use shared::AppConfig;
+use shared::{AppConfig, SERVER_PIPE_PATH};
 
 use std::{
     backtrace::Backtrace,
@@ -1900,14 +1900,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_v1()
         .map_err(std::io::Error::other)?;
 
-    let incoming = TonicNamedPipeServer::new_with_first_pipe_callback("azookey_server", || {
+    let incoming = TonicNamedPipeServer::new_with_first_pipe_callback(SERVER_PIPE_PATH, || {
         log_event_lazy!(ServerLogLevel::Info, "AzookeyServer listening");
         write_server_crash_trace(
             "rust",
             "server_startup",
             "listening",
             "completed",
-            "pipe=azookey_server",
+            "pipe=LOCAL\\azookey_server",
         );
         write_crash_trace_file(
             LAUNCHER_CRASH_TRACE_FILE_NAME,
@@ -1915,9 +1915,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "server_startup",
             "server_listening",
             "completed",
-            &format!("server_pid={};pipe=azookey_server", std::process::id()),
+            &format!(
+                "server_pid={};pipe=LOCAL\\azookey_server",
+                std::process::id()
+            ),
         );
-    });
+    })?;
 
     Server::builder()
         .add_service(AzookeyServiceServer::new(service))

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -12,7 +12,12 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58.0", features = ["Win32_Storage_FileSystem", "Win32_System_Threading"] }
+windows = { version = "0.58.0", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 tempfile = "3.14.0"

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -12,6 +12,60 @@ pub mod proto {
         tonic::include_file_descriptor_set!("azookey_service_descriptor");
 }
 
+// The LOCAL prefix gives packaged/AppContainer clients a logon-session-scoped
+// named-pipe namespace. Keep these paths centralized so every process uses the
+// same session-local endpoint.
+pub const SERVER_PIPE_PATH: &str = r"\\.\pipe\LOCAL\azookey_server";
+pub const UI_PIPE_PATH: &str = r"\\.\pipe\LOCAL\azookey_ui";
+
+#[cfg(windows)]
+pub fn open_named_pipe_client_handle(
+    pipe_path: &str,
+) -> io::Result<std::os::windows::io::OwnedHandle> {
+    use std::os::windows::io::{FromRawHandle, OwnedHandle};
+    use windows::{
+        core::PCWSTR,
+        Win32::{
+            Foundation::HANDLE,
+            Storage::FileSystem::{
+                CreateFileW, FILE_FLAG_OVERLAPPED, FILE_READ_DATA, FILE_SHARE_MODE,
+                FILE_WRITE_DATA, OPEN_EXISTING, SECURITY_IDENTIFICATION, SECURITY_SQOS_PRESENT,
+                SYNCHRONIZE,
+            },
+        },
+    };
+
+    let pipe_path_wide = pipe_path.encode_utf16().chain(Some(0)).collect::<Vec<_>>();
+    let desired_access = (FILE_READ_DATA | FILE_WRITE_DATA | SYNCHRONIZE).0;
+    let flags = FILE_FLAG_OVERLAPPED | SECURITY_IDENTIFICATION | SECURITY_SQOS_PRESENT;
+    let handle = unsafe {
+        CreateFileW(
+            PCWSTR(pipe_path_wide.as_ptr()),
+            desired_access,
+            FILE_SHARE_MODE(0),
+            None,
+            OPEN_EXISTING,
+            flags,
+            HANDLE::default(),
+        )
+    }
+    .map_err(|_| io::Error::last_os_error())?;
+
+    Ok(unsafe { OwnedHandle::from_raw_handle(handle.0) })
+}
+
+#[cfg(test)]
+mod pipe_path_tests {
+    use super::{SERVER_PIPE_PATH, UI_PIPE_PATH};
+
+    #[test]
+    fn ipc_pipe_paths_use_the_logon_session_local_namespace() {
+        assert_eq!(SERVER_PIPE_PATH, r"\\.\pipe\LOCAL\azookey_server");
+        assert_eq!(UI_PIPE_PATH, r"\\.\pipe\LOCAL\azookey_ui");
+        assert_ne!(SERVER_PIPE_PATH, UI_PIPE_PATH);
+    }
+}
+
 /// Enables RedirectionGuard before a privileged process reads or writes data
 /// below user-writable directories. The policy blocks traversal through
 /// junctions and symbolic links created by non-administrators.

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -6,7 +6,7 @@ use azookey_server::TonicNamedPipeServer;
 use ipc::{WindowAction, WindowController, WindowService};
 use shared::{
     proto::window_service_server::WindowServiceServer,
-    LIVE_CONVERSION_READING_VERTICAL_ADJUSTMENT_DEFAULT,
+    LIVE_CONVERSION_READING_VERTICAL_ADJUSTMENT_DEFAULT, UI_PIPE_PATH,
 };
 use tao::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 use tao::platform::windows::{EventLoopBuilderExtWindows, WindowExtWindows};
@@ -355,11 +355,12 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // start grpc server
+    let incoming = TonicNamedPipeServer::new(UI_PIPE_PATH)?;
     tokio::spawn(async move {
         println!("WindowServer listening");
         Server::builder()
             .add_service(WindowServiceServer::new(grpc_service))
-            .serve_with_incoming(TonicNamedPipeServer::new("azookey_ui"))
+            .serve_with_incoming(incoming)
             .await
             .expect("gRPC server failed");
     });

--- a/frontend/src-tauri/src/ipc.rs
+++ b/frontend/src-tauri/src/ipc.rs
@@ -2,16 +2,21 @@ use anyhow::Result;
 use hyper_util::rt::TokioIo;
 use shared::proto::azookey_service_client::AzookeyServiceClient;
 use std::{
+    os::windows::io::IntoRawHandle,
     sync::Arc,
     time::{Duration, Instant},
 };
-use tokio::{net::windows::named_pipe::ClientOptions, time};
+use tokio::{net::windows::named_pipe::NamedPipeClient, time};
 use tonic::transport::Endpoint;
 use tower::service_fn;
 use windows::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, ERROR_PIPE_BUSY};
 
-const SERVER_PIPE_PATH: &str = r"\\.\pipe\azookey_server";
 const IPC_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+fn open_named_pipe_client(pipe_name: &str) -> std::io::Result<NamedPipeClient> {
+    let handle = shared::open_named_pipe_client_handle(pipe_name)?;
+    unsafe { NamedPipeClient::from_raw_handle(handle.into_raw_handle()) }
+}
 
 // connect to kkc server
 #[derive(Debug, Clone)]
@@ -53,7 +58,7 @@ impl IPCService {
                 move |_| async move {
                     let started_at = Instant::now();
                     let client = loop {
-                        match ClientOptions::new().open(SERVER_PIPE_PATH) {
+                        match open_named_pipe_client(shared::SERVER_PIPE_PATH) {
                             Ok(client) => break client,
                             Err(e)
                                 if should_retry_pipe_connect_error(


### PR DESCRIPTION
## Summary
- server/UI の named pipe を login session ごとの `LOCAL\` namespace と logon SID ACL に結び付けました。
- AppContainer/Restricted Code には接続に必要な data read/write + synchronize のみを許可し、pipe instance 作成権限を除外しました。
- 通常 client も individual access rights で pipe を開き、ACL・session-local path・first-instance の回帰 test を追加しました。

## Background
- Issue: #139
- Issue close: 対象リリース公開・成果物確認後
- 従来は固定 pipe 名に対して Builtin Users へ Generic All を許可していたため、別ユーザーや別 logon session から server/UI RPC へ到達できる余地がありました。
- Microsoft の [named pipe security guidance](https://learn.microsoft.com/en-us/windows/win32/ipc/named-pipe-security-and-access-rights) と [packaged app IPC guidance](https://learn.microsoft.com/en-us/windows/apps/develop/communication/interprocess-communication) に合わせ、logon SID と `LOCAL\` namespace の両方で境界を作ります。

## Changes
- shared IPC path: server/UI の完全な pipe path を共有定数化し、`\\.\pipe\LOCAL\...` に変更
- server/UI DACL: `BU` / `BA` を除去し、network logon を deny、current `TokenLogonSid` と AppContainer/Restricted Code を明示許可
- least privilege: AppContainer/Restricted Code と client open を `FILE_READ_DATA | FILE_WRITE_DATA | SYNCHRONIZE` に限定し、`FILE_CREATE_PIPE_INSTANCE` を許可しない構成へ変更
- server lifecycle: security descriptor を全 pipe instance の lifetime 中保持し、既存の first-pipe-instance 保護を維持
- tests: path/SDDL、NETWORK token 拒否、same-logon client 接続、first-instance 再作成拒否を追加

### Security boundary / compatibility
- 別 logon SID、別 login session、NETWORK token を今回の拒否境界とします。同一 login の full-trust process は同一ユーザー trust boundary に残り、後続 server instance を作る権限も持ちます。
- IME DLL は任意の入力先 application/package に load されるため package allowlist は採用せず、AppContainer/Restricted Code 側は接続用 individual rights のみに制限しました。
- pipe 名が変わるため、更新前 DLL を load 済みの host は application の再起動または Windows 再起動後に新しい endpoint を使用します。installer は DLL replacement が保留される場合に再起動を案内します。

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/29936929025
- [x] Windows VM build 成功
  - artifact: `azookey-setup-fix_139-session-bound-pipes-20260722-233717.exe`
- [x] Windows test / static checks
  - Windows target: affected 5 packages の `cargo check` 成功
  - server test target: `cargo check -p azookey-server --tests` 成功
  - shared: 16 tests 成功
  - server Windows test: SDDL test 成功、SSH/NETWORK token からの production pipe open が `ERROR_ACCESS_DENIED` になることを確認
- [x] Windows 実機確認
  - installer: 現行 `scripts/vm_stage_for_manual_test.sh` で silent install と必須 file/task/process 検証に成功
  - Notepad: AzooKey DLL load と `aiueo` → `あいうえお` の入力を確認
  - Windows Search: `TokenIsAppContainer=true` の SearchHost 上で検索 UI を開き、`あいうえお` の入力・検索結果表示を確認
  - 別 logon: 独立 batch logon SID (`S-1-5-5-...`) から server/UI の両 pipe が接続拒否されることを確認
  - NETWORK logon: SSH token から server/UI の両 pipe が接続拒否されることを確認
  - VM は検証後に clean snapshot へ復元済み

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->