### PR TITLE
fix: minimize DLL lifecycle callbacks

### DIFF
--- a/crates/client/src/globals.rs
+++ b/crates/client/src/globals.rs
@@ -1,10 +1,13 @@
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    mpsc::Sender,
-    Arc, Mutex, MutexGuard, OnceLock,
+use std::{
+    ffi::c_void,
+    ptr,
+    sync::{
+        atomic::{AtomicPtr, AtomicUsize, Ordering},
+        Arc, Mutex, MutexGuard, OnceLock,
+    },
 };
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use windows::{
     core::GUID,
@@ -56,7 +59,8 @@ pub const DISPLAY_ATTRIBUTE: TF_DISPLAYATTRIBUTE = TF_DISPLAYATTRIBUTE {
 // You can use any value for this cookie.
 pub const TEXTSERVICE_LANGBARITEMSINK_COOKIE: u32 = 0;
 
-pub static DLL_INSTANCE: OnceLock<Mutex<DllModule>> = OnceLock::new();
+static DLL_MODULE_HANDLE: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+static DLL_INSTANCE: OnceLock<Mutex<DllModule>> = OnceLock::new();
 
 unsafe impl Sync for DllModule {}
 unsafe impl Send for DllModule {}
@@ -64,20 +68,36 @@ unsafe impl Send for DllModule {}
 #[derive(Debug)]
 pub struct DllModule {
     pub ref_count: Arc<AtomicUsize>,
-    pub hinst: Option<HMODULE>,
-    pub sender: Option<Sender<bool>>,
 }
 
 impl DllModule {
     pub fn new() -> Self {
         Self {
             ref_count: Arc::new(AtomicUsize::new(0)),
-            hinst: None,
-            sender: None,
         }
     }
 
+    pub fn set_module_handle(hinst: HMODULE) {
+        DLL_MODULE_HANDLE.store(hinst.0, Ordering::Release);
+    }
+
+    pub fn module_handle() -> Result<HMODULE> {
+        let handle = DLL_MODULE_HANDLE.load(Ordering::Acquire);
+        if handle.is_null() {
+            Err(anyhow::anyhow!("Dll module handle is not initialized"))
+        } else {
+            Ok(HMODULE(handle))
+        }
+    }
+
+    pub fn initialize() -> Result<()> {
+        Self::module_handle()?;
+        DLL_INSTANCE.get_or_init(|| Mutex::new(DllModule::new()));
+        Ok(())
+    }
+
     pub fn get() -> Result<MutexGuard<'static, DllModule>> {
+        Self::initialize()?;
         DLL_INSTANCE
             .get()
             .ok_or_else(|| anyhow::anyhow!("DllModule is not initialized"))?
@@ -87,12 +107,8 @@ impl DllModule {
 
     pub fn get_path() -> anyhow::Result<String> {
         let path = {
-            let dll_instance = DllModule::get()?.hinst;
-
             let mut buffer: [u16; MAX_PATH as usize] = [0; MAX_PATH as usize];
-            let length = unsafe {
-                GetModuleFileNameW(dll_instance.context("Dll instance not found")?, &mut buffer)
-            };
+            let length = unsafe { GetModuleFileNameW(Self::module_handle()?, &mut buffer) };
 
             String::from_utf16_lossy(&buffer[..length as usize])
         };

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -7,19 +7,18 @@ mod trace;
 mod tracing_chrome;
 mod tsf;
 
-use std::{ffi::c_void, sync::Mutex};
+use std::ffi::c_void;
 
-use globals::{DllModule, DLL_INSTANCE, GUID_TEXT_SERVICE};
+use globals::{DllModule, GUID_TEXT_SERVICE};
 use register::{CLSIDMgr, CategoryMgr, ProfileMgr};
 use tsf::factory::TextServiceFactory;
 use windows::{
     core::{IUnknown, Interface as _, GUID, HRESULT},
     Win32::{
-        Foundation::{CLASS_E_CLASSNOTAVAILABLE, E_FAIL, E_UNEXPECTED, HMODULE, S_FALSE, S_OK},
+        Foundation::{CLASS_E_CLASSNOTAVAILABLE, E_UNEXPECTED, HMODULE, S_FALSE},
         System::{
-            Com::IClassFactory,
-            Ole::SELFREG_E_CLASS,
-            SystemServices::{DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH},
+            Com::IClassFactory, LibraryLoader::DisableThreadLibraryCalls, Ole::SELFREG_E_CLASS,
+            SystemServices::DLL_PROCESS_ATTACH,
         },
     },
 };
@@ -33,41 +32,16 @@ pub extern "system" fn DllMain(
     _lpv_reserved: *mut c_void,
 ) -> bool {
     if fdw_reason == DLL_PROCESS_ATTACH {
-        let result: anyhow::Result<()> = (|| {
-            let mut dll_instance = DllModule::new();
-            dll_instance.hinst = Some(hinst);
-            DLL_INSTANCE
-                .set(Mutex::new(dll_instance))
-                .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))?;
-            Ok(())
-        })();
-
-        // use unwrap only in this function
-        std::thread::spawn(|| {
-            trace::setup_logger().unwrap();
-        });
-
-        tracing::debug!("DllMain");
-
-        check_err!(result, true, false)
-    } else if fdw_reason == DLL_PROCESS_DETACH {
-        tracing::debug!("DLL_PROCESS_DETACH");
-
-        let result: anyhow::Result<()> = (|| {
-            let mut dll_instance = DllModule::get()?;
-            dll_instance.hinst = None;
-            // send a signal to the tracing writer thread to exit
-            if let Some(sender) = dll_instance.sender.take() {
-                sender.send(true).unwrap();
-            }
-
-            Ok(())
-        })();
-
-        check_err!(result, true, false)
-    } else {
-        return true;
+        DllModule::set_module_handle(hinst);
+        // This may fail when static TLS is active. Thread notifications are
+        // already no-ops, so failure does not affect correctness.
+        let _ = unsafe { DisableThreadLibraryCalls(hinst) };
     }
+
+    // Process detach is deliberately a no-op. Cleanup that can lock, allocate,
+    // or panic must never run while the loader lock is held.
+
+    true
 }
 
 #[no_mangle]
@@ -85,6 +59,7 @@ pub unsafe extern "system" fn DllGetClassObject(
     tracing::debug!("DllGetClassObject");
 
     let result: anyhow::Result<()> = (|| {
+        DllModule::initialize()?;
         let rclsid = unsafe { *rclsid };
         let riid = unsafe { *riid };
         let ppv = unsafe { &mut *ppv };

--- a/crates/client/src/trace.rs
+++ b/crates/client/src/trace.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write as _;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use tracing::field::{Field, Visit};
 use tracing_core::LevelFilter;
 use tracing_subscriber::filter::Targets;
@@ -7,8 +8,9 @@ use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt};
 use windows::{core::PCWSTR, Win32::System::Diagnostics::Debug::OutputDebugStringW};
 
 use crate::extension::StringExt as _;
-use crate::globals::DllModule;
 use crate::tracing_chrome::{ChromeLayerBuilder, EventOrSpan};
+
+static LOGGER_INIT_RESULT: OnceLock<Result<(), String>> = OnceLock::new();
 
 pub struct StringVisitor<'a> {
     string: &'a mut String,
@@ -37,7 +39,24 @@ fn resolve_trace_log_folder() -> PathBuf {
         .join("logs")
 }
 
-pub fn setup_logger() -> anyhow::Result<()> {
+pub fn initialize_logger() {
+    if let Err(error) =
+        LOGGER_INIT_RESULT.get_or_init(|| contain_logger_initialization(setup_logger))
+    {
+        diagnostic_log(format!("logger initialization disabled: {error}"));
+    }
+}
+
+fn contain_logger_initialization(
+    initializer: impl FnOnce() -> anyhow::Result<()>,
+) -> Result<(), String> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(initializer)) {
+        Ok(result) => result.map_err(|error| error.to_string()),
+        Err(_) => Err("logger initialization panicked".to_string()),
+    }
+}
+
+fn setup_logger() -> anyhow::Result<()> {
     diagnostic_log("setup_logger called");
     #[cfg(not(debug_assertions))]
     {
@@ -88,9 +107,7 @@ pub fn setup_logger() -> anyhow::Result<()> {
             EventOrSpan::Span(span) => span.metadata().name().to_string(),
         }));
 
-    let (chrome_layer, sender) = builder.build();
-
-    DllModule::get()?.sender = Some(sender);
+    let chrome_layer = builder.build();
 
     // ignore traces from other crates
     let filter = Targets::new()
@@ -100,7 +117,27 @@ pub fn setup_logger() -> anyhow::Result<()> {
     tracing_subscriber::registry()
         .with(filter)
         .with(chrome_layer)
-        .init();
+        .try_init()
+        .map_err(|error| anyhow::anyhow!(error.to_string()))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::contain_logger_initialization;
+
+    #[test]
+    fn logger_initialization_error_is_contained() {
+        let result = contain_logger_initialization(|| anyhow::bail!("expected failure"));
+
+        assert_eq!(result, Err("expected failure".to_string()));
+    }
+
+    #[test]
+    fn logger_initialization_panic_is_contained() {
+        let result = contain_logger_initialization(|| panic!("expected panic"));
+
+        assert_eq!(result, Err("logger initialization panicked".to_string()));
+    }
 }

--- a/crates/client/src/tracing_chrome.rs
+++ b/crates/client/src/tracing_chrome.rs
@@ -15,7 +15,7 @@ use std::{
     fs::File,
     io::{Seek, Write},
     marker::PhantomData,
-    sync::{mpsc::Sender, Arc, Mutex},
+    sync::{Arc, Mutex},
 };
 
 type NameFn<S> = Box<dyn Fn(&EventOrSpan<'_, '_, S>) -> String + Send + Sync>;
@@ -116,32 +116,10 @@ where
     }
 
     /// Set the file to which to output the trace.
-    ///
-    /// Defaults to `./trace-{unix epoch in micros}.json`.
-    ///
-    /// # Panics
-    ///
-    /// If `file` could not be opened/created. To handle errors,
-    /// open a file and pass it to [`writer`](crate::ChromeLayerBuilder::writer) instead.
     pub fn file(mut self, file: File) -> Self {
         self.out_writer = Some(file);
         self
     }
-
-    /// Supply an arbitrary writer to which to write trace contents.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use tracing_chrome::ChromeLayerBuilder;
-    /// # use tracing_subscriber::prelude::*;
-    /// let (layer, guard) = ChromeLayerBuilder::new().writer(std::io::sink()).build();
-    /// # tracing_subscriber::registry().with(layer).init();
-    /// ```
-    // pub fn writer<W: Write + Send + 'static>(mut self, writer: W) -> Self {
-    //     self.out_writer = Some();
-    //     self
-    // }
 
     /// Include arguments in each trace entry.
     ///
@@ -170,25 +148,9 @@ where
         self
     }
 
-    pub fn build(self) -> (ChromeLayer<S>, Sender<bool>) {
+    pub fn build(self) -> ChromeLayer<S> {
         let writer = self.out_writer.unwrap();
-        let writer_rc = Mutex::new(Arc::new(writer.try_clone().unwrap()));
-
-        let (sender, receiver) = std::sync::mpsc::channel();
-
-        std::thread::spawn(move || {
-            while let Ok(_) = receiver.recv() {
-                let writer = writer_rc.lock().unwrap();
-                let trace = ChromeTrace::new();
-                trace
-                    .write_entries(&mut writer.try_clone().unwrap())
-                    .unwrap();
-
-                break;
-            }
-        });
-
-        let layer = ChromeLayer {
+        ChromeLayer {
             writer: Mutex::new(writer),
             trace: ChromeTrace::new(),
             start: std::time::Instant::now(),
@@ -197,9 +159,7 @@ where
             include_args: self.include_args,
             include_locations: self.include_locations,
             _inner: PhantomData,
-        };
-
-        (layer, sender)
+        }
     }
 }
 

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -198,7 +198,6 @@ impl ITfLangBarItemButton_Impl for TextServiceFactory_Impl {
 
     #[macros::anyhow]
     fn GetIcon(&self) -> Result<HICON> {
-        let dll_module = DllModule::get()?;
         let keyboard_disabled = IMEState::keyboard_disabled()?;
         let input_mode = if keyboard_disabled {
             InputMode::Latin
@@ -226,7 +225,7 @@ impl ITfLangBarItemButton_Impl for TextServiceFactory_Impl {
 
         unsafe {
             let handle = LoadImageW(
-                dll_module.hinst.context("Dll instance not found")?,
+                DllModule::module_handle()?,
                 PCWSTR(icon_id as *mut u16),
                 IMAGE_ICON,
                 0,
@@ -392,8 +391,7 @@ unsafe extern "system" fn menu_owner_window_proc(
 }
 
 fn create_menu_owner_window() -> Result<MenuOwnerWindow> {
-    let dll_module = DllModule::get()?;
-    let hmodule = dll_module.hinst.context("Dll instance not found")?;
+    let hmodule = DllModule::module_handle()?;
     let hinstance = HINSTANCE(hmodule.0);
 
     unsafe {

--- a/crates/client/src/tsf/text_input_proccesor.rs
+++ b/crates/client/src/tsf/text_input_proccesor.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::{
     engine::{composition::CapsLockKeyboardLayout, state::IMEState},
     globals::{DllModule, GUID_DISPLAY_ATTRIBUTE, GUID_PRESERVED_KEY_EISU_CAPSLOCK_ANY_MODIFIER},
+    trace,
 };
 
 use super::factory::{TextServiceFactory, TextServiceFactory_Impl};
@@ -26,6 +27,10 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
     #[macros::anyhow]
     #[tracing::instrument]
     fn Activate(&self, ptim: Option<&ITfThreadMgr>, tid: u32) -> Result<()> {
+        // Logger setup may allocate and touch the file system, so it must run
+        // after DllMain has returned. Initialization failure is intentionally
+        // contained and must not prevent the text service from activating.
+        trace::initialize_logger();
         tracing::debug!("Activated with tid: {tid}");
 
         // add reference to the dll instance to prevent it from being unloaded

--- a/scripts/test_client_dll_lifecycle.ps1
+++ b/scripts/test_client_dll_lifecycle.ps1
@@ -1,0 +1,83 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DllPath,
+
+    [ValidateRange(1, 100000)]
+    [int]$Iterations = 1000
+)
+
+$ErrorActionPreference = "Stop"
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class NativeLibraryLifecycle
+{
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
+    public static extern IntPtr LoadLibraryW(string fileName);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
+    public static extern IntPtr GetProcAddress(IntPtr module, string procedureName);
+
+    [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool FreeLibrary(IntPtr module);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+    public static extern IntPtr GetModuleHandleW(string moduleName);
+}
+"@
+
+$resolvedDllPath = (Resolve-Path -LiteralPath $DllPath).Path
+$moduleName = [IO.Path]::GetFileName($resolvedDllPath)
+
+$stream = [IO.File]::OpenRead($resolvedDllPath)
+try {
+    $reader = [IO.BinaryReader]::new($stream)
+    $stream.Position = 0x3c
+    $peHeaderOffset = $reader.ReadInt32()
+    $stream.Position = $peHeaderOffset + 4
+    $machine = $reader.ReadUInt16()
+}
+finally {
+    $stream.Dispose()
+}
+
+$expectedMachine = if ([Environment]::Is64BitProcess) { 0x8664 } else { 0x014c }
+if ($machine -ne $expectedMachine) {
+    $processArchitecture = if ([Environment]::Is64BitProcess) { "x64" } else { "x86" }
+    throw "DLL architecture does not match the $processArchitecture PowerShell process"
+}
+
+if ([NativeLibraryLifecycle]::GetModuleHandleW($moduleName) -ne [IntPtr]::Zero) {
+    throw "$moduleName is already loaded; run this test in a clean PowerShell process"
+}
+
+for ($iteration = 1; $iteration -le $Iterations; $iteration++) {
+    $module = [NativeLibraryLifecycle]::LoadLibraryW($resolvedDllPath)
+    if ($module -eq [IntPtr]::Zero) {
+        $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        throw "LoadLibraryW failed at iteration $iteration with Win32 error $errorCode"
+    }
+
+    try {
+        $entryPoint = [NativeLibraryLifecycle]::GetProcAddress($module, "DllCanUnloadNow")
+        if ($entryPoint -eq [IntPtr]::Zero) {
+            $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+            throw "DllCanUnloadNow was not exported at iteration $iteration (Win32 error $errorCode)"
+        }
+    }
+    finally {
+        if (-not [NativeLibraryLifecycle]::FreeLibrary($module)) {
+            $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+            throw "FreeLibrary failed at iteration $iteration with Win32 error $errorCode"
+        }
+    }
+
+    if ([NativeLibraryLifecycle]::GetModuleHandleW($moduleName) -ne [IntPtr]::Zero) {
+        throw "$moduleName remained loaded after iteration $iteration"
+    }
+}
+
+Write-Host "PASS: loaded and unloaded $resolvedDllPath $Iterations times"


### PR DESCRIPTION
## Summary
- `DllMain` を module handle の保存と best-effort の `DisableThreadLibraryCalls` のみに縮小しました。
- logger 初期化を TSF activation 後へ遅延し、失敗・panic を host process へ伝播させない idempotent な処理に変更しました。
- x64/x86 DLL の load/export確認/unload を繰り返す lifecycle stress test を追加しました。

## Background
- Issue: #143
- Issue close: 対象リリース公開・成果物確認後
- IME DLL は多数の host process に読み込まれます。従来は loader lock 下の `DllMain` から thread を生成し、detach 時に mutex/channel/panic 可能な後始末を行っていたため、deadlock や host 起動失敗につながる余地がありました。

## Changes
- DLL lifecycle: `DllMain` では pointer-sized atomic への `HMODULE` 保存と `DisableThreadLibraryCalls` だけを実行し、detach は no-op に変更
- module state: `DllModule` の mutex/`Arc` 初期化を COM entry point 後へ遅延し、resource lookup は atomic に保存した module handle を使用
- logger: TSF `Activate` 時の一度だけの初期化へ移動し、`catch_unwind`、`try_init`、失敗結果の保存によって activation から失敗を分離
- trace writer: event ごとの同期書き込みを維持しつつ、detach signal 専用の background thread/channel を削除
- tests: logger error/panic containment の unit test と、architecture照合・実 unload 確認を含む `scripts/test_client_dll_lifecycle.ps1` を追加

### Lifecycle boundary
- process termination と explicit `FreeLibrary` のどちらでも loader lock 下の cleanup は行いません。現在の COM lifecycle は `DllCanUnloadNow == S_FALSE` であり、activation 後の resource は process termination 時に OS が回収します。
- 将来 `DllCanUnloadNow` を `S_OK` にする場合は、loader lock 外の明示的 shutdown と worker/resource lifetime の再設計を別途行う必要があります。
- `DisableThreadLibraryCalls` は static TLS により失敗し得るため best-effort とし、thread notification が no-op である現状の correctness は戻り値に依存しません。

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/29942279339
- [x] Windows VM build 成功
  - artifact: `azookey-setup-fix_143-minimal-dllmain-20260723-012624.exe`
- [x] Windows test / static checks
  - x64/x86 Windows target: `cargo check -p azookey-windows --tests` 成功
  - logger failure containment: Windows VM で error/panic fault injection の2件成功 (`2 passed; 0 failed`)
  - lifecycle stress: architecture-matched PowerShell から x64/x86 DLL を各1,000回 load/export確認/unloadし、各 iteration 後の module 不在を確認
  - static: `cargo fmt --all --check`、`git diff --check`、PowerShell parser 成功
- [x] Windows 実機確認
  - installer: clean snapshot から現行 `scripts/vm_stage_for_manual_test.sh` で silent install と必須 file/task/process 検証に成功
  - Notepad: `azookey.dll` load と `あいうえお` composition・候補 UI を確認
  - Windows Search: session 1 の SearchHost が稼働する検索 UI で `あいうえお` の入力・検索結果表示を確認
  - Microsoft Edge: `msedge.exe` への `azookey.dll` load と address bar の `あいうえお` composition・候補 UI を確認
  - VM cleanup: 検証後に clean snapshot へ復元済み

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
