### PR TITLE
Remove i8 limit from clause operation offsets

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -20,8 +20,8 @@ use super::{
     input_mode::InputMode,
     ipc_service::{
         client_performance_log_enabled, current_input_trace_request_id,
-        is_non_destructive_ipc_error, Candidates, ClientInputTraceGuard, IPCService,
-        WindowRpcDelivery,
+        is_non_destructive_ipc_error, requires_ipc_recovery, Candidates, ClauseSnapshotOperation,
+        ClientInputTraceGuard, IPCService, WindowRpcDelivery,
     },
     romaji_lookup::RomajiLookup,
     state::{keyboard_disabled_from_context, AppConfigSnapshot, IMEState},
@@ -256,9 +256,6 @@ impl ITfCompositionSink_Impl for TextServiceFactory_Impl {
 }
 
 impl TextServiceFactory {
-    const MOVE_CURSOR_CLEAR_CLAUSE_SNAPSHOTS: i32 = 125;
-    const MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT: i32 = 126;
-    const MOVE_CURSOR_POP_CLAUSE_SNAPSHOT: i32 = 127;
     const MOVE_CLAUSE_TO_LAST: i32 = i32::MAX;
 
     fn log_client_performance(
@@ -1507,9 +1504,7 @@ impl TextServiceFactory {
         }
 
         clause_snapshots.clear();
-        let _ = ipc_service
-            .move_cursor_with_context(Self::MOVE_CURSOR_CLEAR_CLAUSE_SNAPSHOTS, candidates)?;
-        Ok(())
+        ipc_service.update_composition_snapshot(ClauseSnapshotOperation::Clear, candidates)
     }
 
     #[inline]
@@ -2554,10 +2549,8 @@ impl TextServiceFactory {
 
         for _ in 0..temp_clause_snapshots.len() {
             let previous_candidates = temp_candidates.clone();
-            let _ = backend.move_cursor_with_context(
-                Self::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT,
-                &previous_candidates,
-            )?;
+            backend
+                .update_composition_snapshot(ClauseSnapshotOperation::Pop, &previous_candidates)?;
         }
 
         state.future_clause_snapshots.clear();
@@ -4313,7 +4306,7 @@ impl TextServiceFactory {
             Err(error) if is_non_destructive_ipc_error(&error) => {
                 tracing::warn!(
                     ?error,
-                    "IPC deadline exceeded; preserving the current composition for recovery"
+                    "IPC operation failed without mutating server state; preserving composition"
                 );
                 Ok(true)
             }
@@ -4380,7 +4373,7 @@ impl TextServiceFactory {
             Err(error) if is_non_destructive_ipc_error(&error) => {
                 tracing::warn!(
                     ?error,
-                    "IPC deadline exceeded on key-up; preserving current composition"
+                    "IPC key-up operation failed without mutation; preserving composition"
                 );
                 Ok(true)
             }
@@ -4481,7 +4474,7 @@ impl TextServiceFactory {
             Err(error) if is_non_destructive_ipc_error(&error) => {
                 tracing::warn!(
                     ?error,
-                    "IPC deadline exceeded during preserved shortcut; preserving composition"
+                    "IPC shortcut operation failed without mutation; preserving composition"
                 );
                 Ok(true)
             }
@@ -5493,9 +5486,18 @@ impl TextServiceFactory {
                                 deferred_clause_navigation_ready_ui_sync.take(),
                                 effect,
                             );
-                        if effect.server_reset {
+                        if effect.server_reset
+                            || (ipc_service.take_server_reset_recovered()
+                                && Self::has_client_composition_state(
+                                    &raw_input,
+                                    &preview,
+                                    &suffix,
+                                    &fixed_prefix,
+                                    &candidates,
+                                ))
+                        {
                             reset_after_empty_server_composition!(
-                                "move_clause returned empty composition"
+                                "move_clause detected server reset"
                             );
                         } else if effect.applied {
                             self.sync_clause_action_ui(
@@ -6252,7 +6254,7 @@ impl TextServiceFactory {
             Ok(())
         })();
 
-        if result.as_ref().is_err_and(is_non_destructive_ipc_error) {
+        if result.as_ref().is_err_and(requires_ipc_recovery) {
             if let Some(actions) = retry_actions.as_ref() {
                 let deferred = deferred_action_suffix(actions, failed_action_index);
                 if let Ok(text_service) = self.borrow() {

--- a/crates/client/src/engine/composition/clause_state.rs
+++ b/crates/client/src/engine/composition/clause_state.rs
@@ -7,7 +7,7 @@ use std::{
 use super::{ClauseSnapshot, Composition, FutureClauseSnapshot, TextServiceFactory};
 use crate::engine::{
     client_action::SetSelectionType,
-    ipc_service::{Candidates, IPCService},
+    ipc_service::{Candidates, ClauseSnapshotOperation, IPCService},
 };
 
 #[derive(Debug, Clone)]
@@ -39,6 +39,14 @@ pub(crate) trait ClauseActionBackend {
     ) -> Result<Candidates> {
         self.shrink_text(offset)
     }
+
+    fn update_composition_snapshot(
+        &mut self,
+        _operation: ClauseSnapshotOperation,
+        _previous_candidates: &Candidates,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 impl ClauseActionBackend for IPCService {
@@ -64,6 +72,14 @@ impl ClauseActionBackend for IPCService {
         previous_candidates: &Candidates,
     ) -> Result<Candidates> {
         IPCService::shrink_text_with_context(self, offset, previous_candidates)
+    }
+
+    fn update_composition_snapshot(
+        &mut self,
+        operation: ClauseSnapshotOperation,
+        previous_candidates: &Candidates,
+    ) -> Result<()> {
+        IPCService::update_composition_snapshot(self, operation, previous_candidates)
     }
 }
 
@@ -467,10 +483,8 @@ impl ClauseState {
             let current_corresponding_count = *state.corresponding_count;
             let previous_candidates = state.candidates.clone();
 
-            let _ = backend.move_cursor_with_context(
-                TextServiceFactory::MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT,
-                &previous_candidates,
-            )?;
+            backend
+                .update_composition_snapshot(ClauseSnapshotOperation::Push, &previous_candidates)?;
             state.clause_snapshots.push(snapshot);
 
             *state.candidates = backend
@@ -550,8 +564,8 @@ impl ClauseState {
                     TextServiceFactory::select_candidate(state.candidates, *state.selection_index)
                 else {
                     let previous_candidates = state.candidates.clone();
-                    let _ = backend.move_cursor_with_context(
-                        TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT,
+                    backend.update_composition_snapshot(
+                        ClauseSnapshotOperation::Pop,
                         &previous_candidates,
                     )?;
                     if let Some(restored) = state.clause_snapshots.pop() {
@@ -614,8 +628,8 @@ impl ClauseState {
                     state.candidates,
                 );
                 let previous_candidates = state.candidates.clone();
-                let _ = backend.move_cursor_with_context(
-                    TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT,
+                backend.update_composition_snapshot(
+                    ClauseSnapshotOperation::Pop,
                     &previous_candidates,
                 )?;
 

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -9,7 +9,7 @@ use crate::engine::{
         ClientAction, LearningCommitKind, LearningCommitScope, SetSelectionType, SetTextType,
     },
     input_mode::InputMode,
-    ipc_service::WindowRpcDelivery,
+    ipc_service::{ClauseSnapshotOperation, WindowRpcDelivery},
     user_action::{Function, Navigation, UserAction},
 };
 use shared::{get_default_romaji_rows, AppConfig, PunctuationStyle, RomajiRule, WidthMode};
@@ -1769,18 +1769,7 @@ impl InitialSplitSingleNBoundaryBackend {
 }
 
 impl ClauseActionBackend for InitialSplitSingleNBoundaryBackend {
-    fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
-        match offset {
-            value if value == TextServiceFactory::MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT => {
-                self.snapshots.push(self.server);
-            }
-            value if value == TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT => {
-                if let Some(restored) = self.snapshots.pop() {
-                    self.server = restored;
-                }
-            }
-            _ => {}
-        }
+    fn move_cursor(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
         Ok(self.current_candidates())
     }
 
@@ -1788,6 +1777,25 @@ impl ClauseActionBackend for InitialSplitSingleNBoundaryBackend {
         assert_eq!(offset, 7);
         self.server = SingleNBoundaryServerState::BadSuffix;
         Ok(self.current_candidates())
+    }
+
+    fn update_composition_snapshot(
+        &mut self,
+        operation: ClauseSnapshotOperation,
+        _previous_candidates: &Candidates,
+    ) -> anyhow::Result<()> {
+        match operation {
+            ClauseSnapshotOperation::Push => {
+                self.snapshots.push(self.server);
+            }
+            ClauseSnapshotOperation::Pop => {
+                if let Some(restored) = self.snapshots.pop() {
+                    self.server = restored;
+                }
+            }
+            ClauseSnapshotOperation::Clear => self.snapshots.clear(),
+        }
+        Ok(())
     }
 }
 

--- a/crates/client/src/engine/composition/tests/stateful_harness.rs
+++ b/crates/client/src/engine/composition/tests/stateful_harness.rs
@@ -1273,22 +1273,6 @@ impl ScenarioBackend {
 impl ClauseActionBackend for ScenarioBackend {
     fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
         match offset {
-            value if value == TextServiceFactory::MOVE_CURSOR_CLEAR_CLAUSE_SNAPSHOTS => {
-                self.server_snapshots.clear();
-                self.blocked_boundary = false;
-                Ok(self.current_candidates())
-            }
-            value if value == TextServiceFactory::MOVE_CURSOR_PUSH_CLAUSE_SNAPSHOT => {
-                self.server_snapshots.push(self.server.clone());
-                Ok(self.current_candidates())
-            }
-            value if value == TextServiceFactory::MOVE_CURSOR_POP_CLAUSE_SNAPSHOT => {
-                if let Some(restored) = self.server_snapshots.pop() {
-                    self.server = restored;
-                }
-                self.blocked_boundary = false;
-                Ok(self.current_candidates())
-            }
             0 => {
                 if self.blocked_boundary {
                     Ok(Candidates::default())
@@ -1332,6 +1316,29 @@ impl ClauseActionBackend for ScenarioBackend {
         }
         self.blocked_boundary = false;
         Ok(self.current_candidates())
+    }
+
+    fn update_composition_snapshot(
+        &mut self,
+        operation: ClauseSnapshotOperation,
+        _previous_candidates: &Candidates,
+    ) -> anyhow::Result<()> {
+        match operation {
+            ClauseSnapshotOperation::Clear => {
+                self.server_snapshots.clear();
+                self.blocked_boundary = false;
+            }
+            ClauseSnapshotOperation::Push => {
+                self.server_snapshots.push(self.server.clone());
+            }
+            ClauseSnapshotOperation::Pop => {
+                if let Some(restored) = self.server_snapshots.pop() {
+                    self.server = restored;
+                }
+                self.blocked_boundary = false;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -155,6 +155,18 @@ pub(crate) fn is_ipc_deadline(error: &anyhow::Error) -> bool {
 }
 
 pub(crate) fn is_non_destructive_ipc_error(error: &anyhow::Error) -> bool {
+    requires_ipc_recovery(error)
+        || error.downcast_ref::<tonic::Status>().is_some_and(|status| {
+            matches!(
+                status.code(),
+                tonic::Code::InvalidArgument
+                    | tonic::Code::OutOfRange
+                    | tonic::Code::FailedPrecondition
+            )
+        })
+}
+
+pub(crate) fn requires_ipc_recovery(error: &anyhow::Error) -> bool {
     is_ipc_deadline(error) || error.downcast_ref::<IpcRecoveryPending>().is_some()
 }
 
@@ -258,6 +270,25 @@ pub struct Candidates {
     pub hiragana: String,
     pub corresponding_count: Vec<i32>,
     pub candidate_ids: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClauseSnapshotOperation {
+    Clear,
+    Push,
+    Pop,
+}
+
+impl ClauseSnapshotOperation {
+    fn proto_value(self) -> i32 {
+        use shared::proto::CompositionSnapshotOperation;
+
+        match self {
+            Self::Clear => CompositionSnapshotOperation::Clear as i32,
+            Self::Push => CompositionSnapshotOperation::Push as i32,
+            Self::Pop => CompositionSnapshotOperation::Pop as i32,
+        }
+    }
 }
 
 impl Candidates {
@@ -656,7 +687,7 @@ impl IPCService {
     }
 
     fn record_successful_move(&self, offset: i32) {
-        if offset == 0 || offset.abs() >= 125 {
+        if offset == 0 {
             return;
         }
         if let Ok(mut ledger) = self.recovery.input_ledger.lock() {
@@ -1052,6 +1083,28 @@ impl IPCService {
         self.observe_server_session("move_cursor", response.server_session_id);
         self.record_successful_move(offset);
         Self::candidates_from_composing_text(response.composing_text)
+    }
+
+    fn send_update_composition_snapshot(
+        &mut self,
+        operation: ClauseSnapshotOperation,
+        request_id: u64,
+    ) -> anyhow::Result<()> {
+        let mut request = tonic::Request::new(shared::proto::UpdateCompositionSnapshotRequest {
+            operation: operation.proto_value(),
+            request_id,
+        });
+        request.set_timeout(INPUT_RPC_DEADLINE);
+        let response = Self::block_on_server_rpc(
+            self.runtime.as_ref(),
+            &self.recovery,
+            "update_composition_snapshot",
+            INPUT_RPC_DEADLINE,
+            self.azookey_client.update_composition_snapshot(request),
+        )?;
+        let response = response.into_inner();
+        self.observe_server_session("update_composition_snapshot", response.server_session_id);
+        Ok(())
     }
 
     fn send_set_context(&mut self, context: &str, request_id: u64) -> anyhow::Result<()> {
@@ -1621,6 +1674,61 @@ impl IPCService {
         Ok(candidates)
     }
 
+    #[tracing::instrument(skip(self, previous_candidates))]
+    pub(crate) fn update_composition_snapshot(
+        &mut self,
+        operation: ClauseSnapshotOperation,
+        previous_candidates: &Candidates,
+    ) -> anyhow::Result<()> {
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let first_attempt = self.send_update_composition_snapshot(operation, request_id);
+        let result: anyhow::Result<NonIdempotentEditRecovery> =
+            (|| match Self::classify_non_idempotent_edit_attempt(
+                "update_composition_snapshot",
+                first_attempt,
+            )? {
+                NonIdempotentEditAttempt::Completed(()) => Ok(NonIdempotentEditRecovery::None),
+                NonIdempotentEditAttempt::ReconnectAndRefresh(first_error) => {
+                    self.reconnect().map_err(|reconnect_error| {
+                        tracing::error!(
+                            ?first_error,
+                            ?reconnect_error,
+                            "composition snapshot reconnect failed"
+                        );
+                        reconnect_error
+                    })?;
+
+                    let refreshed_candidates = self.send_move_cursor(0, request_id)?;
+                    if Self::should_retry_non_idempotent_edit_after_refresh(
+                        Some(previous_candidates),
+                        &refreshed_candidates,
+                    ) {
+                        self.send_update_composition_snapshot(operation, request_id)?;
+                        Ok(NonIdempotentEditRecovery::RetriedAfterUnchangedRefresh)
+                    } else {
+                        Ok(NonIdempotentEditRecovery::RefreshedAfterReconnect)
+                    }
+                }
+            })();
+        self.log_client_performance_from_start(
+            performance_start,
+            request_id,
+            "update_composition_snapshot",
+            "rpc_total",
+            || match &result {
+                Ok(recovery) => format!(
+                    "status=success;operation={operation:?};recovery={}",
+                    recovery.log_value()
+                ),
+                Err(error) => {
+                    format!("status=error;operation={operation:?};error={error:?}")
+                }
+            },
+        );
+        result.map(|_| ())
+    }
+
     pub fn set_context(&mut self, context: String) -> anyhow::Result<()> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
@@ -2043,9 +2151,9 @@ mod tests {
         append_input_segment, await_rpc_with_deadline, fallback_input_ledger,
         is_non_destructive_ipc_error, mark_input_ledger_incomplete, move_input_cursor,
         pop_input_segment_character, preserve_recovery_error, recovery_generation_is_current,
-        restart_generation_ready, restart_request_needed, Candidates, CompositionOperation,
-        IPCService, InputLedger, IpcDeadlineExceeded, NonIdempotentEditAttempt, INPUT_STYLE_DIRECT,
-        INPUT_STYLE_ROMAN2KANA,
+        requires_ipc_recovery, restart_generation_ready, restart_request_needed, Candidates,
+        ClauseSnapshotOperation, CompositionOperation, IPCService, InputLedger,
+        IpcDeadlineExceeded, NonIdempotentEditAttempt, INPUT_STYLE_DIRECT, INPUT_STYLE_ROMAN2KANA,
     };
     use std::{
         future::Future,
@@ -2199,6 +2307,48 @@ mod tests {
                 },
                 CompositionOperation::Remove,
             ]
+        );
+    }
+
+    #[test]
+    fn input_ledger_preserves_full_i32_cursor_offsets() {
+        let mut ledger = InputLedger {
+            complete: true,
+            ..InputLedger::default()
+        };
+
+        for offset in [125, 126, 127, 128, 129, 1024, -125, i32::MIN] {
+            move_input_cursor(&mut ledger, offset);
+        }
+
+        assert_eq!(
+            ledger.operations,
+            vec![
+                CompositionOperation::MoveCursor(125),
+                CompositionOperation::MoveCursor(126),
+                CompositionOperation::MoveCursor(127),
+                CompositionOperation::MoveCursor(128),
+                CompositionOperation::MoveCursor(129),
+                CompositionOperation::MoveCursor(1024),
+                CompositionOperation::MoveCursor(-125),
+                CompositionOperation::MoveCursor(i32::MIN),
+            ]
+        );
+    }
+
+    #[test]
+    fn snapshot_operations_have_distinct_proto_values() {
+        assert_eq!(
+            ClauseSnapshotOperation::Clear.proto_value(),
+            shared::proto::CompositionSnapshotOperation::Clear as i32
+        );
+        assert_eq!(
+            ClauseSnapshotOperation::Push.proto_value(),
+            shared::proto::CompositionSnapshotOperation::Push as i32
+        );
+        assert_eq!(
+            ClauseSnapshotOperation::Pop.proto_value(),
+            shared::proto::CompositionSnapshotOperation::Pop as i32
         );
     }
 
@@ -2442,6 +2592,8 @@ mod tests {
         let error = anyhow::Error::new(tonic::Status::invalid_argument("offset out of range"));
 
         assert!(!IPCService::should_reconnect_rpc_error(&error));
+        assert!(is_non_destructive_ipc_error(&error));
+        assert!(!requires_ipc_recovery(&error));
     }
 
     #[test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -8,9 +8,10 @@ use windows::Win32::System::Threading::{GetCurrentProcess, SetPriorityClass, HIG
 use shared::proto::azookey_service_server::{AzookeyService, AzookeyServiceServer};
 use shared::proto::{
     AppendTextRequest, AppendTextResponse, ClearTextRequest, ClearTextResponse, ComposingText,
-    CompositionOperationKind, MoveCursorRequest, MoveCursorResponse, PerformanceLogRequest,
-    PerformanceLogResponse, RemoveTextRequest, RemoveTextResponse, ReplaceCompositionRequest,
-    ReplaceCompositionResponse, ShrinkTextRequest, ShrinkTextResponse, Suggestion,
+    CompositionOperationKind, CompositionSnapshotOperation, MoveCursorRequest, MoveCursorResponse,
+    PerformanceLogRequest, PerformanceLogResponse, RemoveTextRequest, RemoveTextResponse,
+    ReplaceCompositionRequest, ReplaceCompositionResponse, ShrinkTextRequest, ShrinkTextResponse,
+    Suggestion, UpdateCompositionSnapshotRequest, UpdateCompositionSnapshotResponse,
 };
 use shared::{AppConfig, SERVER_PIPE_PATH};
 
@@ -381,7 +382,7 @@ macro_rules! performance_event_lazy {
 
 struct RawComposingText {
     text: String,
-    cursor: i8,
+    cursor: i32,
 }
 
 struct ComposedText {
@@ -406,6 +407,9 @@ unsafe extern "C" {
     fn AppendTextDirect(input: *const c_char, cursorPtr: *mut c_int) -> *mut c_char;
     fn RemoveText(cursorPtr: *mut c_int) -> *mut c_char;
     fn MoveCursor(offset: c_int, cursorPtr: *mut c_int) -> *mut c_char;
+    fn ClearComposingTextSnapshots();
+    fn PushComposingTextSnapshot();
+    fn PopComposingTextSnapshot();
     fn ShrinkText(offset: c_int) -> *mut c_char;
     fn ClearText();
     fn Warmup() -> bool;
@@ -1094,34 +1098,20 @@ fn ffi_text_result(scope: &str, result: *mut c_char) -> Result<String, String> {
     Ok(result.to_string_lossy())
 }
 
-#[allow(clippy::result_large_err)]
-fn i8_offset_from_i32(scope: &str, raw: i32) -> Result<i8, Status> {
-    i8::try_from(raw).map_err(|_| {
-        log_event(
-            ServerLogLevel::Warn,
-            &format!("[{scope}] offset out of range: {raw}"),
-        );
-        Status::invalid_argument("offset out of range")
-    })
-}
-
-fn cursor_from_c_int(scope: &str, cursor: c_int) -> i8 {
-    match i8::try_from(cursor) {
-        Ok(value) => value,
-        Err(_) => {
-            let clamped = cursor.clamp(i8::MIN as c_int, i8::MAX as c_int) as i8;
-            log_event(
-                ServerLogLevel::Warn,
-                &format!("[{scope}] cursor out of range: {cursor}, clamped to {clamped}"),
-            );
-            clamped
-        }
-    }
-}
-
 fn status_from_error(scope: &str, error: String) -> Status {
     log_event(ServerLogLevel::Error, &error);
     Status::internal(format!("{scope} failed"))
+}
+
+#[allow(clippy::result_large_err)]
+fn validate_shrink_offset(offset: i32) -> Result<i32, Status> {
+    if offset < 0 {
+        Err(Status::invalid_argument(
+            "shrink_text offset must be non-negative",
+        ))
+    } else {
+        Ok(offset)
+    }
 }
 
 fn initialize(path: &str) -> Result<(), String> {
@@ -1140,10 +1130,7 @@ fn add_text(input: &str) -> Result<RawComposingText, String> {
         let result = AppendText(input.as_ptr(), &mut cursor);
         let text = ffi_text_result("AppendText", result)?;
 
-        Ok(RawComposingText {
-            text,
-            cursor: cursor_from_c_int("AppendText", cursor),
-        })
+        Ok(RawComposingText { text, cursor })
     }
 }
 
@@ -1155,24 +1142,17 @@ fn add_text_direct(input: &str) -> Result<RawComposingText, String> {
         let result = AppendTextDirect(input.as_ptr(), &mut cursor);
         let text = ffi_text_result("AppendTextDirect", result)?;
 
-        Ok(RawComposingText {
-            text,
-            cursor: cursor_from_c_int("AppendTextDirect", cursor),
-        })
+        Ok(RawComposingText { text, cursor })
     }
 }
 
-fn move_cursor(offset: i8) -> Result<RawComposingText, String> {
+fn move_cursor(offset: i32) -> Result<RawComposingText, String> {
     unsafe {
-        let offset = c_int::from(offset);
         let mut cursor: c_int = 0;
         let result = MoveCursor(offset, &mut cursor);
         let text = ffi_text_result("MoveCursor", result)?;
 
-        Ok(RawComposingText {
-            text,
-            cursor: cursor_from_c_int("MoveCursor", cursor),
-        })
+        Ok(RawComposingText { text, cursor })
     }
 }
 
@@ -1182,10 +1162,7 @@ fn remove_text() -> Result<RawComposingText, String> {
         let result = RemoveText(&mut cursor);
         let text = ffi_text_result("RemoveText", result)?;
 
-        Ok(RawComposingText {
-            text,
-            cursor: cursor_from_c_int("RemoveText", cursor),
-        })
+        Ok(RawComposingText { text, cursor })
     }
 }
 
@@ -1346,9 +1323,8 @@ fn get_composed_text(use_cursor_prefix: bool, request_id: u64) -> Result<Compose
     })
 }
 
-fn shrink_text(offset: i8) -> Result<RawComposingText, String> {
+fn shrink_text(offset: i32) -> Result<RawComposingText, String> {
     unsafe {
-        let offset = c_int::from(offset);
         let result = ShrinkText(offset);
         let text = ffi_text_result("ShrinkText", result)?;
 
@@ -1464,14 +1440,8 @@ impl AzookeyService for MyAzookeyService {
                         .map_err(|error| status_from_error("replace_composition", error))?;
                 }
                 CompositionOperationKind::MoveCursor => {
-                    let mut remaining_offset = operation.cursor_offset;
-                    while remaining_offset != 0 {
-                        let chunk = remaining_offset.clamp(-124, 124);
-                        let offset = i8_offset_from_i32("replace_composition", chunk)?;
-                        composing_text = move_cursor(offset)
-                            .map_err(|error| status_from_error("replace_composition", error))?;
-                        remaining_offset -= chunk;
-                    }
+                    composing_text = move_cursor(operation.cursor_offset)
+                        .map_err(|error| status_from_error("replace_composition", error))?;
                 }
             }
         }
@@ -1572,11 +1542,10 @@ impl AzookeyService for MyAzookeyService {
         let handler_start = Instant::now();
         let raw_offset = request.offset;
 
-        let offset = i8_offset_from_i32("move_cursor", raw_offset)?;
-        let use_cursor_prefix = offset == 0;
+        let use_cursor_prefix = raw_offset == 0;
         let move_start = Instant::now();
         let composing_text =
-            move_cursor(offset).map_err(|error| status_from_error("move_cursor", error))?;
+            move_cursor(raw_offset).map_err(|error| status_from_error("move_cursor", error))?;
         performance_event_lazy!(
             request_id,
             "move_cursor",
@@ -1602,7 +1571,7 @@ impl AzookeyService for MyAzookeyService {
             "move_cursor",
             "total",
             elapsed_ms(handler_start),
-            "status=success;cursor={};hiragana_len={};suggestions={};use_cursor_prefix={use_cursor_prefix}",
+            "status=success;offset={raw_offset};cursor={};hiragana_len={};suggestions={};use_cursor_prefix={use_cursor_prefix}",
             composing_text.cursor,
             composing_text.text.chars().count(),
             composed_text.suggestions.len()
@@ -1613,6 +1582,44 @@ impl AzookeyService for MyAzookeyService {
                 hiragana: composed_text.hiragana.unwrap_or(composing_text.text),
                 suggestions: composed_text.suggestions,
             }),
+            server_session_id: server_session_id(),
+        }))
+    }
+
+    async fn update_composition_snapshot(
+        &self,
+        request: Request<UpdateCompositionSnapshotRequest>,
+    ) -> Result<Response<UpdateCompositionSnapshotResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
+        let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(true);
+        let request_id = request_id_or_next(request.request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+        let operation = CompositionSnapshotOperation::try_from(request.operation)
+            .map_err(|_| Status::invalid_argument("unknown composition snapshot operation"))?;
+
+        unsafe {
+            match operation {
+                CompositionSnapshotOperation::Unspecified => {
+                    return Err(Status::invalid_argument(
+                        "composition snapshot operation is required",
+                    ));
+                }
+                CompositionSnapshotOperation::Clear => ClearComposingTextSnapshots(),
+                CompositionSnapshotOperation::Push => PushComposingTextSnapshot(),
+                CompositionSnapshotOperation::Pop => PopComposingTextSnapshot(),
+            }
+        }
+        performance_event_lazy!(
+            request_id,
+            "update_composition_snapshot",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success;operation={operation:?}"
+        );
+
+        Ok(Response::new(UpdateCompositionSnapshotResponse {
             server_session_id: server_session_id(),
         }))
     }
@@ -1659,12 +1666,11 @@ impl AzookeyService for MyAzookeyService {
         let request_id = request_id_or_next(request.request_id);
         set_request_id(request_id);
         let handler_start = Instant::now();
-        let raw_offset = request.offset;
+        let raw_offset = validate_shrink_offset(request.offset)?;
 
-        let offset = i8_offset_from_i32("shrink_text", raw_offset)?;
         let shrink_start = Instant::now();
         let composing_text =
-            shrink_text(offset).map_err(|error| status_from_error("shrink_text", error))?;
+            shrink_text(raw_offset).map_err(|error| status_from_error("shrink_text", error))?;
         performance_event_lazy!(
             request_id,
             "shrink_text",
@@ -2031,7 +2037,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 mod path_tests {
-    use super::{resolve_log_path_from_roots, MyAzookeyService};
+    use super::{resolve_log_path_from_roots, validate_shrink_offset, MyAzookeyService};
     use std::{ffi::OsStr, path::Path};
 
     #[tokio::test]
@@ -2053,6 +2059,22 @@ mod path_tests {
         )
         .await
         .expect("lock should become available");
+    }
+
+    #[test]
+    fn shrink_offset_accepts_long_compositions_without_narrowing() {
+        for offset in [127, 128, 129, 1024, i32::MAX] {
+            assert_eq!(
+                validate_shrink_offset(offset).expect("non-negative offset"),
+                offset
+            );
+        }
+    }
+
+    #[test]
+    fn shrink_offset_rejects_negative_values_before_swift_ffi() {
+        let status = validate_shrink_offset(-1).expect_err("negative offset must fail");
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
     }
 
     #[test]

--- a/crates/shared/service.proto
+++ b/crates/shared/service.proto
@@ -70,10 +70,25 @@ message RemoveTextResponse {
   uint64 server_session_id = 2; // Identifies the current server process session.
 }
 
-// Request message for MoveCursor.
 message MoveCursorRequest {
-  int32 offset = 1; // The new cursor position.
+  int32 offset = 1; // Relative cursor movement in input units.
   uint64 request_id = 2;
+}
+
+enum CompositionSnapshotOperation {
+  COMPOSITION_SNAPSHOT_OPERATION_UNSPECIFIED = 0;
+  COMPOSITION_SNAPSHOT_OPERATION_CLEAR = 1;
+  COMPOSITION_SNAPSHOT_OPERATION_PUSH = 2;
+  COMPOSITION_SNAPSHOT_OPERATION_POP = 3;
+}
+
+message UpdateCompositionSnapshotRequest {
+  CompositionSnapshotOperation operation = 1;
+  uint64 request_id = 2;
+}
+
+message UpdateCompositionSnapshotResponse {
+  uint64 server_session_id = 1;
 }
 
 // Request message for ShrinkText.
@@ -164,6 +179,7 @@ service AzookeyService {
   rpc RemoveText (RemoveTextRequest) returns (RemoveTextResponse);
   rpc ShrinkText (ShrinkTextRequest) returns (ShrinkTextResponse);
   rpc MoveCursor (MoveCursorRequest) returns (MoveCursorResponse);
+  rpc UpdateCompositionSnapshot (UpdateCompositionSnapshotRequest) returns (UpdateCompositionSnapshotResponse);
   rpc ClearText (ClearTextRequest) returns (ClearTextResponse);
   rpc SetContext (SetContextRequest) returns (SetContextResponse);
   rpc UpdateConfig (UpdateConfigRequest) returns (UpdateConfigResponse);

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -2190,35 +2190,38 @@ func cursorPrefixBoundaryFirstClauseResults(
     cursorPtr: UnsafeMutablePointer<CInt>
 ) -> UnsafeMutablePointer<CChar> {
     serverLog("DEBUG", "MoveCursor: start offset=\(offset)")
-    if offset == 125 {
-        composingTextSnapshots.removeAll()
-        cursorPtr.pointee = CInt(composingText.convertTargetCursorPosition)
-        serverLog("DEBUG", "MoveCursor: clear snapshots")
-        return _strdup(composingText.convertTarget)!
-    }
-
-    if offset == 126 {
-        composingTextSnapshots.append(composingText)
-        cursorPtr.pointee = CInt(composingText.convertTargetCursorPosition)
-        serverLog("DEBUG", "MoveCursor: push snapshot count=\(composingTextSnapshots.count)")
-        return _strdup(composingText.convertTarget)!
-    }
-
-    if offset == 127 {
-        if let restored = composingTextSnapshots.popLast() {
-            composingText = restored
-        }
-        cursorPtr.pointee = CInt(composingText.convertTargetCursorPosition)
-        serverLog("DEBUG", "MoveCursor: pop snapshot remaining=\(composingTextSnapshots.count)")
-        return _strdup(composingText.convertTarget)!
-    }
-
     let cursor = composingText.moveCursorFromCursorPosition(count: Int(offset))
     serverLog("DEBUG", "MoveCursor: offset=\(offset) cursor=\(cursor)")
 
     cursorPtr.pointee = CInt(cursor)
     serverLog("DEBUG", "MoveCursor: completed cursor=\(cursor)")
     return _strdup(composingText.convertTarget)!
+}
+
+@_silgen_name("ClearComposingTextSnapshots")
+@MainActor public func clear_composing_text_snapshots() {
+    composingTextSnapshots.removeAll()
+    serverLog("DEBUG", "ClearComposingTextSnapshots: completed")
+}
+
+@_silgen_name("PushComposingTextSnapshot")
+@MainActor public func push_composing_text_snapshot() {
+    composingTextSnapshots.append(composingText)
+    serverLog(
+        "DEBUG",
+        "PushComposingTextSnapshot: completed count=\(composingTextSnapshots.count)"
+    )
+}
+
+@_silgen_name("PopComposingTextSnapshot")
+@MainActor public func pop_composing_text_snapshot() {
+    if let restored = composingTextSnapshots.popLast() {
+        composingText = restored
+    }
+    serverLog(
+        "DEBUG",
+        "PopComposingTextSnapshot: completed remaining=\(composingTextSnapshots.count)"
+    )
 }
 
 @_silgen_name("ClearText")
@@ -2866,7 +2869,8 @@ public func free_candidate_list(
 ) -> UnsafeMutablePointer<CChar>  {
     serverLog("DEBUG", "ShrinkText: start offset=\(offset)")
     var afterComposingText = composingText
-    afterComposingText.prefixComplete(composingCount: .inputCount(Int(offset)))
+    let boundedOffset = min(max(Int(offset), 0), afterComposingText.input.count)
+    afterComposingText.prefixComplete(composingCount: .inputCount(boundedOffset))
     composingText = afterComposingText
 
     serverLog("DEBUG", "ShrinkText: completed hiraganaLength=\(composingText.convertTarget.count) inputCount=\(composingText.input.count)")

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -386,6 +386,96 @@ private func testCandidate(
     free_c_string(text)
 }
 
+@Test func cursorOffsetsUseFullInt32RangeWithoutSnapshotCollisions() async {
+    await MainActor.run {
+        let previousComposingText = composingText
+        let previousComposingTextSnapshots = composingTextSnapshots
+        defer {
+            composingText = previousComposingText
+            composingTextSnapshots = previousComposingTextSnapshots
+        }
+
+        let inputLength = 2048
+        let input = String(repeating: "あ", count: inputLength)
+        for offset in [125, 126, 127, 128, 129, 1024] {
+            composingText = ComposingText()
+            composingText.insertAtCursorPosition(input, inputStyle: .direct)
+            composingTextSnapshots.removeAll()
+
+            var cursor: CInt = 0
+            free_c_string(move_cursor(offset: -CInt(inputLength), cursorPtr: &cursor))
+            #expect(cursor == -CInt(inputLength))
+            #expect(composingText.convertTargetCursorPosition == 0)
+            free_c_string(move_cursor(offset: CInt(offset), cursorPtr: &cursor))
+            #expect(cursor == CInt(offset))
+            #expect(composingText.convertTargetCursorPosition == offset)
+            #expect(composingTextSnapshots.isEmpty)
+        }
+
+        composingText = ComposingText()
+        composingText.insertAtCursorPosition(input, inputStyle: .direct)
+        var extremeCursor: CInt = 0
+        free_c_string(move_cursor(offset: CInt.min, cursorPtr: &extremeCursor))
+        #expect(extremeCursor == -CInt(inputLength))
+        #expect(composingText.convertTargetCursorPosition == 0)
+        free_c_string(move_cursor(offset: CInt.max, cursorPtr: &extremeCursor))
+        #expect(extremeCursor == CInt(inputLength))
+        #expect(composingText.convertTargetCursorPosition == inputLength)
+
+        composingText = ComposingText()
+        composingText.insertAtCursorPosition(input, inputStyle: .direct)
+        composingTextSnapshots.removeAll()
+        push_composing_text_snapshot()
+        #expect(composingTextSnapshots.count == 1)
+
+        var cursor: CInt = 0
+        free_c_string(move_cursor(offset: -1024, cursorPtr: &cursor))
+        free_c_string(move_cursor(offset: 125, cursorPtr: &cursor))
+        #expect(cursor == 125)
+        #expect(composingText.convertTargetCursorPosition == 1149)
+        #expect(composingTextSnapshots.count == 1)
+
+        pop_composing_text_snapshot()
+        #expect(composingText.convertTargetCursorPosition == inputLength)
+        #expect(composingTextSnapshots.isEmpty)
+
+        push_composing_text_snapshot()
+        clear_composing_text_snapshots()
+        #expect(composingTextSnapshots.isEmpty)
+    }
+}
+
+@Test func shrinkTextSupportsLongOffsetsAndClampsDirectFfiInput() async {
+    await MainActor.run {
+        let previousComposingText = composingText
+        defer {
+            composingText = previousComposingText
+        }
+
+        let inputLength = 1100
+        let input = String(repeating: "あ", count: inputLength)
+        for offset in [127, 128, 129, 1024] {
+            composingText = ComposingText()
+            composingText.insertAtCursorPosition(input, inputStyle: .direct)
+
+            let result = shrink_text(offset: CInt(offset))
+            let remaining = String(cString: result)
+            free_c_string(result)
+
+            #expect(remaining.count == inputLength - offset)
+            #expect(composingText.input.count == inputLength - offset)
+        }
+
+        composingText = ComposingText()
+        composingText.insertAtCursorPosition(input, inputStyle: .direct)
+        let negativeResult = shrink_text(offset: -1)
+        let unchanged = String(cString: negativeResult)
+        free_c_string(negativeResult)
+        #expect(unchanged.count == inputLength)
+        #expect(composingText.input.count == inputLength)
+    }
+}
+
 @Test func ffiFreeCandidateListAcceptsNullEmptyAndPopulatedLists() async throws {
     free_candidate_list(nil, 0)
 


### PR DESCRIPTION
## Summary
- 文節移動・境界調整の offset を Rust server 内でも `i32` のまま扱い、127文字を超える未確定入力を操作できるようにしました。
- snapshot push/pop/clear を専用 RPC へ分離し、通常 cursor offset の 125/126/127 との衝突を解消しました。
- server が不正な offset を拒否した場合や snapshot 操作中に再接続した場合も、未確定文字列を破棄・不整合化しない回復経路にしました。

## Background
- Issue: #131
- Issue close: 対象リリース公開・成果物確認後
- protobuf・client・Swift FFI は `i32` / `Int32` を扱える一方、Rust server だけが `i8` に狭めていたため、128文字以上の文節操作が `InvalidArgument` となり、未確定文字列を失う可能性がありました。

## Changes
- Rust server / Swift FFI: `move_cursor` と `shrink_text` の offset を `i32` のまま転送し、長い composition の復旧 replay も単一呼び出しへ変更
- protobuf / snapshot: snapshot clear/push/pop 用の enum と専用 RPC を追加し、通常 cursor offset から制御用マジック値を除去
- client recovery: `InvalidArgument` などの非破壊エラーでは composition を保持し、snapshot RPC の再接続・server session 変更時には client state を安全にリセット
- tests: 125/126/127/128/129/1024、`i32::MIN/MAX`、長い shrink、snapshot 衝突、非破壊エラー分類を回帰テストへ追加
- performance: 通常の MoveCursor/Shrink は従来どおり 1 RPC のまま。snapshot 成功時の未使用 candidate 生成と CString allocation を削減し、1024 offset の recovery replay は最大9回の FFI 呼び出しから1回へ削減

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/30024714791
- [x] ローカル静的検証
  - `cargo fmt --all -- --check`
  - Windows x86_64 target の `cargo clippy --workspace --all-targets -- -D warnings`
  - `git diff --check`
- [x] Windows VM tests
  - Rust client composition tests: 127 passed
  - Swift server tests: 58 passed
- [x] Windows 実機確認
  - Win11 VM / Notepad: 140文字の未確定入力から左・右・Shift+左・Shift+右・確定を実行し、`140/140 文字` が保持されることを確認
  - screenshot: `.local/vm-debug/issue131-long-clause-final.png`
  - installer: `.local/artifacts/azookey-setup-fix_131-long-clause-offsets-20260724-002201.exe`
  - install log: `.local/logs/win11-install-20260724-005618.log`

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
