### PR TITLE
Add deadline-based IPC recovery for input hot path

### DIFF
--- a/crates/client/src/engine/client_action.rs
+++ b/crates/client/src/engine/client_action.rs
@@ -1,6 +1,6 @@
 use super::input_mode::InputMode;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ClientAction {
     StartComposition,
     EndComposition,
@@ -33,7 +33,7 @@ pub enum ClientAction {
     SetIMEMode(InputMode),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum SetSelectionType {
     Up,
     Down,

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -68,6 +68,20 @@ fn deferred_action_suffix(
     actions.get(failed_index..).unwrap_or_default().to_vec()
 }
 
+fn has_same_com_identity(left: &ITfComposition, right: &ITfComposition) -> bool {
+    match (left.cast::<IUnknown>(), right.cast::<IUnknown>()) {
+        (Ok(left), Ok(right)) => left.as_raw() == right.as_raw(),
+        (Err(left_error), Err(right_error)) => {
+            tracing::warn!(?left_error, ?right_error, "Failed to query COM identities");
+            false
+        }
+        (Err(error), _) | (_, Err(error)) => {
+            tracing::warn!(?error, "Failed to query COM identity");
+            false
+        }
+    }
+}
+
 mod clause_state;
 pub(super) use clause_state::{
     CandidateSelection, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut,
@@ -4490,7 +4504,7 @@ impl TextServiceFactory {
                     .and_then(|composition| composition.tip_composition.clone())
             })
             .zip(terminated.cloned())
-            .is_some_and(|(current, terminated)| current.as_raw() == terminated.as_raw());
+            .is_some_and(|(current, terminated)| has_same_com_identity(&current, &terminated));
         if !is_current {
             tracing::debug!("Ignore termination callback for a stale TSF composition");
             return;
@@ -4738,14 +4752,7 @@ impl TextServiceFactory {
                 }
 
                 let recovered = ipc_service
-                    .recover_composition_if_needed(
-                        if raw_hiragana.is_empty() {
-                            &raw_input
-                        } else {
-                            &raw_hiragana
-                        },
-                        !raw_hiragana.is_empty(),
-                    )?
+                    .recover_composition_if_needed(&raw_input, &raw_hiragana)?
                     .context("IPC recovery unexpectedly produced no composition")?;
                 tracing::warn!(
                     raw_input_len = raw_input.chars().count(),

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashSet, VecDeque},
     rc::Rc,
     time::{Duration, Instant},
 };
@@ -19,8 +19,9 @@ use super::{
     full_width::{convert_kana_symbol, to_fullwidth, to_halfwidth},
     input_mode::InputMode,
     ipc_service::{
-        client_performance_log_enabled, current_input_trace_request_id, Candidates,
-        ClientInputTraceGuard, IPCService, WindowRpcDelivery,
+        client_performance_log_enabled, current_input_trace_request_id,
+        is_non_destructive_ipc_error, Candidates, ClientInputTraceGuard, IPCService,
+        WindowRpcDelivery,
     },
     romaji_lookup::RomajiLookup,
     state::{keyboard_disabled_from_context, AppConfigSnapshot, IMEState},
@@ -59,6 +60,13 @@ const VK_TRANSLATED_CAPSLOCK_KEY_CODE: usize = 0xF0;
 const CAPSLOCK_SCAN_CODE: isize = 0x3A;
 const KEYBOARD_TYPE_ENHANCED_101_OR_102: i32 = 0x4;
 const KEYBOARD_TYPE_JAPANESE: i32 = 0x7;
+
+fn deferred_action_suffix(
+    actions: &[DeferredClientAction],
+    failed_index: usize,
+) -> Vec<DeferredClientAction> {
+    actions.get(failed_index..).unwrap_or_default().to_vec()
+}
 
 mod clause_state;
 pub(super) use clause_state::{
@@ -127,6 +135,42 @@ pub struct Composition {
     pub temporary_latin: bool,
     pub temporary_latin_shift_pending: bool,
     pub tip_composition: Option<ITfComposition>,
+    deferred_actions: Vec<DeferredClientAction>,
+    deferred_inputs: VecDeque<DeferredInputEvent>,
+    deferred_projection: Option<DeferredProjection>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct DeferredClientAction {
+    action: ClientAction,
+    transition: CompositionState,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct DeferredUserAction {
+    action: UserAction,
+    is_shift_pressed: bool,
+    is_shift_key: bool,
+    shift_alphabet_shortcut: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum DeferredInputEvent {
+    User {
+        input: DeferredUserAction,
+        fallback: Vec<DeferredClientAction>,
+    },
+    Actions(Vec<DeferredClientAction>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct DeferredProjection {
+    mode: InputMode,
+    state: CompositionState,
+    raw_input: String,
+    temporary_latin: bool,
+    temporary_latin_shift_pending: bool,
+    reliable: bool,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -186,13 +230,12 @@ impl ITfCompositionSink_Impl for TextServiceFactory_Impl {
     fn OnCompositionTerminated(
         &self,
         _ecwrite: u32,
-        _pcomposition: Option<&ITfComposition>,
+        pcomposition: Option<&ITfComposition>,
     ) -> Result<()> {
         // if user clicked outside the composition, the composition will be terminated
         tracing::debug!("OnCompositionTerminated");
 
-        let actions = vec![ClientAction::EndComposition];
-        self.handle_action(&actions, CompositionState::None)?;
+        self.handle_external_composition_terminated(pcomposition);
 
         Ok(())
     }
@@ -3627,6 +3670,202 @@ impl TextServiceFactory {
         result
     }
 
+    fn plan_deferred_user_action(
+        composition: &Composition,
+        deferred: &DeferredUserAction,
+        mode: &InputMode,
+        app_config: &AppConfig,
+        romaji_lookup: &RomajiLookup,
+    ) -> Option<(CompositionState, Vec<ClientAction>)> {
+        let start_temporary_latin = !composition.temporary_latin
+            && *mode == InputMode::Kana
+            && deferred.shift_alphabet_shortcut;
+        let (transition, mut actions) = Self::plan_actions_for_user_action_with_lookup(
+            composition,
+            &deferred.action,
+            mode,
+            deferred.is_shift_pressed,
+            app_config,
+            romaji_lookup,
+            start_temporary_latin,
+        )?;
+
+        if composition.temporary_latin {
+            let should_reset_on_confirm = matches!(
+                deferred.action,
+                UserAction::Enter | UserAction::CommitAndNextClause | UserAction::CommitFirstClause
+            );
+            let should_reset_on_end = transition == CompositionState::None
+                || actions.iter().any(|action| {
+                    matches!(
+                        action,
+                        ClientAction::EndComposition | ClientAction::SetIMEMode(_)
+                    )
+                });
+
+            if (should_reset_on_confirm || should_reset_on_end)
+                && !actions
+                    .iter()
+                    .any(|action| matches!(action, ClientAction::SetTemporaryLatin(false)))
+            {
+                actions.insert(0, ClientAction::SetTemporaryLatin(false));
+            }
+        }
+
+        if composition.temporary_latin_shift_pending
+            && !deferred.is_shift_key
+            && !actions
+                .iter()
+                .any(|action| matches!(action, ClientAction::SetTemporaryLatinShiftPending(_)))
+        {
+            actions.insert(0, ClientAction::SetTemporaryLatinShiftPending(false));
+        }
+
+        Some((transition, actions))
+    }
+
+    fn apply_actions_to_deferred_projection(
+        projection: &mut DeferredProjection,
+        actions: &[DeferredClientAction],
+    ) {
+        for deferred in actions {
+            projection.state = deferred.transition.clone();
+            match &deferred.action {
+                ClientAction::AppendText(text)
+                | ClientAction::AppendTextRaw(text)
+                | ClientAction::AppendTextDirect(text) => projection.raw_input.push_str(text),
+                ClientAction::RemoveText => {
+                    projection.raw_input.pop();
+                }
+                ClientAction::ShrinkText(text)
+                | ClientAction::ShrinkTextRaw(text)
+                | ClientAction::ShrinkTextDirect(text) => {
+                    projection.raw_input = text.clone();
+                    projection.reliable = false;
+                }
+                ClientAction::EnsureClauseNavigationReady
+                | ClientAction::MoveClause(_)
+                | ClientAction::AdjustBoundary(_)
+                | ClientAction::SetSelection(_)
+                | ClientAction::SetTextWithType(_) => projection.reliable = false,
+                ClientAction::SetIMEMode(mode) => {
+                    projection.mode = mode.clone();
+                    if projection.state == CompositionState::None {
+                        projection.raw_input.clear();
+                        projection.reliable = true;
+                    }
+                }
+                ClientAction::SetTemporaryLatin(value) => projection.temporary_latin = *value,
+                ClientAction::SetTemporaryLatinShiftPending(value) => {
+                    projection.temporary_latin_shift_pending = *value;
+                }
+                ClientAction::EndComposition => {
+                    projection.raw_input.clear();
+                    projection.temporary_latin = false;
+                    projection.temporary_latin_shift_pending = false;
+                    projection.reliable = true;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn deferred_projection(composition: &Composition, mode: InputMode) -> DeferredProjection {
+        if let Some(projection) = composition.deferred_projection.clone() {
+            return projection;
+        }
+        let mut projection = DeferredProjection {
+            mode,
+            state: composition.state.clone(),
+            raw_input: composition.raw_input.clone(),
+            temporary_latin: composition.temporary_latin,
+            temporary_latin_shift_pending: composition.temporary_latin_shift_pending,
+            reliable: true,
+        };
+        Self::apply_actions_to_deferred_projection(&mut projection, &composition.deferred_actions);
+        projection
+    }
+
+    fn enqueue_deferred_user_action(
+        &self,
+        composition: &Composition,
+        input: DeferredUserAction,
+        config_snapshot: &AppConfigSnapshot,
+    ) -> Result<bool> {
+        let mut projection = Self::deferred_projection(composition, IMEState::input_mode()?);
+        let mut projected_composition = composition.clone();
+        projected_composition.state = projection.state.clone();
+        projected_composition.raw_input = projection.raw_input.clone();
+        projected_composition.temporary_latin = projection.temporary_latin;
+        projected_composition.temporary_latin_shift_pending =
+            projection.temporary_latin_shift_pending;
+        projected_composition.deferred_actions.clear();
+        projected_composition.deferred_inputs.clear();
+        projected_composition.deferred_projection = None;
+
+        let mut planned = Self::plan_deferred_user_action(
+            &projected_composition,
+            &input,
+            &projection.mode,
+            config_snapshot.app_config(),
+            config_snapshot.romaji_lookup(),
+        );
+        if planned.is_none() && !projection.reliable {
+            for state in [
+                CompositionState::Composing,
+                CompositionState::Previewing,
+                CompositionState::None,
+            ] {
+                projected_composition.state = state;
+                if let Some(alternative) = Self::plan_deferred_user_action(
+                    &projected_composition,
+                    &input,
+                    &projection.mode,
+                    config_snapshot.app_config(),
+                    config_snapshot.romaji_lookup(),
+                ) {
+                    planned = Some(alternative);
+                    break;
+                }
+            }
+        }
+        let Some((transition, actions)) = planned else {
+            return Ok(false);
+        };
+        let fallback = actions
+            .into_iter()
+            .map(|action| DeferredClientAction {
+                action,
+                transition: transition.clone(),
+            })
+            .collect::<Vec<_>>();
+        Self::apply_actions_to_deferred_projection(&mut projection, &fallback);
+
+        let text_service = self.borrow()?;
+        let mut persisted = text_service.borrow_mut_composition()?;
+        persisted
+            .deferred_inputs
+            .push_back(DeferredInputEvent::User { input, fallback });
+        persisted.deferred_projection = Some(projection);
+        Ok(true)
+    }
+
+    fn enqueue_deferred_actions(
+        &self,
+        composition: &Composition,
+        actions: Vec<DeferredClientAction>,
+    ) -> Result<()> {
+        let mut projection = Self::deferred_projection(composition, IMEState::input_mode()?);
+        Self::apply_actions_to_deferred_projection(&mut projection, &actions);
+        let text_service = self.borrow()?;
+        let mut persisted = text_service.borrow_mut_composition()?;
+        persisted
+            .deferred_inputs
+            .push_back(DeferredInputEvent::Actions(actions));
+        persisted.deferred_projection = Some(projection);
+        Ok(())
+    }
+
     #[tracing::instrument]
     pub fn process_key(
         &self,
@@ -3748,17 +3987,53 @@ impl TextServiceFactory {
             }
 
             #[allow(clippy::let_and_return)]
-            let (composition, mode) = {
+            let (mut composition, mut mode) = {
                 let text_service = self.borrow()?;
                 let composition = text_service.borrow_composition()?.clone();
                 let mode = IMEState::input_mode()?;
                 (composition, mode)
             };
-            let start_temporary_latin = !composition.temporary_latin
-                && mode == InputMode::Kana
-                && Self::is_shift_alphabet_shortcut(wparam, is_shift_pressed);
-
-            if composition.temporary_latin && is_shift_key && !is_shift_left && !is_shift_right {
+            let mut has_deferred_input =
+                !composition.deferred_actions.is_empty() || !composition.deferred_inputs.is_empty();
+            if has_deferred_input {
+                let restart_ready = IMEState::ipc_service()?
+                    .is_some_and(|ipc_service| ipc_service.wait_for_recovery_restart());
+                if restart_ready {
+                    if let Err(error) = self.flush_deferred_user_actions() {
+                        tracing::warn!(
+                            ?error,
+                            "Deferred recovery was not ready before planning the next key"
+                        );
+                    } else {
+                        let text_service = self.borrow()?;
+                        composition = text_service.borrow_composition()?.clone();
+                        mode = IMEState::input_mode()?;
+                        has_deferred_input = !composition.deferred_actions.is_empty()
+                            || !composition.deferred_inputs.is_empty();
+                    }
+                }
+            }
+            let projected =
+                has_deferred_input.then(|| Self::deferred_projection(&composition, mode.clone()));
+            let temporary_latin = projected
+                .as_ref()
+                .map(|projection| projection.temporary_latin)
+                .unwrap_or(composition.temporary_latin);
+            if temporary_latin && is_shift_key && !is_shift_left && !is_shift_right {
+                if let Some(projection) = projected {
+                    self.enqueue_deferred_actions(
+                        &composition,
+                        vec![DeferredClientAction {
+                            action: ClientAction::SetTemporaryLatinShiftPending(true),
+                            transition: projection.state,
+                        }],
+                    )?;
+                    return Ok(Some((
+                        Vec::new(),
+                        composition.state.clone(),
+                        config_snapshot,
+                    )));
+                }
                 return Ok(Some((
                     vec![ClientAction::SetTemporaryLatinShiftPending(true)],
                     composition.state.clone(),
@@ -3785,53 +4060,39 @@ impl TextServiceFactory {
                 UserAction::try_from(wparam.0)?
             };
 
-            let Some((transition, mut actions)) = Self::plan_actions_for_user_action_with_lookup(
-                &composition,
-                &action,
-                &mode,
+            let deferred_user_action = DeferredUserAction {
+                action,
                 is_shift_pressed,
+                is_shift_key,
+                shift_alphabet_shortcut: Self::is_shift_alphabet_shortcut(wparam, is_shift_pressed),
+            };
+
+            if has_deferred_input {
+                if !self.enqueue_deferred_user_action(
+                    &composition,
+                    deferred_user_action,
+                    &config_snapshot,
+                )? {
+                    self.clear_temporary_latin_shift_pending_if_needed(should_clear_shift_pending)?;
+                    return Ok(None);
+                }
+                return Ok(Some((
+                    Vec::new(),
+                    composition.state.clone(),
+                    config_snapshot,
+                )));
+            }
+
+            let Some((transition, actions)) = Self::plan_deferred_user_action(
+                &composition,
+                &deferred_user_action,
+                &mode,
                 app_config,
                 romaji_lookup,
-                start_temporary_latin,
             ) else {
                 self.clear_temporary_latin_shift_pending_if_needed(should_clear_shift_pending)?;
                 return Ok(None);
             };
-
-            if composition.temporary_latin {
-                let should_reset_on_confirm = matches!(
-                    action,
-                    UserAction::Enter
-                        | UserAction::CommitAndNextClause
-                        | UserAction::CommitFirstClause
-                );
-                let should_reset_on_end = transition == CompositionState::None
-                    || actions.iter().any(|current_action| {
-                        matches!(
-                            current_action,
-                            ClientAction::EndComposition | ClientAction::SetIMEMode(_)
-                        )
-                    });
-
-                if (should_reset_on_confirm || should_reset_on_end)
-                    && !actions.iter().any(|current_action| {
-                        matches!(current_action, ClientAction::SetTemporaryLatin(false))
-                    })
-                {
-                    actions.insert(0, ClientAction::SetTemporaryLatin(false));
-                }
-            }
-
-            if should_clear_shift_pending
-                && !actions.iter().any(|current_action| {
-                    matches!(
-                        current_action,
-                        ClientAction::SetTemporaryLatinShiftPending(_)
-                    )
-                })
-            {
-                actions.insert(0, ClientAction::SetTemporaryLatinShiftPending(false));
-            }
 
             if !Self::ensure_ipc_service_for_key_event("process_key") {
                 return Ok(None);
@@ -3889,6 +4150,28 @@ impl TextServiceFactory {
             composition
         };
 
+        if !composition.deferred_actions.is_empty() || !composition.deferred_inputs.is_empty() {
+            let projection = Self::deferred_projection(&composition, IMEState::input_mode()?);
+            if !projection.temporary_latin_shift_pending {
+                return Ok(None);
+            }
+            let mut actions = vec![ClientAction::SetTemporaryLatinShiftPending(false)];
+            if projection.temporary_latin {
+                actions.insert(0, ClientAction::SetTemporaryLatin(false));
+            }
+            self.enqueue_deferred_actions(
+                &composition,
+                actions
+                    .into_iter()
+                    .map(|action| DeferredClientAction {
+                        action,
+                        transition: projection.state.clone(),
+                    })
+                    .collect(),
+            )?;
+            return Ok(Some((Vec::new(), composition.state.clone())));
+        }
+
         if !composition.temporary_latin_shift_pending {
             return Ok(None);
         }
@@ -3903,6 +4186,56 @@ impl TextServiceFactory {
         }
 
         Ok(Some((actions, composition.state.clone())))
+    }
+
+    fn flush_deferred_user_actions(&self) -> Result<()> {
+        loop {
+            let composition = self.borrow()?.borrow_composition()?.clone();
+            if !composition.deferred_actions.is_empty() {
+                self.handle_action(&[], composition.state.clone())?;
+                continue;
+            }
+
+            let Some(event) = composition.deferred_inputs.front().cloned() else {
+                self.borrow()?.borrow_mut_composition()?.deferred_projection = None;
+                return Ok(());
+            };
+            self.borrow()?
+                .borrow_mut_composition()?
+                .deferred_inputs
+                .pop_front();
+
+            match event {
+                DeferredInputEvent::Actions(actions) => {
+                    self.borrow()?
+                        .borrow_mut_composition()?
+                        .deferred_actions
+                        .extend(actions);
+                }
+                DeferredInputEvent::User { input, fallback } => {
+                    let config_snapshot = IMEState::app_config_snapshot()?;
+                    let mode = IMEState::input_mode()?;
+                    if let Some((transition, actions)) = Self::plan_deferred_user_action(
+                        &composition,
+                        &input,
+                        &mode,
+                        config_snapshot.app_config(),
+                        config_snapshot.romaji_lookup(),
+                    ) {
+                        self.handle_action_with_config_snapshot(
+                            &actions,
+                            transition,
+                            config_snapshot,
+                        )?;
+                    } else {
+                        self.borrow()?
+                            .borrow_mut_composition()?
+                            .deferred_actions
+                            .extend(fallback);
+                    }
+                }
+            }
+        }
     }
 
     #[tracing::instrument]
@@ -3925,7 +4258,11 @@ impl TextServiceFactory {
             if let Some((actions, transition, config_snapshot)) =
                 self.process_key(context, wparam, lparam)?
             {
-                self.handle_action_with_config_snapshot(&actions, transition, config_snapshot)?;
+                if actions.is_empty() {
+                    self.flush_deferred_user_actions()?;
+                } else {
+                    self.handle_action_with_config_snapshot(&actions, transition, config_snapshot)?;
+                }
                 Ok(true)
             } else {
                 Ok(false)
@@ -3955,6 +4292,13 @@ impl TextServiceFactory {
 
         match result {
             Ok(handled) => Ok(handled),
+            Err(error) if is_non_destructive_ipc_error(&error) => {
+                tracing::warn!(
+                    ?error,
+                    "IPC deadline exceeded; preserving the current composition for recovery"
+                );
+                Ok(true)
+            }
             Err(error) => {
                 tracing::error!("handle_key failed: {error:?}");
                 self.recover_after_key_error();
@@ -3981,7 +4325,11 @@ impl TextServiceFactory {
             };
 
             if let Some((actions, transition)) = self.process_key_up(context, wparam, lparam)? {
-                self.handle_action(&actions, transition)?;
+                if actions.is_empty() {
+                    self.flush_deferred_user_actions()?;
+                } else {
+                    self.handle_action(&actions, transition)?;
+                }
                 return Ok(true);
             }
 
@@ -4011,6 +4359,13 @@ impl TextServiceFactory {
 
         match result {
             Ok(handled) => Ok(handled),
+            Err(error) if is_non_destructive_ipc_error(&error) => {
+                tracing::warn!(
+                    ?error,
+                    "IPC deadline exceeded on key-up; preserving current composition"
+                );
+                Ok(true)
+            }
             Err(error) => {
                 tracing::error!("handle_key_up failed: {error:?}");
                 self.recover_after_key_error();
@@ -4071,25 +4426,29 @@ impl TextServiceFactory {
                 (composition, mode)
             };
 
-            let Some((transition, mut actions)) = Self::plan_actions_for_user_action_with_lookup(
-                &composition,
-                &UserAction::ToggleInputMode,
-                &mode,
+            let deferred = DeferredUserAction {
+                action: UserAction::ToggleInputMode,
                 is_shift_pressed,
+                is_shift_key: false,
+                shift_alphabet_shortcut: false,
+            };
+            if !composition.deferred_actions.is_empty() || !composition.deferred_inputs.is_empty() {
+                if !self.enqueue_deferred_user_action(&composition, deferred, &config_snapshot)? {
+                    return Ok(false);
+                }
+                self.flush_deferred_user_actions()?;
+                return Ok(true);
+            }
+
+            let Some((transition, actions)) = Self::plan_deferred_user_action(
+                &composition,
+                &deferred,
+                &mode,
                 app_config,
                 config_snapshot.romaji_lookup(),
-                false,
             ) else {
                 return Ok(false);
             };
-
-            if composition.temporary_latin
-                && !actions
-                    .iter()
-                    .any(|action| matches!(action, ClientAction::SetTemporaryLatin(false)))
-            {
-                actions.insert(0, ClientAction::SetTemporaryLatin(false));
-            }
 
             if !Self::ensure_ipc_service_for_key_event("handle_preserved_eisu_shortcut") {
                 return Ok(false);
@@ -4101,6 +4460,13 @@ impl TextServiceFactory {
 
         match result {
             Ok(handled) => Ok(handled),
+            Err(error) if is_non_destructive_ipc_error(&error) => {
+                tracing::warn!(
+                    ?error,
+                    "IPC deadline exceeded during preserved shortcut; preserving composition"
+                );
+                Ok(true)
+            }
             Err(error) => {
                 tracing::error!("handle_preserved_eisu_shortcut failed: {error:?}");
                 self.recover_after_key_error();
@@ -4111,6 +4477,41 @@ impl TextServiceFactory {
 
     fn recover_after_key_error(&self) {
         self.cancel_composition_for_disabled_context();
+    }
+
+    fn handle_external_composition_terminated(&self, terminated: Option<&ITfComposition>) {
+        let is_current = self
+            .borrow()
+            .ok()
+            .and_then(|text_service| {
+                text_service
+                    .borrow_composition()
+                    .ok()
+                    .and_then(|composition| composition.tip_composition.clone())
+            })
+            .zip(terminated.cloned())
+            .is_some_and(|(current, terminated)| current.as_raw() == terminated.as_raw());
+        if !is_current {
+            tracing::debug!("Ignore termination callback for a stale TSF composition");
+            return;
+        }
+
+        if let Ok(text_service) = self.borrow() {
+            if let Ok(mut composition) = text_service.borrow_mut_composition() {
+                *composition = Composition::default();
+            }
+        }
+
+        if let Ok(Some(mut ipc_service)) = IMEState::ipc_service() {
+            ipc_service.discard_input_ledger();
+            if let Ok(delivery) =
+                ipc_service.update_candidate_window(Some(false), None, Some(vec![]), Some(0), None)
+            {
+                self.remember_candidate_window_visibility_if_sent(delivery, Some(false));
+            }
+            let _ = ipc_service.clear_text();
+            let _ = IMEState::set_ipc_service(ipc_service);
+        }
     }
 
     fn cancel_composition_for_disabled_context(&self) {
@@ -4177,6 +4578,9 @@ impl TextServiceFactory {
         let trace_request_id = current_input_trace_request_id();
         let total_start = trace_request_id.map(|_| Instant::now());
         let requested_transition = transition.clone();
+        let mut retry_actions = None;
+        let mut failed_action_index = 0usize;
+        let mut failed_ledger_snapshot = None;
         let result: Result<()> = (|| {
             #[allow(clippy::let_and_return)]
             let (composition, mode) = {
@@ -4187,6 +4591,17 @@ impl TextServiceFactory {
             };
             let app_config = config_snapshot.app_config();
             let romaji_lookup = config_snapshot.romaji_lookup();
+            let mut effective_actions = composition.deferred_actions.clone();
+            effective_actions.extend(actions.iter().cloned().map(|action| DeferredClientAction {
+                action,
+                transition: transition.clone(),
+            }));
+            retry_actions = Some(effective_actions.clone());
+            let actions = effective_actions.as_slice();
+            let action_values = effective_actions
+                .iter()
+                .map(|deferred| deferred.action.clone())
+                .collect::<Vec<_>>();
 
             let mut preview = composition.preview.clone();
             let mut suffix = composition.suffix.clone();
@@ -4213,10 +4628,37 @@ impl TextServiceFactory {
             let mut pending_learning_commits = Vec::new();
             let has_learning_action = actions
                 .iter()
-                .any(|action| matches!(action, ClientAction::CommitLearning { .. }));
+                .any(|deferred| matches!(deferred.action, ClientAction::CommitLearning { .. }));
             let learning_blocked = has_learning_action
                 && (IMEState::keyboard_disabled().unwrap_or(true)
                     || self.current_context_has_sensitive_input_scope());
+
+            macro_rules! persist_local_state {
+                () => {{
+                    let text_service = self.borrow()?;
+                    let mut persisted = text_service.borrow_mut_composition()?;
+                    persisted.preview = preview.clone();
+                    persisted.state = transition.clone();
+                    persisted.selection_index = selection_index;
+                    persisted.raw_input = raw_input.clone();
+                    persisted.raw_hiragana = raw_hiragana.clone();
+                    persisted.fixed_prefix = fixed_prefix.clone();
+                    persisted.candidates = candidates.clone();
+                    persisted.clause_snapshots = clause_snapshots.clone();
+                    persisted.future_clause_snapshots = future_clause_snapshots.clone();
+                    persisted.current_clause_is_split_derived = current_clause_is_split_derived;
+                    persisted.current_clause_is_direct_split_remainder =
+                        current_clause_is_direct_split_remainder;
+                    persisted.current_clause_has_split_left_neighbor =
+                        current_clause_has_split_left_neighbor;
+                    persisted.current_clause_split_group_id = current_clause_split_group_id;
+                    persisted.next_split_group_id = next_split_group_id;
+                    persisted.suffix = suffix.clone();
+                    persisted.corresponding_count = corresponding_count;
+                    persisted.temporary_latin = temporary_latin;
+                    persisted.temporary_latin_shift_pending = temporary_latin_shift_pending;
+                }};
+            }
 
             macro_rules! reset_after_empty_server_composition {
                 ($reason:expr) => {{
@@ -4287,8 +4729,60 @@ impl TextServiceFactory {
             }
 
             ipc_service = IMEState::ipc_service()?.context("ipc_service is None")?;
+            failed_ledger_snapshot = Some(ipc_service.input_ledger_snapshot());
 
-            for (action_index, action) in actions.iter().enumerate() {
+            if ipc_service.recovery_pending() {
+                ipc_service.ensure_server_restart_requested();
+                if !ipc_service.recovery_restart_ready() {
+                    return Err(ipc_service.recovery_pending_error());
+                }
+
+                let recovered = ipc_service
+                    .recover_composition_if_needed(
+                        if raw_hiragana.is_empty() {
+                            &raw_input
+                        } else {
+                            &raw_hiragana
+                        },
+                        !raw_hiragana.is_empty(),
+                    )?
+                    .context("IPC recovery unexpectedly produced no composition")?;
+                tracing::warn!(
+                    raw_input_len = raw_input.chars().count(),
+                    "Rebuilt server composition after IPC deadline"
+                );
+                candidates = recovered.candidates;
+                clause_snapshots.clear();
+                future_clause_snapshots.clear();
+                current_clause_is_split_derived = false;
+                current_clause_is_direct_split_remainder = false;
+                current_clause_has_split_left_neighbor = false;
+                current_clause_split_group_id = None;
+                next_split_group_id = 0;
+                selection_index = 0;
+                if let Some(selected) = Self::select_candidate(&candidates, selection_index) {
+                    corresponding_count = selected.corresponding_count;
+                    preview = Self::merge_preview_with_prefix(&fixed_prefix, &selected.text);
+                    suffix = selected.sub_text.clone();
+                    raw_hiragana = selected.hiragana;
+                    if composition.tip_composition.is_some() {
+                        self.set_text(&preview, &suffix)?;
+                        self.sync_candidate_window_after_text_update(
+                            &mut ipc_service,
+                            &candidates,
+                            selection_index,
+                            app_config,
+                            &transition,
+                        )?;
+                    }
+                }
+            }
+
+            for (action_index, deferred) in actions.iter().enumerate() {
+                failed_action_index = action_index;
+                failed_ledger_snapshot = Some(ipc_service.input_ledger_snapshot());
+                transition = deferred.transition.clone();
+                let action = &deferred.action;
                 if Self::action_needs_context_update(action) {
                     IMEState::set_ipc_service(ipc_service.clone())?;
                     self.update_context(&preview)?;
@@ -4297,7 +4791,14 @@ impl TextServiceFactory {
 
                 match action {
                     ClientAction::StartComposition => {
-                        self.start_composition()?;
+                        let composition_started = self
+                            .borrow()?
+                            .borrow_composition()?
+                            .tip_composition
+                            .is_some();
+                        if !composition_started {
+                            self.start_composition()?;
+                        }
                         if app_config.general.show_candidate_window_after_space {
                             let delivery = ipc_service.update_candidate_window(
                                 Some(false),
@@ -4345,6 +4846,7 @@ impl TextServiceFactory {
                                 ?kind,
                                 "Skip conversion learning in disabled or sensitive context"
                             );
+                            persist_local_state!();
                             continue;
                         }
                         pending_learning_commits.extend(
@@ -4618,6 +5120,7 @@ impl TextServiceFactory {
                             reset_after_empty_server_composition!(
                                 "server session changed before remove_text"
                             );
+                            persist_local_state!();
                             continue;
                         }
                         raw_input.pop();
@@ -4634,6 +5137,7 @@ impl TextServiceFactory {
                             reset_after_empty_server_composition!(
                                 "remove_text detected server session change"
                             );
+                            persist_local_state!();
                             continue;
                         }
                         if let Some(selected) = Self::select_candidate(&candidates, selection_index)
@@ -4721,6 +5225,7 @@ impl TextServiceFactory {
                             reset_after_empty_server_composition!(
                                 "server session changed before move_cursor"
                             );
+                            persist_local_state!();
                             continue;
                         }
                         candidates = ipc_service.move_cursor_with_context(*offset, &candidates)?;
@@ -4736,6 +5241,7 @@ impl TextServiceFactory {
                             reset_after_empty_server_composition!(
                                 "move_cursor detected server session change"
                             );
+                            persist_local_state!();
                             continue;
                         }
                         if let Some(selected) = Self::select_candidate(&candidates, selection_index)
@@ -4785,6 +5291,7 @@ impl TextServiceFactory {
                             reset_after_empty_server_composition!(
                                 "server session changed before clause_navigation_ready"
                             );
+                            persist_local_state!();
                             continue;
                         }
                         Self::log_clause_action_state(
@@ -4836,7 +5343,7 @@ impl TextServiceFactory {
                             );
                         } else if effect.applied {
                             let defer_ui_sync = Self::should_defer_clause_navigation_ready_sync(
-                                actions,
+                                &action_values,
                                 action_index,
                             );
                             let ready_ui_sync = Self::clause_navigation_ready_ui_sync(effect);
@@ -4856,6 +5363,7 @@ impl TextServiceFactory {
                                     &clause_snapshots,
                                     &future_clause_snapshots,
                                 );
+                                persist_local_state!();
                                 continue;
                             }
 
@@ -4923,6 +5431,7 @@ impl TextServiceFactory {
                             reset_after_empty_server_composition!(
                                 "server session changed before move_clause"
                             );
+                            persist_local_state!();
                             continue;
                         }
                         Self::log_clause_action_state(
@@ -5077,6 +5586,7 @@ impl TextServiceFactory {
                             reset_after_empty_server_composition!(
                                 "server session changed before adjust_boundary"
                             );
+                            persist_local_state!();
                             continue;
                         }
                         Self::log_clause_action_state(
@@ -5704,34 +6214,22 @@ impl TextServiceFactory {
                         self.set_text(&preview, &suffix)?;
                     }
                 }
+                if matches!(
+                    action,
+                    ClientAction::ShrinkText(_)
+                        | ClientAction::ShrinkTextRaw(_)
+                        | ClientAction::ShrinkTextDirect(_)
+                ) {
+                    ipc_service.replace_input_ledger_direct(&raw_hiragana);
+                }
+                persist_local_state!();
             }
 
-            let text_service = self.borrow()?;
-            let mut composition = text_service.borrow_mut_composition()?;
-
-            composition.preview = preview.clone();
-            composition.state = transition;
-            composition.selection_index = selection_index;
-            composition.raw_input = raw_input.clone();
-            composition.raw_hiragana = raw_hiragana.clone();
-            composition.fixed_prefix = fixed_prefix.clone();
-            composition.candidates = candidates;
-            composition.clause_snapshots = clause_snapshots;
-            composition.future_clause_snapshots = future_clause_snapshots;
-            composition.current_clause_is_split_derived = current_clause_is_split_derived;
-            composition.current_clause_is_direct_split_remainder =
-                current_clause_is_direct_split_remainder;
-            composition.current_clause_has_split_left_neighbor =
-                current_clause_has_split_left_neighbor;
-            composition.current_clause_split_group_id = current_clause_split_group_id;
-            composition.next_split_group_id = next_split_group_id;
-            composition.suffix = suffix.clone();
-            composition.corresponding_count = corresponding_count;
-            composition.temporary_latin = temporary_latin;
-            composition.temporary_latin_shift_pending = temporary_latin_shift_pending;
-
-            drop(composition);
-            drop(text_service);
+            persist_local_state!();
+            self.borrow()?
+                .borrow_mut_composition()?
+                .deferred_actions
+                .clear();
 
             if let Err(error) = IMEState::set_ipc_service(ipc_service) {
                 tracing::warn!(
@@ -5742,6 +6240,25 @@ impl TextServiceFactory {
 
             Ok(())
         })();
+
+        if result.as_ref().is_err_and(is_non_destructive_ipc_error) {
+            if let Some(actions) = retry_actions.as_ref() {
+                let deferred = deferred_action_suffix(actions, failed_action_index);
+                if let Ok(text_service) = self.borrow() {
+                    if let Ok(mut composition) = text_service.borrow_mut_composition() {
+                        composition.deferred_actions = deferred;
+                    }
+                }
+            }
+
+            if let Ok(Some(ipc_service)) = IMEState::ipc_service() {
+                if let Some(snapshot) = failed_ledger_snapshot.take() {
+                    ipc_service.restore_input_ledger(snapshot);
+                }
+                ipc_service.ensure_server_restart_requested();
+                let _ = IMEState::set_ipc_service(ipc_service);
+            }
+        }
 
         if let (Some(request_id), Some(total_start)) = (trace_request_id, total_start) {
             let details = match &result {

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,7 +1,8 @@
 use super::{
-    Candidates, CapsLockKeyboardLayout, ClauseActionBackend, ClauseActionEffect,
-    ClauseActionStateMut, ClauseNavigationReadyUiSync, ClauseSnapshot, ClauseState, Composition,
-    CompositionReducer, CompositionState, FutureClauseSnapshot, TextServiceFactory,
+    deferred_action_suffix, Candidates, CapsLockKeyboardLayout, ClauseActionBackend,
+    ClauseActionEffect, ClauseActionStateMut, ClauseNavigationReadyUiSync, ClauseSnapshot,
+    ClauseState, Composition, CompositionReducer, CompositionState, DeferredClientAction,
+    DeferredProjection, DeferredUserAction, FutureClauseSnapshot, TextServiceFactory,
 };
 use crate::engine::{
     client_action::{
@@ -13,6 +14,265 @@ use crate::engine::{
 };
 use shared::{get_default_romaji_rows, AppConfig, PunctuationStyle, RomajiRule, WidthMode};
 use windows::Win32::Foundation::LPARAM;
+
+#[test]
+fn deadline_recovery_defers_all_actions_from_failure_point() {
+    let actions = vec![
+        DeferredClientAction {
+            action: ClientAction::AppendText("a".to_string()),
+            transition: CompositionState::Composing,
+        },
+        DeferredClientAction {
+            action: ClientAction::RemoveText,
+            transition: CompositionState::Composing,
+        },
+        DeferredClientAction {
+            action: ClientAction::MoveCursor(-1),
+            transition: CompositionState::Selecting,
+        },
+        DeferredClientAction {
+            action: ClientAction::ShrinkText("k".to_string()),
+            transition: CompositionState::Composing,
+        },
+        DeferredClientAction {
+            action: ClientAction::EndComposition,
+            transition: CompositionState::None,
+        },
+    ];
+
+    let deferred = deferred_action_suffix(&actions, 1);
+    assert_eq!(deferred, actions[1..]);
+    assert_eq!(deferred[1].transition, CompositionState::Selecting);
+    assert_eq!(deferred[3].transition, CompositionState::None);
+}
+
+#[test]
+fn deferred_backspace_is_replanned_against_recovered_input() {
+    let app_config = AppConfig::default();
+    let romaji_lookup = super::RomajiLookup::from_rows(&app_config.romaji_table.rows);
+    let composition = Composition {
+        state: CompositionState::Composing,
+        raw_input: "ka".to_string(),
+        ..Composition::default()
+    };
+    let deferred = DeferredUserAction {
+        action: UserAction::Backspace,
+        is_shift_pressed: false,
+        is_shift_key: false,
+        shift_alphabet_shortcut: false,
+    };
+
+    let (transition, actions) = TextServiceFactory::plan_deferred_user_action(
+        &composition,
+        &deferred,
+        &InputMode::Kana,
+        &app_config,
+        &romaji_lookup,
+    )
+    .expect("backspace should remain handled after recovery");
+
+    assert_eq!(transition, CompositionState::Composing);
+    assert_eq!(actions, vec![ClientAction::RemoveText]);
+}
+
+#[test]
+fn deferred_projection_decides_handledness_after_queued_mode_change() {
+    let app_config = AppConfig::default();
+    let romaji_lookup = super::RomajiLookup::from_rows(&app_config.romaji_table.rows);
+    let composition = Composition::default();
+    let input = DeferredUserAction {
+        action: UserAction::Input('a'),
+        is_shift_pressed: false,
+        is_shift_key: false,
+        shift_alphabet_shortcut: false,
+    };
+    let mut projection = DeferredProjection {
+        mode: InputMode::Kana,
+        state: CompositionState::None,
+        raw_input: String::new(),
+        temporary_latin: false,
+        temporary_latin_shift_pending: false,
+        reliable: true,
+    };
+    TextServiceFactory::apply_actions_to_deferred_projection(
+        &mut projection,
+        &[DeferredClientAction {
+            action: ClientAction::SetIMEMode(InputMode::Latin),
+            transition: CompositionState::None,
+        }],
+    );
+
+    assert!(TextServiceFactory::plan_deferred_user_action(
+        &composition,
+        &input,
+        &projection.mode,
+        &app_config,
+        &romaji_lookup,
+    )
+    .is_none());
+
+    TextServiceFactory::apply_actions_to_deferred_projection(
+        &mut projection,
+        &[DeferredClientAction {
+            action: ClientAction::SetIMEMode(InputMode::Kana),
+            transition: CompositionState::None,
+        }],
+    );
+    assert!(TextServiceFactory::plan_deferred_user_action(
+        &composition,
+        &input,
+        &projection.mode,
+        &app_config,
+        &romaji_lookup,
+    )
+    .is_some());
+}
+
+#[test]
+fn deferred_projection_preserves_shift_transition_order() {
+    let mut projection = DeferredProjection {
+        mode: InputMode::Kana,
+        state: CompositionState::Composing,
+        raw_input: String::new(),
+        temporary_latin: true,
+        temporary_latin_shift_pending: false,
+        reliable: true,
+    };
+    TextServiceFactory::apply_actions_to_deferred_projection(
+        &mut projection,
+        &[
+            DeferredClientAction {
+                action: ClientAction::SetTemporaryLatinShiftPending(true),
+                transition: CompositionState::Composing,
+            },
+            DeferredClientAction {
+                action: ClientAction::SetTemporaryLatin(false),
+                transition: CompositionState::Composing,
+            },
+            DeferredClientAction {
+                action: ClientAction::SetTemporaryLatinShiftPending(false),
+                transition: CompositionState::Composing,
+            },
+        ],
+    );
+
+    assert!(!projection.temporary_latin);
+    assert!(!projection.temporary_latin_shift_pending);
+}
+
+#[test]
+fn deferred_projection_tracks_raw_input_before_navigation() {
+    let app_config = AppConfig::default();
+    let romaji_lookup = super::RomajiLookup::from_rows(&app_config.romaji_table.rows);
+    let mut projection = DeferredProjection {
+        mode: InputMode::Kana,
+        state: CompositionState::Composing,
+        raw_input: String::new(),
+        temporary_latin: false,
+        temporary_latin_shift_pending: false,
+        reliable: true,
+    };
+    TextServiceFactory::apply_actions_to_deferred_projection(
+        &mut projection,
+        &[
+            DeferredClientAction {
+                action: ClientAction::AppendText("a".to_string()),
+                transition: CompositionState::Composing,
+            },
+            DeferredClientAction {
+                action: ClientAction::AppendText("b".to_string()),
+                transition: CompositionState::Composing,
+            },
+            DeferredClientAction {
+                action: ClientAction::RemoveText,
+                transition: CompositionState::Composing,
+            },
+        ],
+    );
+    let projected_composition = Composition {
+        state: projection.state.clone(),
+        raw_input: projection.raw_input.clone(),
+        ..Composition::default()
+    };
+    let left = DeferredUserAction {
+        action: UserAction::Navigation(Navigation::Left),
+        is_shift_pressed: false,
+        is_shift_key: false,
+        shift_alphabet_shortcut: false,
+    };
+
+    assert_eq!(projection.raw_input, "a");
+    assert!(TextServiceFactory::plan_deferred_user_action(
+        &projected_composition,
+        &left,
+        &projection.mode,
+        &app_config,
+        &romaji_lookup,
+    )
+    .is_some());
+}
+
+#[test]
+fn deferred_projection_marks_backend_dependent_transitions_unreliable() {
+    let mut projection = DeferredProjection {
+        mode: InputMode::Kana,
+        state: CompositionState::Composing,
+        raw_input: "kana".to_string(),
+        temporary_latin: false,
+        temporary_latin_shift_pending: false,
+        reliable: true,
+    };
+
+    TextServiceFactory::apply_actions_to_deferred_projection(
+        &mut projection,
+        &[DeferredClientAction {
+            action: ClientAction::ShrinkText(String::new()),
+            transition: CompositionState::Composing,
+        }],
+    );
+
+    assert!(!projection.reliable);
+
+    TextServiceFactory::apply_actions_to_deferred_projection(
+        &mut projection,
+        &[
+            DeferredClientAction {
+                action: ClientAction::EndComposition,
+                transition: CompositionState::None,
+            },
+            DeferredClientAction {
+                action: ClientAction::SetIMEMode(InputMode::Latin),
+                transition: CompositionState::None,
+            },
+        ],
+    );
+    assert!(projection.reliable);
+    assert_eq!(projection.state, CompositionState::None);
+    assert_eq!(projection.mode, InputMode::Latin);
+
+    let app_config = AppConfig::default();
+    let romaji_lookup = super::RomajiLookup::from_rows(&app_config.romaji_table.rows);
+    let reset_composition = Composition::default();
+    for action in [
+        UserAction::Navigation(Navigation::Left),
+        UserAction::Input('a'),
+    ] {
+        let input = DeferredUserAction {
+            action,
+            is_shift_pressed: false,
+            is_shift_key: false,
+            shift_alphabet_shortcut: false,
+        };
+        assert!(TextServiceFactory::plan_deferred_user_action(
+            &reset_composition,
+            &input,
+            &projection.mode,
+            &app_config,
+            &romaji_lookup,
+        )
+        .is_none());
+    }
+}
 
 pub(super) fn row(input: &str, output: &str, next_input: &str) -> RomajiRule {
     RomajiRule {

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -217,6 +217,11 @@ fn move_input_cursor(ledger: &mut InputLedger, offset: i32) {
     }
 }
 
+fn mark_input_ledger_incomplete(ledger: &mut InputLedger) {
+    ledger.operations.clear();
+    ledger.complete = false;
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Candidates {
     pub texts: Vec<String>,
@@ -643,8 +648,7 @@ impl IPCService {
 
     fn invalidate_input_ledger(&self) {
         if let Ok(mut ledger) = self.recovery.input_ledger.lock() {
-            ledger.operations.clear();
-            ledger.complete = false;
+            mark_input_ledger_incomplete(&mut ledger);
         }
     }
 
@@ -858,6 +862,12 @@ impl IPCService {
                             ));
                         }
 
+                        // The edit may have completed before the connection failed, but
+                        // refresh alone cannot safely reproduce that mutation in the local
+                        // recovery ledger. Discard it so a later deadline recovery cannot
+                        // rebuild the pre-edit composition and resurrect removed text or an
+                        // old cursor position.
+                        self.invalidate_input_ledger();
                         Ok((
                             refreshed_candidates,
                             NonIdempotentEditRecovery::RefreshedAfterReconnect,
@@ -2015,10 +2025,10 @@ impl IPCService {
 mod tests {
     use super::{
         append_input_segment, await_rpc_with_deadline, is_non_destructive_ipc_error,
-        move_input_cursor, pop_input_segment_character, preserve_recovery_error,
-        recovery_generation_is_current, restart_generation_ready, restart_request_needed,
-        Candidates, CompositionOperation, IPCService, InputLedger, IpcDeadlineExceeded,
-        NonIdempotentEditAttempt, INPUT_STYLE_DIRECT, INPUT_STYLE_ROMAN2KANA,
+        mark_input_ledger_incomplete, move_input_cursor, pop_input_segment_character,
+        preserve_recovery_error, recovery_generation_is_current, restart_generation_ready,
+        restart_request_needed, Candidates, CompositionOperation, IPCService, InputLedger,
+        IpcDeadlineExceeded, NonIdempotentEditAttempt, INPUT_STYLE_DIRECT, INPUT_STYLE_ROMAN2KANA,
     };
     use std::{
         future::Future,
@@ -2472,5 +2482,24 @@ mod tests {
         );
 
         assert!(attempt.is_err());
+    }
+
+    #[test]
+    fn ambiguous_non_idempotent_refresh_invalidates_input_ledger() {
+        let mut ledger = InputLedger {
+            operations: vec![
+                CompositionOperation::Append {
+                    text: "かな".to_string(),
+                    input_style: 0,
+                },
+                CompositionOperation::MoveCursor(-1),
+            ],
+            complete: true,
+        };
+
+        mark_input_ledger_incomplete(&mut ledger);
+
+        assert!(ledger.operations.is_empty());
+        assert!(!ledger.complete);
     }
 }

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -9,8 +9,11 @@ use shared::{
 };
 use std::{
     cell::Cell,
+    error::Error as StdError,
+    fmt,
+    future::Future,
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex, OnceLock,
     },
     time::{Duration, Instant},
@@ -18,14 +21,20 @@ use std::{
 use tokio::{net::windows::named_pipe::ClientOptions, time};
 use tonic::transport::{channel::Channel, Endpoint};
 use tower::service_fn;
-use windows::Win32::Foundation::ERROR_PIPE_BUSY;
+use windows::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, ERROR_PIPE_BUSY};
 
 const INPUT_STYLE_ROMAN2KANA: i32 = 0;
 const INPUT_STYLE_DIRECT: i32 = 1;
 const CLIENT_LOG_CONFIG_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const PIPE_BUSY_RETRY_INTERVAL: Duration = Duration::from_millis(50);
-const SERVER_PIPE_BUSY_TIMEOUT: Duration = Duration::from_millis(250);
+const SERVER_PIPE_BUSY_TIMEOUT: Duration = Duration::from_millis(750);
 const UI_PIPE_BUSY_TIMEOUT: Duration = Duration::ZERO;
+const IPC_CONNECT_DEADLINE: Duration = Duration::from_secs(1);
+const INPUT_RPC_DEADLINE: Duration = Duration::from_secs(2);
+const STATE_RPC_DEADLINE: Duration = Duration::from_secs(1);
+const LEARNING_RPC_DEADLINE: Duration = Duration::from_secs(1);
+const UI_RPC_DEADLINE: Duration = Duration::from_millis(250);
+const PERFORMANCE_RPC_DEADLINE: Duration = Duration::from_millis(100);
 
 static CLIENT_REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 static IPC_CONNECTION_SEQUENCE: AtomicU64 = AtomicU64::new(1);
@@ -50,9 +59,162 @@ pub struct IPCService {
     // candidate window server client
     window_client: Option<WindowServiceClient<Channel>>,
     runtime: Arc<tokio::runtime::Runtime>,
-    performance_log_tx: tokio::sync::mpsc::UnboundedSender<PerformanceLogRequest>,
+    performance_log_tx: tokio::sync::mpsc::Sender<PerformanceLogRequest>,
     server_session_id: Option<u64>,
     server_reset_recovered: bool,
+    recovery: Arc<ServerRecoveryState>,
+}
+
+#[derive(Debug)]
+struct ServerRecoveryState {
+    pending: AtomicBool,
+    generation: AtomicU64,
+    restart_completed_generation: AtomicU64,
+    restart_request_in_flight: AtomicBool,
+    input_ledger: Mutex<InputLedger>,
+}
+
+impl Default for ServerRecoveryState {
+    fn default() -> Self {
+        Self {
+            pending: AtomicBool::new(false),
+            generation: AtomicU64::new(0),
+            restart_completed_generation: AtomicU64::new(0),
+            restart_request_in_flight: AtomicBool::new(false),
+            input_ledger: Mutex::new(InputLedger {
+                operations: Vec::new(),
+                complete: true,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct InputLedger {
+    operations: Vec<CompositionOperation>,
+    complete: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CompositionOperation {
+    Append { text: String, input_style: i32 },
+    Remove,
+    MoveCursor(i32),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecoveredComposition {
+    pub(crate) candidates: Candidates,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct InputLedgerSnapshot(InputLedger);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IpcDeadlineExceeded {
+    operation: &'static str,
+    deadline: Duration,
+}
+
+impl fmt::Display for IpcDeadlineExceeded {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{} exceeded IPC deadline of {:?}",
+            self.operation, self.deadline
+        )
+    }
+}
+
+impl StdError for IpcDeadlineExceeded {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IpcRecoveryPending {
+    details: String,
+}
+
+impl fmt::Display for IpcRecoveryPending {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "IPC recovery is still pending: {}", self.details)
+    }
+}
+
+impl StdError for IpcRecoveryPending {}
+
+pub(crate) fn is_ipc_deadline(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<IpcDeadlineExceeded>().is_some()
+        || error
+            .downcast_ref::<tonic::Status>()
+            .is_some_and(|status| status.code() == tonic::Code::DeadlineExceeded)
+}
+
+pub(crate) fn is_non_destructive_ipc_error(error: &anyhow::Error) -> bool {
+    is_ipc_deadline(error) || error.downcast_ref::<IpcRecoveryPending>().is_some()
+}
+
+fn preserve_recovery_error(error: anyhow::Error) -> anyhow::Error {
+    if is_ipc_deadline(&error) {
+        error
+    } else {
+        IpcRecoveryPending {
+            details: format!("{error:#}"),
+        }
+        .into()
+    }
+}
+
+async fn await_rpc_with_deadline<T, F>(
+    operation: &'static str,
+    deadline: Duration,
+    future: F,
+) -> anyhow::Result<T>
+where
+    F: Future<Output = Result<T, tonic::Status>>,
+{
+    match time::timeout(deadline, future).await {
+        Ok(result) => result.map_err(Into::into),
+        Err(_) => Err(IpcDeadlineExceeded {
+            operation,
+            deadline,
+        }
+        .into()),
+    }
+}
+
+fn recovery_generation_is_current(expected: u64, current: u64) -> bool {
+    expected == current
+}
+
+fn restart_generation_ready(required: u64, completed: u64) -> bool {
+    required != 0 && completed >= required
+}
+
+fn restart_request_needed(pending: bool, ready: bool, in_flight: bool) -> bool {
+    pending && !ready && !in_flight
+}
+
+fn append_input_segment(ledger: &mut InputLedger, text: &str, input_style: i32) {
+    if !ledger.complete || text.is_empty() {
+        return;
+    }
+    ledger.operations.push(CompositionOperation::Append {
+        text: text.to_string(),
+        input_style,
+    });
+}
+
+fn pop_input_segment_character(ledger: &mut InputLedger) {
+    if ledger.complete {
+        ledger.operations.push(CompositionOperation::Remove);
+    }
+}
+
+fn move_input_cursor(ledger: &mut InputLedger, offset: i32) {
+    if ledger.complete && offset != 0 {
+        ledger
+            .operations
+            .push(CompositionOperation::MoveCursor(offset));
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -230,13 +392,18 @@ impl IPCService {
 
         let azookey_client = AzookeyServiceClient::new(server_channel);
         let (performance_log_tx, mut performance_log_rx) =
-            tokio::sync::mpsc::unbounded_channel::<PerformanceLogRequest>();
+            tokio::sync::mpsc::channel::<PerformanceLogRequest>(64);
         let mut performance_log_client = azookey_client.clone();
         runtime.spawn(async move {
             while let Some(request) = performance_log_rx.recv().await {
-                if let Err(error) = performance_log_client
-                    .log_performance(tonic::Request::new(request))
-                    .await
+                let mut request = tonic::Request::new(request);
+                request.set_timeout(PERFORMANCE_RPC_DEADLINE);
+                if let Err(error) = await_rpc_with_deadline(
+                    "log_performance",
+                    PERFORMANCE_RPC_DEADLINE,
+                    performance_log_client.log_performance(request),
+                )
+                .await
                 {
                     tracing::debug!("failed to write client performance log: {error:?}");
                 }
@@ -252,6 +419,7 @@ impl IPCService {
             performance_log_tx,
             server_session_id: None,
             server_reset_recovered: false,
+            recovery: Arc::new(ServerRecoveryState::default()),
         })
     }
 
@@ -261,31 +429,47 @@ impl IPCService {
         pipe_name: &'static str,
         busy_timeout: Duration,
     ) -> Result<Channel> {
-        let channel = runtime.block_on(Endpoint::try_from(endpoint)?.connect_with_connector(
-            service_fn(move |_| async move {
-                let busy_started_at = Instant::now();
-                let client = loop {
-                    match ClientOptions::new().open(pipe_name) {
-                        Ok(client) => break client,
-                        Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY.0 as i32) => {
-                            if busy_started_at.elapsed() >= busy_timeout {
-                                return Err(std::io::Error::new(
-                                    std::io::ErrorKind::TimedOut,
-                                    format!(
-                                        "{pipe_name} remained busy for at least {busy_timeout:?}"
-                                    ),
-                                ));
-                            }
+        let endpoint = Endpoint::try_from(endpoint)?;
+        let connect = endpoint.connect_with_connector(service_fn(move |_| async move {
+            let busy_started_at = Instant::now();
+            let client = loop {
+                match ClientOptions::new().open(pipe_name) {
+                    Ok(client) => break client,
+                    Err(e)
+                        if matches!(
+                            e.raw_os_error(),
+                            Some(code)
+                                if code == ERROR_PIPE_BUSY.0 as i32
+                                    || code == ERROR_FILE_NOT_FOUND.0 as i32
+                                    || code == ERROR_PATH_NOT_FOUND.0 as i32
+                        ) =>
+                    {
+                        if busy_started_at.elapsed() >= busy_timeout {
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::TimedOut,
+                                format!(
+                                    "{pipe_name} remained unavailable for at least {busy_timeout:?}"
+                                ),
+                            ));
                         }
-                        Err(e) => return Err(e),
                     }
+                    Err(e) => return Err(e),
+                }
 
-                    time::sleep(PIPE_BUSY_RETRY_INTERVAL).await;
-                };
+                time::sleep(PIPE_BUSY_RETRY_INTERVAL).await;
+            };
 
-                Ok::<_, std::io::Error>(TokioIo::new(client))
-            }),
-        ))?;
+            Ok::<_, std::io::Error>(TokioIo::new(client))
+        }));
+        let channel = runtime.block_on(async {
+            time::timeout(IPC_CONNECT_DEADLINE, connect)
+                .await
+                .map_err(|_| IpcDeadlineExceeded {
+                    operation: "connect_named_pipe",
+                    deadline: IPC_CONNECT_DEADLINE,
+                })?
+                .map_err(anyhow::Error::from)
+        })?;
 
         Ok(channel)
     }
@@ -333,6 +517,193 @@ impl IPCService {
         self.runtime = refreshed.runtime;
         self.performance_log_tx = refreshed.performance_log_tx;
         Ok(())
+    }
+
+    fn mark_server_timeout(recovery: &Arc<ServerRecoveryState>, operation: &'static str) {
+        recovery.generation.fetch_add(1, Ordering::AcqRel);
+        recovery.pending.store(true, Ordering::Release);
+        Self::request_server_restart(recovery, operation);
+    }
+
+    fn request_server_restart(recovery: &Arc<ServerRecoveryState>, operation: &'static str) {
+        if recovery
+            .restart_request_in_flight
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let generation = recovery.generation.load(Ordering::Acquire);
+        let recovery = recovery.clone();
+        std::thread::spawn(move || {
+            match crate::launcher_control::request_restart() {
+                Ok(()) => {
+                    recovery
+                        .restart_completed_generation
+                        .fetch_max(generation, Ordering::AcqRel);
+                    tracing::warn!(
+                        operation,
+                        generation,
+                        "Launcher completed azookey server restart"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        ?error,
+                        operation,
+                        generation,
+                        "Failed to request azookey server restart; next input will retry"
+                    );
+                }
+            }
+            recovery
+                .restart_request_in_flight
+                .store(false, Ordering::Release);
+        });
+    }
+
+    pub(crate) fn recovery_pending(&self) -> bool {
+        self.recovery.pending.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn ensure_server_restart_requested(&self) {
+        if restart_request_needed(
+            self.recovery_pending(),
+            self.recovery_restart_ready(),
+            self.recovery
+                .restart_request_in_flight
+                .load(Ordering::Acquire),
+        ) {
+            Self::request_server_restart(&self.recovery, "recovery_retry");
+        }
+    }
+
+    pub(crate) fn recovery_restart_ready(&self) -> bool {
+        let generation = self.recovery.generation.load(Ordering::Acquire);
+        restart_generation_ready(
+            generation,
+            self.recovery
+                .restart_completed_generation
+                .load(Ordering::Acquire),
+        )
+    }
+
+    pub(crate) fn wait_for_recovery_restart(&self) -> bool {
+        let started = Instant::now();
+        while started.elapsed() < INPUT_RPC_DEADLINE {
+            self.ensure_server_restart_requested();
+            if self.recovery_restart_ready() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        self.recovery_restart_ready()
+    }
+
+    pub(crate) fn recovery_pending_error(&self) -> anyhow::Error {
+        IpcRecoveryPending {
+            details: "waiting for launcher to complete server restart".to_string(),
+        }
+        .into()
+    }
+
+    fn record_successful_append(&self, text: &str, input_style: i32) {
+        let Ok(mut ledger) = self.recovery.input_ledger.lock() else {
+            return;
+        };
+        append_input_segment(&mut ledger, text, input_style);
+    }
+
+    fn record_successful_remove(&self) {
+        let Ok(mut ledger) = self.recovery.input_ledger.lock() else {
+            return;
+        };
+        pop_input_segment_character(&mut ledger);
+    }
+
+    fn record_successful_move(&self, offset: i32) {
+        if offset == 0 || offset.abs() >= 125 {
+            return;
+        }
+        if let Ok(mut ledger) = self.recovery.input_ledger.lock() {
+            move_input_cursor(&mut ledger, offset);
+        }
+    }
+
+    fn clear_input_ledger(&self) {
+        if let Ok(mut ledger) = self.recovery.input_ledger.lock() {
+            ledger.operations.clear();
+            ledger.complete = true;
+        }
+    }
+
+    pub(crate) fn discard_input_ledger(&self) {
+        self.clear_input_ledger();
+    }
+
+    fn invalidate_input_ledger(&self) {
+        if let Ok(mut ledger) = self.recovery.input_ledger.lock() {
+            ledger.operations.clear();
+            ledger.complete = false;
+        }
+    }
+
+    pub(crate) fn input_ledger_snapshot(&self) -> InputLedgerSnapshot {
+        let ledger = self
+            .recovery
+            .input_ledger
+            .lock()
+            .map(|ledger| ledger.clone())
+            .unwrap_or_default();
+        InputLedgerSnapshot(ledger)
+    }
+
+    pub(crate) fn restore_input_ledger(&self, snapshot: InputLedgerSnapshot) {
+        if let Ok(mut ledger) = self.recovery.input_ledger.lock() {
+            *ledger = snapshot.0;
+        }
+    }
+
+    pub(crate) fn replace_input_ledger_direct(&self, text: &str) {
+        if let Ok(mut ledger) = self.recovery.input_ledger.lock() {
+            ledger.operations = if text.is_empty() {
+                Vec::new()
+            } else {
+                vec![CompositionOperation::Append {
+                    text: text.to_string(),
+                    input_style: INPUT_STYLE_DIRECT,
+                }]
+            };
+            ledger.complete = true;
+        }
+    }
+
+    fn block_on_server_rpc<T, F>(
+        runtime: &tokio::runtime::Runtime,
+        recovery: &Arc<ServerRecoveryState>,
+        operation: &'static str,
+        deadline: Duration,
+        future: F,
+    ) -> anyhow::Result<T>
+    where
+        F: Future<Output = Result<T, tonic::Status>>,
+    {
+        let result = runtime.block_on(await_rpc_with_deadline(operation, deadline, future));
+        if result.as_ref().is_err_and(is_ipc_deadline) {
+            Self::mark_server_timeout(recovery, operation);
+        }
+        result
+    }
+
+    fn block_on_window_rpc<T, F>(
+        runtime: &tokio::runtime::Runtime,
+        operation: &'static str,
+        future: F,
+    ) -> anyhow::Result<T>
+    where
+        F: Future<Output = Result<T, tonic::Status>>,
+    {
+        runtime.block_on(await_rpc_with_deadline(operation, UI_RPC_DEADLINE, future))
     }
 
     fn observe_server_session(&mut self, operation: &str, server_session_id: u64) {
@@ -504,6 +875,11 @@ impl IPCService {
     }
 
     fn should_reconnect_rpc_error(error: &anyhow::Error) -> bool {
+        if is_ipc_deadline(error) {
+            // A local timeout means the server may still apply the operation.
+            // Replaying before absolute-state reconstruction is unsafe.
+            return false;
+        }
         let Some(status) = error.downcast_ref::<tonic::Status>() else {
             return true;
         };
@@ -513,7 +889,6 @@ impl IPCService {
             tonic::Code::Aborted
                 | tonic::Code::Cancelled
                 | tonic::Code::DataLoss
-                | tonic::Code::DeadlineExceeded
                 | tonic::Code::Internal
                 | tonic::Code::Unavailable
                 | tonic::Code::Unknown
@@ -526,40 +901,59 @@ impl IPCService {
         input_style: i32,
         request_id: u64,
     ) -> anyhow::Result<shared::proto::AppendTextResponse> {
-        let request = tonic::Request::new(shared::proto::AppendTextRequest {
+        let mut request = tonic::Request::new(shared::proto::AppendTextRequest {
             text_to_append: text.to_string(),
             input_style,
             request_id,
         });
+        request.set_timeout(INPUT_RPC_DEADLINE);
 
-        let response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.append_text(request))?;
+        let response = Self::block_on_server_rpc(
+            self.runtime.as_ref(),
+            &self.recovery,
+            "append_text",
+            INPUT_RPC_DEADLINE,
+            self.azookey_client.append_text(request),
+        );
+        if response.is_err() && !response.as_ref().is_err_and(is_ipc_deadline) {
+            self.invalidate_input_ledger();
+        }
+        let response = response?;
         let response = response.into_inner();
         self.observe_server_session("append_text", response.server_session_id);
+        self.record_successful_append(text, input_style);
         Ok(response)
     }
 
     fn send_remove_text(&mut self, request_id: u64) -> anyhow::Result<Candidates> {
-        let request = tonic::Request::new(shared::proto::RemoveTextRequest { request_id });
-        let response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.remove_text(request))?;
+        let mut request = tonic::Request::new(shared::proto::RemoveTextRequest { request_id });
+        request.set_timeout(INPUT_RPC_DEADLINE);
+        let response = Self::block_on_server_rpc(
+            self.runtime.as_ref(),
+            &self.recovery,
+            "remove_text",
+            INPUT_RPC_DEADLINE,
+            self.azookey_client.remove_text(request),
+        )?;
         let response = response.into_inner();
         self.observe_server_session("remove_text", response.server_session_id);
+        self.record_successful_remove();
         Self::candidates_from_composing_text(response.composing_text)
     }
 
     fn send_clear_text(&mut self, request_id: u64) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::ClearTextRequest { request_id });
-        let response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.clear_text(request))?;
+        let mut request = tonic::Request::new(shared::proto::ClearTextRequest { request_id });
+        request.set_timeout(STATE_RPC_DEADLINE);
+        let response = Self::block_on_server_rpc(
+            self.runtime.as_ref(),
+            &self.recovery,
+            "clear_text",
+            STATE_RPC_DEADLINE,
+            self.azookey_client.clear_text(request),
+        )?;
         let response = response.into_inner();
         self.observe_server_session("clear_text", response.server_session_id);
+        self.clear_input_ledger();
         Ok(())
     }
 
@@ -569,54 +963,185 @@ impl IPCService {
         commit_kind: i32,
         request_id: u64,
     ) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::CommitLearningCandidateRequest {
+        let mut request = tonic::Request::new(shared::proto::CommitLearningCandidateRequest {
             candidate_id,
             commit_kind,
             request_id,
         });
-        let response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.commit_learning_candidate(request))?;
+        request.set_timeout(LEARNING_RPC_DEADLINE);
+        let response = Self::block_on_server_rpc(
+            self.runtime.as_ref(),
+            &self.recovery,
+            "commit_learning_candidate",
+            LEARNING_RPC_DEADLINE,
+            self.azookey_client.commit_learning_candidate(request),
+        )?;
         let response = response.into_inner();
         self.observe_server_session("commit_learning_candidate", response.server_session_id);
         Ok(())
     }
 
     fn send_shrink_text(&mut self, offset: i32, request_id: u64) -> anyhow::Result<Candidates> {
-        let request = tonic::Request::new(shared::proto::ShrinkTextRequest { offset, request_id });
-        let response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.shrink_text(request))?;
+        let mut request =
+            tonic::Request::new(shared::proto::ShrinkTextRequest { offset, request_id });
+        request.set_timeout(INPUT_RPC_DEADLINE);
+        let response = Self::block_on_server_rpc(
+            self.runtime.as_ref(),
+            &self.recovery,
+            "shrink_text",
+            INPUT_RPC_DEADLINE,
+            self.azookey_client.shrink_text(request),
+        )?;
         let response = response.into_inner();
         self.observe_server_session("shrink_text", response.server_session_id);
+        self.invalidate_input_ledger();
         Self::candidates_from_composing_text(response.composing_text)
     }
 
     fn send_move_cursor(&mut self, offset: i32, request_id: u64) -> anyhow::Result<Candidates> {
-        let request = tonic::Request::new(shared::proto::MoveCursorRequest { offset, request_id });
-        let response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.move_cursor(request))?;
+        let mut request =
+            tonic::Request::new(shared::proto::MoveCursorRequest { offset, request_id });
+        request.set_timeout(INPUT_RPC_DEADLINE);
+        let response = Self::block_on_server_rpc(
+            self.runtime.as_ref(),
+            &self.recovery,
+            "move_cursor",
+            INPUT_RPC_DEADLINE,
+            self.azookey_client.move_cursor(request),
+        )?;
         let response = response.into_inner();
         self.observe_server_session("move_cursor", response.server_session_id);
+        self.record_successful_move(offset);
         Self::candidates_from_composing_text(response.composing_text)
     }
 
     fn send_set_context(&mut self, context: &str, request_id: u64) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::SetContextRequest {
+        let mut request = tonic::Request::new(shared::proto::SetContextRequest {
             context: context.to_string(),
             request_id,
         });
-        let response = self
-            .runtime
-            .clone()
-            .block_on(self.azookey_client.set_context(request))?;
+        request.set_timeout(STATE_RPC_DEADLINE);
+        let response = Self::block_on_server_rpc(
+            self.runtime.as_ref(),
+            &self.recovery,
+            "set_context",
+            STATE_RPC_DEADLINE,
+            self.azookey_client.set_context(request),
+        )?;
         let response = response.into_inner();
         self.observe_server_session("set_context", response.server_session_id);
         Ok(())
+    }
+
+    fn send_replace_composition(
+        &mut self,
+        input_ledger: &InputLedger,
+        request_id: u64,
+    ) -> anyhow::Result<Candidates> {
+        let operations = input_ledger
+            .operations
+            .iter()
+            .map(|operation| match operation {
+                CompositionOperation::Append { text, input_style } => {
+                    shared::proto::CompositionOperation {
+                        kind: shared::proto::CompositionOperationKind::Append as i32,
+                        text: text.clone(),
+                        input_style: *input_style,
+                        cursor_offset: 0,
+                    }
+                }
+                CompositionOperation::Remove => shared::proto::CompositionOperation {
+                    kind: shared::proto::CompositionOperationKind::Remove as i32,
+                    text: String::new(),
+                    input_style: INPUT_STYLE_ROMAN2KANA,
+                    cursor_offset: 0,
+                },
+                CompositionOperation::MoveCursor(cursor_offset) => {
+                    shared::proto::CompositionOperation {
+                        kind: shared::proto::CompositionOperationKind::MoveCursor as i32,
+                        text: String::new(),
+                        input_style: INPUT_STYLE_ROMAN2KANA,
+                        cursor_offset: *cursor_offset,
+                    }
+                }
+            })
+            .collect();
+        let mut request = tonic::Request::new(shared::proto::ReplaceCompositionRequest {
+            operations,
+            request_id,
+        });
+        request.set_timeout(INPUT_RPC_DEADLINE);
+        let response = Self::block_on_server_rpc(
+            self.runtime.as_ref(),
+            &self.recovery,
+            "replace_composition",
+            INPUT_RPC_DEADLINE,
+            self.azookey_client.replace_composition(request),
+        )?
+        .into_inner();
+        self.observe_server_session("replace_composition", response.server_session_id);
+        if let Ok(mut ledger) = self.recovery.input_ledger.lock() {
+            *ledger = input_ledger.clone();
+        }
+        Self::candidates_from_composing_text(response.composing_text)
+    }
+
+    pub(crate) fn recover_composition_if_needed(
+        &mut self,
+        raw_input: &str,
+        direct_input: bool,
+    ) -> anyhow::Result<Option<RecoveredComposition>> {
+        if !self.recovery.pending.load(Ordering::Acquire) {
+            return Ok(None);
+        }
+        if !self.recovery_restart_ready() {
+            return Err(self.recovery_pending_error());
+        }
+
+        let recovery_generation = self.recovery.generation.load(Ordering::Acquire);
+        let input_ledger = self
+            .recovery
+            .input_ledger
+            .lock()
+            .ok()
+            .filter(|ledger| ledger.complete)
+            .map(|ledger| ledger.clone())
+            .unwrap_or_else(|| InputLedger {
+                operations: if raw_input.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![CompositionOperation::Append {
+                        text: raw_input.to_string(),
+                        input_style: if direct_input {
+                            INPUT_STYLE_DIRECT
+                        } else {
+                            INPUT_STYLE_ROMAN2KANA
+                        },
+                    }]
+                },
+                complete: true,
+            });
+
+        self.reconnect().map_err(preserve_recovery_error)?;
+        let candidates = self
+            .send_replace_composition(&input_ledger, current_or_next_request_id())
+            .map_err(preserve_recovery_error)?;
+
+        if !self.recovery_restart_ready() {
+            return Err(self.recovery_pending_error());
+        }
+
+        // A second timeout may have started while this reconstruction was in
+        // progress. Only the generation that we rebuilt is allowed to clear the
+        // recovery flag; late results from an older generation are ignored.
+        if recovery_generation_is_current(
+            recovery_generation,
+            self.recovery.generation.load(Ordering::Acquire),
+        ) {
+            self.recovery.pending.store(false, Ordering::Release);
+        }
+        self.server_reset_recovered = false;
+        Ok(Some(RecoveredComposition { candidates }))
     }
 
     pub(crate) fn connection_id(&self) -> u64 {
@@ -640,8 +1165,8 @@ impl IPCService {
             details,
         };
 
-        if let Err(error) = self.performance_log_tx.send(request) {
-            tracing::debug!("failed to enqueue client performance log: {error:?}");
+        if let Err(error) = self.performance_log_tx.try_send(request) {
+            tracing::debug!("dropped client performance log without blocking input: {error:?}");
         }
     }
 
@@ -754,6 +1279,13 @@ impl IPCService {
         let response = match send(self) {
             Ok(response) => response,
             Err(first_error) => {
+                if !Self::should_reconnect_rpc_error(&first_error) {
+                    tracing::warn!(
+                        "append_text failed without immediate replay (style={input_style}, text_len={}): {first_error:?}",
+                        text.chars().count()
+                    );
+                    return Err(first_error);
+                }
                 tracing::warn!(
                     "append_text first attempt failed (style={input_style}, text_len={}), reconnecting IPC: {first_error:?}",
                     text.chars().count()
@@ -927,7 +1459,21 @@ impl IPCService {
                 Err(error) => format!("status=error;error={error:?}"),
             },
         );
-        result.map(|((), _)| ())
+        match result {
+            Ok(((), _)) => Ok(()),
+            Err(error) if is_ipc_deadline(&error) => {
+                // Clear is an absolute, idempotent desired state. The timeout
+                // already requested a server restart, whose fresh process is
+                // empty, so let the client finish clearing its own preedit.
+                tracing::warn!(
+                    ?error,
+                    "Treating timed-out clear_text as best-effort success"
+                );
+                self.clear_input_ledger();
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
     }
 
     #[tracing::instrument]
@@ -938,18 +1484,18 @@ impl IPCService {
     ) -> anyhow::Result<()> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
-        let result = self.run_rpc_with_reconnect("commit_learning_candidate", |this| {
-            this.send_commit_learning_candidate(candidate_id, commit_kind, request_id)
-        });
+        // Learning is an external side effect and the server has no dedupe
+        // ledger. Never replay it after an ambiguous failure.
+        let result = self.send_commit_learning_candidate(candidate_id, commit_kind, request_id);
         self.log_client_performance_from_start(
             performance_start,
             request_id,
             "commit_learning_candidate",
             "rpc_total",
             || match &result {
-                Ok(((), retried)) => {
+                Ok(()) => {
                     format!(
-                        "status=success;retry={retried};candidate_id={candidate_id};commit_kind={commit_kind}"
+                        "status=success;retry=false;candidate_id={candidate_id};commit_kind={commit_kind}"
                     )
                 }
                 Err(error) => {
@@ -959,7 +1505,7 @@ impl IPCService {
                 }
             },
         );
-        result.map(|((), _)| ())
+        result
     }
 
     #[tracing::instrument]
@@ -1179,9 +1725,14 @@ impl IPCService {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
         let result: anyhow::Result<()> = (|| {
-            let request = tonic::Request::new(shared::proto::EmptyResponse {});
+            let mut request = tonic::Request::new(shared::proto::EmptyResponse {});
+            request.set_timeout(UI_RPC_DEADLINE);
             self.with_window_client("ui_show_window", |runtime, window_client| {
-                runtime.block_on(window_client.show_window(request))?;
+                Self::block_on_window_rpc(
+                    runtime,
+                    "ui_show_window",
+                    window_client.show_window(request),
+                )?;
                 Ok(())
             })
         })();
@@ -1203,9 +1754,14 @@ impl IPCService {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
         let result: anyhow::Result<()> = (|| {
-            let request = tonic::Request::new(shared::proto::EmptyResponse {});
+            let mut request = tonic::Request::new(shared::proto::EmptyResponse {});
+            request.set_timeout(UI_RPC_DEADLINE);
             self.with_window_client("ui_hide_window", |runtime, window_client| {
-                runtime.block_on(window_client.hide_window(request))?;
+                Self::block_on_window_rpc(
+                    runtime,
+                    "ui_hide_window",
+                    window_client.hide_window(request),
+                )?;
                 Ok(())
             })
         })();
@@ -1233,7 +1789,7 @@ impl IPCService {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
         let result: anyhow::Result<()> = (|| {
-            let request = tonic::Request::new(shared::proto::SetPositionRequest {
+            let mut request = tonic::Request::new(shared::proto::SetPositionRequest {
                 position: Some(shared::proto::WindowPosition {
                     top,
                     left,
@@ -1241,8 +1797,13 @@ impl IPCService {
                     right,
                 }),
             });
+            request.set_timeout(UI_RPC_DEADLINE);
             self.with_window_client("ui_set_window_position", |runtime, window_client| {
-                runtime.block_on(window_client.set_window_position(request))?;
+                Self::block_on_window_rpc(
+                    runtime,
+                    "ui_set_window_position",
+                    window_client.set_window_position(request),
+                )?;
                 Ok(())
             })
         })();
@@ -1269,9 +1830,15 @@ impl IPCService {
         let performance_start = client_performance_start();
         let candidate_count = performance_start.map(|_| candidates.len());
         let result: anyhow::Result<()> = (|| {
-            let request = tonic::Request::new(shared::proto::SetCandidateRequest { candidates });
+            let mut request =
+                tonic::Request::new(shared::proto::SetCandidateRequest { candidates });
+            request.set_timeout(UI_RPC_DEADLINE);
             self.with_window_client("ui_set_candidates", |runtime, window_client| {
-                runtime.block_on(window_client.set_candidate(request))?;
+                Self::block_on_window_rpc(
+                    runtime,
+                    "ui_set_candidates",
+                    window_client.set_candidate(request),
+                )?;
                 Ok(())
             })
         })();
@@ -1298,9 +1865,14 @@ impl IPCService {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
         let result: anyhow::Result<()> = (|| {
-            let request = tonic::Request::new(shared::proto::SetSelectionRequest { index });
+            let mut request = tonic::Request::new(shared::proto::SetSelectionRequest { index });
+            request.set_timeout(UI_RPC_DEADLINE);
             self.with_window_client("ui_set_selection", |runtime, window_client| {
-                runtime.block_on(window_client.set_selection(request))?;
+                Self::block_on_window_rpc(
+                    runtime,
+                    "ui_set_selection",
+                    window_client.set_selection(request),
+                )?;
                 Ok(())
             })
         })();
@@ -1322,11 +1894,16 @@ impl IPCService {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
         let result: anyhow::Result<()> = (|| {
-            let request = tonic::Request::new(shared::proto::SetInputModeRequest {
+            let mut request = tonic::Request::new(shared::proto::SetInputModeRequest {
                 mode: mode.to_string(),
             });
+            request.set_timeout(UI_RPC_DEADLINE);
             self.with_window_client("ui_set_input_mode", |runtime, window_client| {
-                runtime.block_on(window_client.set_input_mode(request))?;
+                Self::block_on_window_rpc(
+                    runtime,
+                    "ui_set_input_mode",
+                    window_client.set_input_mode(request),
+                )?;
                 Ok(())
             })
         })();
@@ -1385,7 +1962,7 @@ impl IPCService {
         let reading_present =
             performance_start.map(|_| reading.is_some_and(|value| !value.is_empty()));
         let result: anyhow::Result<WindowRpcDelivery> = (|| {
-            let request = tonic::Request::new(shared::proto::UpdateCandidateWindowRequest {
+            let mut request = tonic::Request::new(shared::proto::UpdateCandidateWindowRequest {
                 visible,
                 position,
                 candidates: candidates
@@ -1396,10 +1973,15 @@ impl IPCService {
                 candidate_list_visible,
                 reading_vertical_adjustment,
             });
+            request.set_timeout(UI_RPC_DEADLINE);
             self.with_window_client_delivery(
                 "ui_update_candidate_window",
                 |runtime, window_client| {
-                    runtime.block_on(window_client.update_candidate_window(request))?;
+                    Self::block_on_window_rpc(
+                        runtime,
+                        "ui_update_candidate_window",
+                        window_client.update_candidate_window(request),
+                    )?;
                     Ok(())
                 },
             )
@@ -1431,7 +2013,195 @@ impl IPCService {
 
 #[cfg(test)]
 mod tests {
-    use super::{Candidates, IPCService, NonIdempotentEditAttempt};
+    use super::{
+        append_input_segment, await_rpc_with_deadline, is_non_destructive_ipc_error,
+        move_input_cursor, pop_input_segment_character, preserve_recovery_error,
+        recovery_generation_is_current, restart_generation_ready, restart_request_needed,
+        Candidates, CompositionOperation, IPCService, InputLedger, IpcDeadlineExceeded,
+        NonIdempotentEditAttempt, INPUT_STYLE_DIRECT, INPUT_STYLE_ROMAN2KANA,
+    };
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        task::{Context, Poll},
+        time::Duration,
+    };
+
+    struct NeverResponds {
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl Future for NeverResponds {
+        type Output = Result<(), tonic::Status>;
+
+        fn poll(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Pending
+        }
+    }
+
+    impl Drop for NeverResponds {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::Release);
+        }
+    }
+
+    #[test]
+    fn timeout_cancels_and_drops_inflight_rpc_future() {
+        let runtime = tokio::runtime::Runtime::new().expect("runtime should initialize");
+        let dropped = Arc::new(AtomicBool::new(false));
+        let error = runtime
+            .block_on(await_rpc_with_deadline(
+                "fault_never_responds",
+                Duration::from_millis(5),
+                NeverResponds {
+                    dropped: dropped.clone(),
+                },
+            ))
+            .expect_err("hung RPC should hit its deadline");
+
+        assert!(error.downcast_ref::<IpcDeadlineExceeded>().is_some());
+        assert!(dropped.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn response_arriving_after_cancel_cannot_complete_old_request() {
+        let runtime = tokio::runtime::Runtime::new().expect("runtime should initialize");
+        let late_delivery_failed = runtime.block_on(async {
+            let (sender, receiver) = tokio::sync::oneshot::channel::<()>();
+            let late_sender = tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                sender.send(()).is_err()
+            });
+
+            let result = await_rpc_with_deadline(
+                "fault_late_response",
+                Duration::from_millis(5),
+                async move {
+                    receiver
+                        .await
+                        .map_err(|_| tonic::Status::cancelled("receiver dropped"))
+                },
+            )
+            .await;
+            assert!(result.is_err());
+            // The response receiver was part of the cancelled RPC future.
+            // A late response has no route back into client state.
+            late_sender.await.expect("late sender task should finish")
+        });
+
+        assert!(late_delivery_failed);
+    }
+
+    #[test]
+    fn server_restart_recovery_ignores_stale_generation_completion() {
+        assert!(recovery_generation_is_current(7, 7));
+        assert!(!recovery_generation_is_current(7, 8));
+    }
+
+    #[test]
+    fn recovery_waits_for_the_requested_restart_generation() {
+        assert!(!restart_generation_ready(0, 0));
+        assert!(!restart_generation_ready(8, 7));
+        assert!(restart_generation_ready(8, 8));
+        assert!(restart_generation_ready(8, 9));
+    }
+
+    #[test]
+    fn failed_launcher_request_is_retried_on_later_input() {
+        assert!(restart_request_needed(true, false, false));
+        assert!(!restart_request_needed(true, false, true));
+        assert!(!restart_request_needed(true, true, false));
+        assert!(!restart_request_needed(false, false, false));
+    }
+
+    #[test]
+    fn mixed_input_ledger_preserves_order_and_style() {
+        let mut ledger = InputLedger {
+            complete: true,
+            ..InputLedger::default()
+        };
+        append_input_segment(&mut ledger, "k", INPUT_STYLE_ROMAN2KANA);
+        append_input_segment(&mut ledger, "あ", INPUT_STYLE_DIRECT);
+        append_input_segment(&mut ledger, "a", INPUT_STYLE_ROMAN2KANA);
+
+        assert_eq!(
+            ledger.operations,
+            vec![
+                CompositionOperation::Append {
+                    text: "k".to_string(),
+                    input_style: INPUT_STYLE_ROMAN2KANA,
+                },
+                CompositionOperation::Append {
+                    text: "あ".to_string(),
+                    input_style: INPUT_STYLE_DIRECT,
+                },
+                CompositionOperation::Append {
+                    text: "a".to_string(),
+                    input_style: INPUT_STYLE_ROMAN2KANA,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn input_ledger_records_successful_mutations_in_order() {
+        let mut ledger = InputLedger {
+            complete: true,
+            ..InputLedger::default()
+        };
+        append_input_segment(&mut ledger, "ka", INPUT_STYLE_ROMAN2KANA);
+        move_input_cursor(&mut ledger, -1);
+        append_input_segment(&mut ledger, "あ", INPUT_STYLE_DIRECT);
+        pop_input_segment_character(&mut ledger);
+
+        assert_eq!(
+            ledger.operations,
+            vec![
+                CompositionOperation::Append {
+                    text: "ka".to_string(),
+                    input_style: INPUT_STYLE_ROMAN2KANA,
+                },
+                CompositionOperation::MoveCursor(-1),
+                CompositionOperation::Append {
+                    text: "あ".to_string(),
+                    input_style: INPUT_STYLE_DIRECT,
+                },
+                CompositionOperation::Remove,
+            ]
+        );
+    }
+
+    #[test]
+    fn server_restart_connection_gap_preserves_client_composition() {
+        let error = preserve_recovery_error(anyhow::anyhow!(
+            "named pipe is briefly absent while launcher restarts server"
+        ));
+
+        assert!(is_non_destructive_ipc_error(&error));
+        assert!(error.to_string().contains("recovery is still pending"));
+    }
+
+    #[test]
+    fn deadline_never_uses_immediate_retry_policy() {
+        let error = anyhow::Error::new(IpcDeadlineExceeded {
+            operation: "append_text",
+            deadline: Duration::from_secs(2),
+        });
+
+        assert!(!IPCService::should_reconnect_rpc_error(&error));
+    }
+
+    #[test]
+    fn grpc_deadline_status_never_replays_non_idempotent_rpc() {
+        let error = anyhow::Error::new(tonic::Status::deadline_exceeded("server timed out"));
+
+        assert!(is_non_destructive_ipc_error(&error));
+        assert!(!IPCService::should_reconnect_rpc_error(&error));
+    }
 
     #[test]
     fn append_retry_is_enabled_when_server_state_is_unchanged() {

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -222,6 +222,29 @@ fn mark_input_ledger_incomplete(ledger: &mut InputLedger) {
     ledger.complete = false;
 }
 
+fn fallback_input_ledger(raw_input: &str, raw_hiragana: &str) -> InputLedger {
+    let (text, input_style) = if raw_input.is_empty() {
+        (raw_hiragana, INPUT_STYLE_DIRECT)
+    } else {
+        // raw_hiragana may still contain an incomplete roman2kana sequence such as
+        // `k`. Replaying raw_input preserves that converter buffer, while kana in
+        // raw_input is also accepted by the roman2kana input path.
+        (raw_input, INPUT_STYLE_ROMAN2KANA)
+    };
+
+    InputLedger {
+        operations: if text.is_empty() {
+            Vec::new()
+        } else {
+            vec![CompositionOperation::Append {
+                text: text.to_string(),
+                input_style,
+            }]
+        },
+        complete: true,
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Candidates {
     pub texts: Vec<String>,
@@ -1099,7 +1122,7 @@ impl IPCService {
     pub(crate) fn recover_composition_if_needed(
         &mut self,
         raw_input: &str,
-        direct_input: bool,
+        raw_hiragana: &str,
     ) -> anyhow::Result<Option<RecoveredComposition>> {
         if !self.recovery.pending.load(Ordering::Acquire) {
             return Ok(None);
@@ -1116,21 +1139,7 @@ impl IPCService {
             .ok()
             .filter(|ledger| ledger.complete)
             .map(|ledger| ledger.clone())
-            .unwrap_or_else(|| InputLedger {
-                operations: if raw_input.is_empty() {
-                    Vec::new()
-                } else {
-                    vec![CompositionOperation::Append {
-                        text: raw_input.to_string(),
-                        input_style: if direct_input {
-                            INPUT_STYLE_DIRECT
-                        } else {
-                            INPUT_STYLE_ROMAN2KANA
-                        },
-                    }]
-                },
-                complete: true,
-            });
+            .unwrap_or_else(|| fallback_input_ledger(raw_input, raw_hiragana));
 
         self.reconnect().map_err(preserve_recovery_error)?;
         let candidates = self
@@ -2024,11 +2033,12 @@ impl IPCService {
 #[cfg(test)]
 mod tests {
     use super::{
-        append_input_segment, await_rpc_with_deadline, is_non_destructive_ipc_error,
-        mark_input_ledger_incomplete, move_input_cursor, pop_input_segment_character,
-        preserve_recovery_error, recovery_generation_is_current, restart_generation_ready,
-        restart_request_needed, Candidates, CompositionOperation, IPCService, InputLedger,
-        IpcDeadlineExceeded, NonIdempotentEditAttempt, INPUT_STYLE_DIRECT, INPUT_STYLE_ROMAN2KANA,
+        append_input_segment, await_rpc_with_deadline, fallback_input_ledger,
+        is_non_destructive_ipc_error, mark_input_ledger_incomplete, move_input_cursor,
+        pop_input_segment_character, preserve_recovery_error, recovery_generation_is_current,
+        restart_generation_ready, restart_request_needed, Candidates, CompositionOperation,
+        IPCService, InputLedger, IpcDeadlineExceeded, NonIdempotentEditAttempt, INPUT_STYLE_DIRECT,
+        INPUT_STYLE_ROMAN2KANA,
     };
     use std::{
         future::Future,
@@ -2501,5 +2511,33 @@ mod tests {
 
         assert!(ledger.operations.is_empty());
         assert!(!ledger.complete);
+    }
+
+    #[test]
+    fn fallback_input_ledger_preserves_pending_romaji_state() {
+        let ledger = fallback_input_ledger("k", "k");
+
+        assert_eq!(
+            ledger.operations,
+            vec![CompositionOperation::Append {
+                text: "k".to_string(),
+                input_style: INPUT_STYLE_ROMAN2KANA,
+            }]
+        );
+        assert!(ledger.complete);
+    }
+
+    #[test]
+    fn fallback_input_ledger_uses_direct_reading_without_raw_input() {
+        let ledger = fallback_input_ledger("", "かな");
+
+        assert_eq!(
+            ledger.operations,
+            vec![CompositionOperation::Append {
+                text: "かな".to_string(),
+                input_style: INPUT_STYLE_DIRECT,
+            }]
+        );
+        assert!(ledger.complete);
     }
 }

--- a/crates/client/src/engine/user_action.rs
+++ b/crates/client/src/engine/user_action.rs
@@ -4,7 +4,7 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     GetKeyboardState, ToUnicode, VK_CONTROL, VK_LCONTROL, VK_RCONTROL, VK_SHIFT,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum UserAction {
     Input(char),
     Backspace,
@@ -26,7 +26,7 @@ pub enum UserAction {
     InputModeOff,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Navigation {
     Up,
     Down,

--- a/crates/client/src/launcher_control.rs
+++ b/crates/client/src/launcher_control.rs
@@ -1,0 +1,90 @@
+use anyhow::{Context as _, Result};
+use std::time::{Duration, Instant};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::windows::named_pipe::{ClientOptions, NamedPipeClient},
+    time,
+};
+use windows::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, ERROR_PIPE_BUSY};
+
+const LAUNCHER_PIPE_PATH: &str = r"\\.\pipe\azookey_launcher";
+const LAUNCHER_RESTART_COMMAND: &[u8] = b"restart-server\n";
+const LAUNCHER_CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
+const LAUNCHER_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+const LAUNCHER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub(crate) fn request_restart() -> Result<()> {
+    let runtime = tokio::runtime::Runtime::new()?;
+    runtime.block_on(async {
+        let mut client = open_launcher_pipe()
+            .await?
+            .context("Launcher restart pipe is not available")?;
+
+        client
+            .write_all(LAUNCHER_RESTART_COMMAND)
+            .await
+            .context("Failed to write launcher restart request")?;
+        client
+            .flush()
+            .await
+            .context("Failed to flush launcher restart request")?;
+
+        let mut response = [0u8; 512];
+        let size = time::timeout(LAUNCHER_RESPONSE_TIMEOUT, client.read(&mut response))
+            .await
+            .context("Timed out waiting for launcher restart response")?
+            .context("Failed to read launcher restart response")?;
+        parse_launcher_response(&response[..size])
+    })
+}
+
+async fn open_launcher_pipe() -> Result<Option<NamedPipeClient>> {
+    let started_at = Instant::now();
+
+    loop {
+        match ClientOptions::new().open(LAUNCHER_PIPE_PATH) {
+            Ok(client) => return Ok(Some(client)),
+            Err(error) if launcher_pipe_missing(error.raw_os_error()) => return Ok(None),
+            Err(error)
+                if error.raw_os_error() == Some(ERROR_PIPE_BUSY.0 as i32)
+                    && started_at.elapsed() < LAUNCHER_CONNECT_TIMEOUT =>
+            {
+                time::sleep(LAUNCHER_RETRY_INTERVAL).await;
+            }
+            Err(error) => return Err(error).context("Failed to connect launcher restart pipe"),
+        }
+    }
+}
+
+fn launcher_pipe_missing(raw_os_error: Option<i32>) -> bool {
+    raw_os_error == Some(ERROR_FILE_NOT_FOUND.0 as i32)
+        || raw_os_error == Some(ERROR_PATH_NOT_FOUND.0 as i32)
+}
+
+pub(crate) fn parse_launcher_response(bytes: &[u8]) -> Result<()> {
+    let response = std::str::from_utf8(bytes)
+        .context("Launcher restart response is not UTF-8")?
+        .trim();
+
+    if response == "ok" {
+        return Ok(());
+    }
+
+    if let Some(message) = response.strip_prefix("error:") {
+        anyhow::bail!("Launcher failed to restart server: {}", message.trim());
+    }
+
+    anyhow::bail!("Unexpected launcher restart response: {response}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_launcher_response;
+
+    #[test]
+    fn launcher_restart_response_is_strictly_validated() {
+        assert!(parse_launcher_response(b"ok\n").is_ok());
+        assert!(parse_launcher_response(b"error: restart throttled\n").is_err());
+        assert!(parse_launcher_response(b"unexpected\n").is_err());
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,6 +1,7 @@
 mod engine;
 mod extension;
 mod globals;
+mod launcher_control;
 mod macros;
 mod register;
 mod trace;

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -3,21 +3,14 @@ use std::{
     os::windows::ffi::OsStrExt as _,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU32, Ordering},
-    time::{Duration, Instant},
-};
-
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::windows::named_pipe::{ClientOptions, NamedPipeClient},
-    time,
 };
 use windows::{
     core::{w, IUnknown, Interface as _, BSTR, GUID, PCWSTR},
     Win32::{
         Foundation::{
             GetLastError, BOOL, ERROR_CLASS_ALREADY_EXISTS, ERROR_FILE_NOT_FOUND,
-            ERROR_PATH_NOT_FOUND, ERROR_PIPE_BUSY, ERROR_SUCCESS, E_INVALIDARG, HINSTANCE, HWND,
-            LPARAM, LRESULT, POINT, RECT, WPARAM,
+            ERROR_PATH_NOT_FOUND, ERROR_SUCCESS, E_INVALIDARG, HINSTANCE, HWND, LPARAM, LRESULT,
+            POINT, RECT, WPARAM,
         },
         System::{
             Ole::CONNECT_E_CANNOTCONNECT,
@@ -51,6 +44,7 @@ use crate::{
     },
     extension::StringExt as _,
     globals::{DllModule, GUID_TEXT_SERVICE, TEXTSERVICE_LANGBARITEMSINK_COOKIE},
+    launcher_control,
 };
 
 use anyhow::{Context as _, Result};
@@ -69,11 +63,6 @@ const SETTINGS_MENU_ID: usize = 1;
 const RESTART_SERVER_MENU_ID: usize = 2;
 const SETTINGS_APP_DIRNAME: &str = "Azookey";
 const SETTINGS_APP_FILENAME: &str = "frontend.exe";
-const LAUNCHER_PIPE_PATH: &str = r"\\.\pipe\azookey_launcher";
-const LAUNCHER_RESTART_COMMAND: &[u8] = b"restart-server\n";
-const LAUNCHER_CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
-const LAUNCHER_RETRY_INTERVAL: Duration = Duration::from_millis(50);
-const LAUNCHER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
 const SETTINGS_APP_INNO_UNINSTALL_SUBKEY: PCWSTR = w!(
     r"Software\Microsoft\Windows\CurrentVersion\Uninstall\{80B746D4-D74D-4345-8F81-47E06BCAB515}_is1"
 );
@@ -245,75 +234,9 @@ impl ITfLangBarItemButton_Impl for TextServiceFactory_Impl {
 }
 
 fn restart_server_with_logging() {
-    if let Err(error) = request_launcher_restart() {
+    if let Err(error) = launcher_control::request_restart() {
         tracing::warn!(?error, "Failed to restart server from language bar");
     }
-}
-
-fn request_launcher_restart() -> Result<()> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
-        let mut client = open_launcher_pipe()
-            .await?
-            .context("Launcher restart pipe is not available")?;
-
-        client
-            .write_all(LAUNCHER_RESTART_COMMAND)
-            .await
-            .context("Failed to write launcher restart request")?;
-        client
-            .flush()
-            .await
-            .context("Failed to flush launcher restart request")?;
-
-        let mut response = [0u8; 512];
-        let size = time::timeout(LAUNCHER_RESPONSE_TIMEOUT, client.read(&mut response))
-            .await
-            .context("Timed out waiting for launcher restart response")?
-            .context("Failed to read launcher restart response")?;
-        parse_launcher_response(&response[..size])
-    })
-}
-
-async fn open_launcher_pipe() -> Result<Option<NamedPipeClient>> {
-    let started_at = Instant::now();
-
-    loop {
-        match ClientOptions::new().open(LAUNCHER_PIPE_PATH) {
-            Ok(client) => return Ok(Some(client)),
-            Err(error) if launcher_pipe_missing(error.raw_os_error()) => return Ok(None),
-            Err(error)
-                if error.raw_os_error() == Some(ERROR_PIPE_BUSY.0 as i32)
-                    && started_at.elapsed() < LAUNCHER_CONNECT_TIMEOUT =>
-            {
-                time::sleep(LAUNCHER_RETRY_INTERVAL).await;
-            }
-            Err(error) => {
-                return Err(error).context("Failed to connect launcher restart pipe");
-            }
-        }
-    }
-}
-
-fn launcher_pipe_missing(raw_os_error: Option<i32>) -> bool {
-    raw_os_error == Some(ERROR_FILE_NOT_FOUND.0 as i32)
-        || raw_os_error == Some(ERROR_PATH_NOT_FOUND.0 as i32)
-}
-
-fn parse_launcher_response(bytes: &[u8]) -> Result<()> {
-    let response = std::str::from_utf8(bytes)
-        .context("Launcher restart response is not UTF-8")?
-        .trim();
-
-    if response == "ok" {
-        return Ok(());
-    }
-
-    if let Some(message) = response.strip_prefix("error:") {
-        anyhow::bail!("Launcher failed to restart server: {}", message.trim());
-    }
-
-    anyhow::bail!("Unexpected launcher restart response: {response}");
 }
 
 fn launch_settings_app_with_logging() {
@@ -795,9 +718,10 @@ impl ITfSource_Impl for TextServiceFactory_Impl {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_launcher_response, resolve_settings_app_path_from_install_location,
-        select_existing_settings_app_path, trim_registry_string, SettingsAppPath,
+        resolve_settings_app_path_from_install_location, select_existing_settings_app_path,
+        trim_registry_string, SettingsAppPath,
     };
+    use crate::launcher_control::parse_launcher_response;
     use std::path::PathBuf;
 
     #[test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -8,8 +8,9 @@ use windows::Win32::System::Threading::{GetCurrentProcess, SetPriorityClass, HIG
 use shared::proto::azookey_service_server::{AzookeyService, AzookeyServiceServer};
 use shared::proto::{
     AppendTextRequest, AppendTextResponse, ClearTextRequest, ClearTextResponse, ComposingText,
-    MoveCursorRequest, MoveCursorResponse, PerformanceLogRequest, PerformanceLogResponse,
-    RemoveTextRequest, RemoveTextResponse, ShrinkTextRequest, ShrinkTextResponse, Suggestion,
+    CompositionOperationKind, MoveCursorRequest, MoveCursorResponse, PerformanceLogRequest,
+    PerformanceLogResponse, RemoveTextRequest, RemoveTextResponse, ReplaceCompositionRequest,
+    ReplaceCompositionResponse, ShrinkTextRequest, ShrinkTextResponse, Suggestion,
 };
 use shared::AppConfig;
 
@@ -22,7 +23,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
-        mpsc, OnceLock,
+        mpsc, Arc, OnceLock,
     },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -1354,8 +1355,10 @@ fn shrink_text(offset: i8) -> Result<RawComposingText, String> {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct MyAzookeyService;
+#[derive(Debug, Clone, Default)]
+pub struct MyAzookeyService {
+    mutation_lock: Arc<tokio::sync::Mutex<()>>,
+}
 
 #[tonic::async_trait]
 impl AzookeyService for MyAzookeyService {
@@ -1363,6 +1366,7 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<AppendTextRequest>,
     ) -> Result<Response<AppendTextResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
         let request = request.into_inner();
         let _request_guard = ServerRequestGuard::begin(true);
         let request_id = request_id_or_next(request.request_id);
@@ -1422,10 +1426,90 @@ impl AzookeyService for MyAzookeyService {
         }))
     }
 
+    async fn replace_composition(
+        &self,
+        request: Request<ReplaceCompositionRequest>,
+    ) -> Result<Response<ReplaceCompositionResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
+        let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(true);
+        let request_id = request_id_or_next(request.request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+
+        // This is an absolute-state operation: clear the old converter state and
+        // replay the complete client-observed mutation log. It is safe to repeat after a
+        // timeout whose server-side completion is unknown.
+        clear_text();
+        let mut composing_text = RawComposingText {
+            text: String::new(),
+            cursor: 0,
+        };
+        for operation in &request.operations {
+            match CompositionOperationKind::try_from(operation.kind)
+                .map_err(|_| Status::invalid_argument("unknown composition operation"))?
+            {
+                CompositionOperationKind::Append => {
+                    composing_text = if operation.input_style == INPUT_STYLE_DIRECT {
+                        add_text_direct(&operation.text)
+                            .map_err(|error| status_from_error("replace_composition", error))?
+                    } else {
+                        add_text(&operation.text)
+                            .map_err(|error| status_from_error("replace_composition", error))?
+                    };
+                }
+                CompositionOperationKind::Remove => {
+                    composing_text = remove_text()
+                        .map_err(|error| status_from_error("replace_composition", error))?;
+                }
+                CompositionOperationKind::MoveCursor => {
+                    let mut remaining_offset = operation.cursor_offset;
+                    while remaining_offset != 0 {
+                        let chunk = remaining_offset.clamp(-124, 124);
+                        let offset = i8_offset_from_i32("replace_composition", chunk)?;
+                        composing_text = move_cursor(offset)
+                            .map_err(|error| status_from_error("replace_composition", error))?;
+                        remaining_offset -= chunk;
+                    }
+                }
+            }
+        }
+
+        let composed_text = if composing_text.text.is_empty() {
+            ComposedText {
+                hiragana: Some(String::new()),
+                suggestions: Vec::new(),
+            }
+        } else {
+            get_composed_text(false, request_id)
+                .map_err(|error| status_from_error("replace_composition", error))?
+        };
+        update_active_composition_state(&composing_text.text);
+        performance_event_lazy!(
+            request_id,
+            "replace_composition",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success;operations={};hiragana_len={};suggestions={}",
+            request.operations.len(),
+            composing_text.text.chars().count(),
+            composed_text.suggestions.len()
+        );
+
+        Ok(Response::new(ReplaceCompositionResponse {
+            composing_text: Some(ComposingText {
+                hiragana: composed_text.hiragana.unwrap_or(composing_text.text),
+                suggestions: composed_text.suggestions,
+            }),
+            server_session_id: server_session_id(),
+        }))
+    }
+
     async fn remove_text(
         &self,
         request: Request<RemoveTextRequest>,
     ) -> Result<Response<RemoveTextResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
         let request = request.into_inner();
         let _request_guard = ServerRequestGuard::begin(true);
         let request_id = request_id_or_next(request.request_id);
@@ -1479,6 +1563,7 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<MoveCursorRequest>,
     ) -> Result<Response<MoveCursorResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
         let request = request.into_inner();
         let _request_guard = ServerRequestGuard::begin(true);
         let request_id = request_id_or_next(request.request_id);
@@ -1535,6 +1620,7 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<ClearTextRequest>,
     ) -> Result<Response<ClearTextResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
         let request = request.into_inner();
         let _request_guard = ServerRequestGuard::begin(true);
         let request_id = request_id_or_next(request.request_id);
@@ -1566,6 +1652,7 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<ShrinkTextRequest>,
     ) -> Result<Response<ShrinkTextResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
         let request = request.into_inner();
         let _request_guard = ServerRequestGuard::begin(true);
         let request_id = request_id_or_next(request.request_id);
@@ -1620,6 +1707,7 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<shared::proto::SetContextRequest>,
     ) -> Result<Response<shared::proto::SetContextResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
         let request = request.into_inner();
         let _request_guard = ServerRequestGuard::begin(false);
         let request_id = request_id_or_next(request.request_id);
@@ -1662,6 +1750,7 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<shared::proto::UpdateConfigRequest>,
     ) -> Result<Response<shared::proto::UpdateConfigResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
         let request = request.into_inner();
         let _request_guard = ServerRequestGuard::begin(false);
         let request_id = request_id_or_next(request.request_id);
@@ -1695,6 +1784,7 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<shared::proto::CommitLearningCandidateRequest>,
     ) -> Result<Response<shared::proto::CommitLearningCandidateResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
         let request = request.into_inner();
         let _request_guard = ServerRequestGuard::begin(true);
         let request_id = request_id_or_next(request.request_id);
@@ -1739,6 +1829,7 @@ impl AzookeyService for MyAzookeyService {
         &self,
         request: Request<shared::proto::ResetLearningMemoryRequest>,
     ) -> Result<Response<shared::proto::ResetLearningMemoryResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
         let request = request.into_inner();
         let _request_guard = ServerRequestGuard::begin(false);
         let request_id = request_id_or_next(request.request_id);
@@ -1937,8 +2028,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 mod path_tests {
-    use super::resolve_log_path_from_roots;
+    use super::{resolve_log_path_from_roots, MyAzookeyService};
     use std::{ffi::OsStr, path::Path};
+
+    #[tokio::test]
+    async fn mutation_lock_keeps_replace_transaction_exclusive() {
+        let service = MyAzookeyService::default();
+        let first = service.mutation_lock.lock().await;
+
+        let second = tokio::time::timeout(
+            std::time::Duration::from_millis(5),
+            service.mutation_lock.lock(),
+        )
+        .await;
+        assert!(second.is_err(), "second mutation must wait for first");
+
+        drop(first);
+        let _second = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            service.mutation_lock.lock(),
+        )
+        .await
+        .expect("lock should become available");
+    }
 
     #[test]
     fn server_logs_use_app_data() {

--- a/crates/shared/service.proto
+++ b/crates/shared/service.proto
@@ -33,6 +33,32 @@ message AppendTextResponse {
   uint64 server_session_id = 2; // Identifies the current server process session.
 }
 
+// A client-observed successful mutation used to rebuild server composition
+// after an ambiguous transport failure. Replaying the complete log after a
+// clear is intentionally idempotent.
+enum CompositionOperationKind {
+  COMPOSITION_OPERATION_KIND_APPEND = 0;
+  COMPOSITION_OPERATION_KIND_REMOVE = 1;
+  COMPOSITION_OPERATION_KIND_MOVE_CURSOR = 2;
+}
+
+message CompositionOperation {
+  CompositionOperationKind kind = 1;
+  string text = 2;
+  InputStyle input_style = 3;
+  int32 cursor_offset = 4;
+}
+
+message ReplaceCompositionRequest {
+  repeated CompositionOperation operations = 1;
+  uint64 request_id = 2;
+}
+
+message ReplaceCompositionResponse {
+  ComposingText composing_text = 1;
+  uint64 server_session_id = 2;
+}
+
 // Request message for RemoveText.
 message RemoveTextRequest {
   uint64 request_id = 1;
@@ -134,6 +160,7 @@ message PerformanceLogResponse {}
 // Service definition for text editing operations.
 service AzookeyService {
   rpc AppendText (AppendTextRequest) returns (AppendTextResponse);
+  rpc ReplaceComposition (ReplaceCompositionRequest) returns (ReplaceCompositionResponse);
   rpc RemoveText (RemoveTextRequest) returns (RemoveTextResponse);
   rpc ShrinkText (ShrinkTextRequest) returns (ShrinkTextResponse);
   rpc MoveCursor (MoveCursorRequest) returns (MoveCursorResponse);

--- a/frontend/src-tauri/src/ipc.rs
+++ b/frontend/src-tauri/src/ipc.rs
@@ -49,6 +49,7 @@ impl IPCService {
 
     fn new_inner(timeout: Option<Duration>) -> Result<Self> {
         let runtime = tokio::runtime::Runtime::new()?;
+        let connect_deadline = connect_deadline(timeout);
 
         let endpoint = Endpoint::try_from("http://[::]:50051")?;
         let connect = endpoint.connect_with_connector(service_fn(move |_| async move {
@@ -71,7 +72,7 @@ impl IPCService {
             Ok::<_, std::io::Error>(TokioIo::new(client))
         }));
         let server_channel: tonic::transport::Channel = runtime.block_on(async {
-            match time::timeout(IPC_CONNECT_DEADLINE, connect).await {
+            match time::timeout(connect_deadline, connect).await {
                 Ok(result) => result.map_err(anyhow::Error::from),
                 Err(_) => Err(anyhow::anyhow!("settings IPC connect deadline exceeded")),
             }
@@ -84,6 +85,10 @@ impl IPCService {
             runtime: Arc::new(runtime),
         })
     }
+}
+
+fn connect_deadline(timeout: Option<Duration>) -> Duration {
+    timeout.unwrap_or(IPC_CONNECT_DEADLINE)
 }
 
 fn should_retry_pipe_connect_error(
@@ -149,10 +154,18 @@ impl IPCService {
 #[cfg(test)]
 mod tests {
     use super::{
-        should_retry_pipe_connect_error, ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND,
-        ERROR_PIPE_BUSY,
+        connect_deadline, should_retry_pipe_connect_error, ERROR_FILE_NOT_FOUND,
+        ERROR_PATH_NOT_FOUND, ERROR_PIPE_BUSY, IPC_CONNECT_DEADLINE,
     };
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn explicit_reconnect_timeout_controls_outer_deadline() {
+        let reconnect_timeout = Duration::from_secs(10);
+
+        assert_eq!(connect_deadline(Some(reconnect_timeout)), reconnect_timeout);
+        assert_eq!(connect_deadline(None), IPC_CONNECT_DEADLINE);
+    }
 
     #[test]
     fn retries_missing_and_busy_pipe_errors_before_timeout() {

--- a/frontend/src-tauri/src/ipc.rs
+++ b/frontend/src-tauri/src/ipc.rs
@@ -12,6 +12,8 @@ use windows::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, ERR
 
 const SERVER_PIPE_PATH: &str = r"\\.\pipe\azookey_server";
 const IPC_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+const IPC_CONNECT_DEADLINE: Duration = Duration::from_secs(2);
+const SETTINGS_RPC_DEADLINE: Duration = Duration::from_secs(5);
 
 // connect to kkc server
 #[derive(Debug, Clone)]
@@ -48,29 +50,32 @@ impl IPCService {
     fn new_inner(timeout: Option<Duration>) -> Result<Self> {
         let runtime = tokio::runtime::Runtime::new()?;
 
-        let server_channel = runtime.block_on(
-            Endpoint::try_from("http://[::]:50051")?.connect_with_connector(service_fn(
-                move |_| async move {
-                    let started_at = Instant::now();
-                    let client = loop {
-                        match ClientOptions::new().open(SERVER_PIPE_PATH) {
-                            Ok(client) => break client,
-                            Err(e)
-                                if should_retry_pipe_connect_error(
-                                    e.raw_os_error(),
-                                    started_at,
-                                    timeout,
-                                ) => {}
-                            Err(e) => return Err(e),
-                        }
+        let endpoint = Endpoint::try_from("http://[::]:50051")?;
+        let connect = endpoint.connect_with_connector(service_fn(move |_| async move {
+            let started_at = Instant::now();
+            let client = loop {
+                match ClientOptions::new().open(SERVER_PIPE_PATH) {
+                    Ok(client) => break client,
+                    Err(e)
+                        if should_retry_pipe_connect_error(
+                            e.raw_os_error(),
+                            started_at,
+                            timeout,
+                        ) => {}
+                    Err(e) => return Err(e),
+                }
 
-                        time::sleep(IPC_RETRY_INTERVAL).await;
-                    };
+                time::sleep(IPC_RETRY_INTERVAL).await;
+            };
 
-                    Ok::<_, std::io::Error>(TokioIo::new(client))
-                },
-            )),
-        )?;
+            Ok::<_, std::io::Error>(TokioIo::new(client))
+        }));
+        let server_channel: tonic::transport::Channel = runtime.block_on(async {
+            match time::timeout(IPC_CONNECT_DEADLINE, connect).await {
+                Ok(result) => result.map_err(anyhow::Error::from),
+                Err(_) => Err(anyhow::anyhow!("settings IPC connect deadline exceeded")),
+            }
+        })?;
 
         let azookey_client = AzookeyServiceClient::new(server_channel);
 
@@ -100,21 +105,41 @@ fn should_retry_pipe_connect_error(
 // implement methods to interact with kkc server
 impl IPCService {
     pub fn update_config(&mut self) -> anyhow::Result<()> {
-        let request = tonic::Request::new(shared::proto::UpdateConfigRequest { request_id: 0 });
-        self.runtime
-            .clone()
-            .block_on(self.azookey_client.update_config(request))?;
+        let mut request = tonic::Request::new(shared::proto::UpdateConfigRequest { request_id: 0 });
+        request.set_timeout(SETTINGS_RPC_DEADLINE);
+        self.runtime.clone().block_on(async {
+            time::timeout(
+                SETTINGS_RPC_DEADLINE,
+                self.azookey_client.update_config(request),
+            )
+            .await
+            .map_err(|_| anyhow::anyhow!("update_config IPC deadline exceeded"))??;
+            anyhow::Ok(())
+        })?;
 
         Ok(())
     }
 
     pub fn reset_learning_memory(&mut self) -> anyhow::Result<bool> {
-        let request =
+        let mut request =
             tonic::Request::new(shared::proto::ResetLearningMemoryRequest { request_id: 0 });
+        request.set_timeout(SETTINGS_RPC_DEADLINE);
         let response = self
             .runtime
             .clone()
-            .block_on(self.azookey_client.reset_learning_memory(request))?
+            .block_on(async {
+                match time::timeout(
+                    SETTINGS_RPC_DEADLINE,
+                    self.azookey_client.reset_learning_memory(request),
+                )
+                .await
+                {
+                    Ok(result) => result.map_err(anyhow::Error::from),
+                    Err(_) => Err(anyhow::anyhow!(
+                        "reset_learning_memory IPC deadline exceeded"
+                    )),
+                }
+            })?
             .into_inner();
 
         Ok(response.reset)


### PR DESCRIPTION
## Summary
- 入力ホットパスを含む全 RPC に明示的な deadline を設定し、ハング時に TSF スレッドが無期限停止しないようにしました。
- timeout/cancel 後は launcher 経由で server を再起動し、成功済み操作ログから composition を再構築して、保留入力を物理順 FIFO で再実行します。
- late response、server restart、非冪等 RPC の retry 抑止、復旧中入力を対象とする fault-injection 回帰テストを追加しました。

## Background
- Issue: #140
- Issue close: 対象リリース公開・成果物確認後
- Named Pipe / gRPC 呼び出しが応答しない場合でも入力を有限時間で戻し、変換途中の状態を破壊せず入力を再開できるようにするための変更です。

## Changes
- client IPC: connect/RPC 別 deadline、future cancel、launcher restart generation、冪等性別 retry policy を追加
- composition recovery: 成功済み mutation operation log と `ReplaceComposition` RPC による冪等な状態再構築を追加
- input handling: recovery 中の user action / client action を物理順 FIFO で保留し、mode・Shift・raw input を含む projection と復旧後再計画を追加
- server: composition mutation を共有 lock で直列化し、置換トランザクションへの割り込みを防止
- settings/UI/performance: RPC deadline と bounded/best-effort 処理を追加
- tests: timeout/cancel/late response/restart/retry/reconstruction/deferred input の回帰テストを追加

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/29970296606
- [ ] Windows 実機確認
  - 手動入力確認: 未実施
- [x] Windows VM test 成功
  - `deferred_projection`: 4 passed（`.local/logs/vm-client-test-20260723-075603.log`）
  - `deadline`: 3 passed（`.local/logs/vm-client-test-20260723-080157.log`）
  - `ambiguous_non_idempotent_refresh_invalidates_input_ledger`: 1 passed（`.local/logs/vm-client-test-20260723-092433.log`）
  - `fallback_input_ledger`: 2 passed（`.local/logs/vm-client-test-20260723-094803.log`）
- [x] Windows VM build / installer 作成成功
  - artifact: `.local/artifacts/azookey-setup-fix_140-ipc-deadline-recovery-20260723-080709.exe`
- [x] ローカル静的検証
  - `cargo fmt --all`
  - x86_64 Windows workspace tests の `cargo check`
  - i686 Windows の shared/client/server tests の `cargo check`
  - `git diff --check`

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
