### PR TITLE
Fix Swift test concurrency around input styles

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -150,8 +150,8 @@ jobs:
       shell: pwsh
       run: Copy-Item "llama_cpu\llama.lib" -Destination "server-swift\" -Force
 
-    - name: Run all Swift tests serially
-      run: swift test --package-path server-swift -c release --no-parallel --verbose -Xcc -D_CRT_USE_C_COMPLEX_H -Xcxx -D_CRT_USE_C_COMPLEX_H
+    - name: Run all Swift tests in parallel
+      run: swift test --package-path server-swift -c release --verbose -Xcc -D_CRT_USE_C_COMPLEX_H -Xcxx -D_CRT_USE_C_COMPLEX_H
 
     - name: Prepare Rust linker input
       shell: pwsh

--- a/scripts/vm_test_client_composition.sh
+++ b/scripts/vm_test_client_composition.sh
@@ -35,12 +35,17 @@ fi
 TARGET_BRANCH="$1"
 CARGO_TEST_FILTER="${2:-composition}"
 SWIFT_TEST_FILTER="${3:-}"
+SWIFT_TEST_ITERATIONS="${SWIFT_TEST_ITERATIONS:-1}"
 
 if [[ "$CARGO_TEST_FILTER" == "-" ]]; then
   CARGO_TEST_FILTER="skip"
 fi
 if [[ "$SWIFT_TEST_FILTER" == "-" ]]; then
   SWIFT_TEST_FILTER="skip"
+fi
+if [[ ! "$SWIFT_TEST_ITERATIONS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "SWIFT_TEST_ITERATIONS must be a positive integer"
+  exit 1
 fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -411,6 +416,7 @@ param(
   [Parameter(Mandatory = $true)][string]$HostTimestampUtc,
   [Parameter(Mandatory = $false)][string]$CargoTestFilter = "composition",
   [Parameter(Mandatory = $false)][string]$SwiftTestFilter = "",
+  [Parameter(Mandatory = $false)][int]$SwiftTestIterations = 1,
   [Parameter(Mandatory = $false)][string]$SwiftVendorTarPath = ""
 )
 
@@ -642,7 +648,8 @@ function Initialize-SwiftTestEnvironment {
 function Invoke-SwiftPackageTests {
   param(
     [Parameter(Mandatory = $true)][string]$SwiftSourceDir,
-    [Parameter(Mandatory = $false)][string]$TestFilter = "all"
+    [Parameter(Mandatory = $false)][string]$TestFilter = "all",
+    [Parameter(Mandatory = $false)][int]$Iterations = 1
   )
 
   $releaseDir = Join-Path $SwiftSourceDir ".build\x86_64-unknown-windows-msvc\release"
@@ -702,16 +709,18 @@ function Invoke-SwiftPackageTests {
     $runArgs += @("--filter", $TestFilter)
   }
 
-  Write-Host "running swift test runner $runnerExe $($runArgs -join ' ')"
-  Push-Location $releaseDir
-  try {
-    & $runnerExe @runArgs
-  } finally {
-    Pop-Location
-  }
+  for ($iteration = 1; $iteration -le $Iterations; $iteration++) {
+    Write-Host "running swift test runner iteration $iteration/$Iterations $runnerExe $($runArgs -join ' ')"
+    Push-Location $releaseDir
+    try {
+      & $runnerExe @runArgs
+    } finally {
+      Pop-Location
+    }
 
-  if ($LASTEXITCODE -ne 0) {
-    throw "swift test runner failed with exit code $LASTEXITCODE"
+    if ($LASTEXITCODE -ne 0) {
+      throw "swift test runner iteration $iteration/$Iterations failed with exit code $LASTEXITCODE"
+    }
   }
 }
 
@@ -772,9 +781,20 @@ if (![string]::IsNullOrWhiteSpace($SwiftTestFilter) -and $SwiftTestFilter -ne "s
   }
   if ($LASTEXITCODE -eq 0) {
     Write-Host "swift test completed without Windows runner workaround"
+    for ($iteration = 2; $iteration -le $SwiftTestIterations; $iteration++) {
+      Write-Host "running swift test iteration $iteration/$SwiftTestIterations with --skip-build"
+      if ($SwiftTestFilter -eq "all") {
+        swift test -c release --skip-build --verbose -Xcc -D_CRT_USE_C_COMPLEX_H
+      } else {
+        swift test -c release --skip-build --verbose -Xcc -D_CRT_USE_C_COMPLEX_H --filter $SwiftTestFilter
+      }
+      if ($LASTEXITCODE -ne 0) {
+        throw "swift test iteration $iteration/$SwiftTestIterations failed with exit code $LASTEXITCODE"
+      }
+    }
   } else {
     Write-Host "swift test returned exit code $LASTEXITCODE; retrying with Windows runner workaround"
-    Invoke-SwiftPackageTests -SwiftSourceDir $swiftSourceDir -TestFilter $SwiftTestFilter
+    Invoke-SwiftPackageTests -SwiftSourceDir $swiftSourceDir -TestFilter $SwiftTestFilter -Iterations $SwiftTestIterations
   }
 } else {
   Write-Host "skipping swift test"
@@ -847,7 +867,7 @@ main() {
   fi
 
   log "VM 上で test を実行します"
-  ssh_run_test "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -SourceTarPath \"$REMOTE_TAR_WIN\" -SourceDir \"$REMOTE_SRC_WIN\" -HostTimestampUtc \"$HOST_TIMESTAMP_UTC\" -CargoTestFilter \"$CARGO_TEST_FILTER\" -SwiftTestFilter \"$SWIFT_TEST_FILTER\"$swift_vendor_arg"
+  ssh_run_test "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS_WIN\" -SourceTarPath \"$REMOTE_TAR_WIN\" -SourceDir \"$REMOTE_SRC_WIN\" -HostTimestampUtc \"$HOST_TIMESTAMP_UTC\" -CargoTestFilter \"$CARGO_TEST_FILTER\" -SwiftTestFilter \"$SWIFT_TEST_FILTER\" -SwiftTestIterations \"$SWIFT_TEST_ITERATIONS\"$swift_vendor_arg"
 
   log "VM を停止します"
   vbox controlvm "$VM_NAME" acpipowerbutton >/dev/null || true

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -1585,29 +1585,6 @@ private func sanitizeDiagnosticField(_ value: String, maxLength: Int = 80) -> St
     return makeWarmupComposingText(input: zenzaiWarmupRomanInput, inputStyle: .roman2kana)
 }
 
-private enum WarmupInputStyleSnapshot: Sendable {
-    case roman2kana
-    case direct
-
-    var inputStyle: InputStyle {
-        switch self {
-        case .roman2kana:
-            return .roman2kana
-        case .direct:
-            return .direct
-        }
-    }
-
-    var label: String {
-        switch self {
-        case .roman2kana:
-            return "roman2kana"
-        case .direct:
-            return "direct"
-        }
-    }
-}
-
 private struct WarmupExecutionSnapshot: Sendable {
     let requestId: UInt64
     let dictionaryURL: URL
@@ -1618,7 +1595,6 @@ private struct WarmupExecutionSnapshot: Sendable {
     let profile: String
     let context: String
     let input: String
-    let inputStyle: WarmupInputStyleSnapshot
     let useZenzai: Bool
     let diagnosticDetails: String
 }
@@ -1659,7 +1635,7 @@ private final class BackgroundWarmupRunner: @unchecked Sendable {
         var warmupComposingText = ComposingText()
         warmupComposingText.insertAtCursorPosition(
             snapshot.input,
-            inputStyle: snapshot.inputStyle.inputStyle
+            inputStyle: .direct
         )
         let options = makeConvertRequestOptions(
             context: snapshot.context,
@@ -1739,21 +1715,25 @@ private final class BackgroundWarmupRunner: @unchecked Sendable {
 
 private let backgroundWarmupRunner = BackgroundWarmupRunner()
 
+// InputStyleManager stores custom tables in an unsynchronized process-wide
+// dictionary. Background work must use direct input so it never reads that
+// registry concurrently with a foreground config reload.
+@MainActor func makeBackgroundWarmupComposingText(
+    zenzaiRuntimeEnabled: Bool
+) -> ComposingText {
+    makeWarmupComposingText(
+        input: zenzaiRuntimeEnabled ? "にほんご" : "あ",
+        inputStyle: .direct
+    )
+}
+
 @MainActor private func makeBackgroundWarmupSnapshot() -> WarmupExecutionSnapshot {
     let contextString = (config["context"] as? String) ?? ""
     let diagnosticSnapshot = zenzaiDiagnosticSnapshot()
-    let inputStyle: WarmupInputStyleSnapshot = if diagnosticSnapshot.runtimeEnabled {
-        .roman2kana
-    } else if currentInputStyle == .direct {
-        .direct
-    } else {
-        .roman2kana
-    }
-    let input = diagnosticSnapshot.runtimeEnabled ? zenzaiWarmupRomanInput : "a"
-    let warmupComposingText = makeWarmupComposingText(
-        input: input,
-        inputStyle: inputStyle.inputStyle
+    let warmupComposingText = makeBackgroundWarmupComposingText(
+        zenzaiRuntimeEnabled: diagnosticSnapshot.runtimeEnabled
     )
+    let input = warmupComposingText.convertTarget
     let useZenzai = effectiveZenzaiEnabledForCandidates(
         isConfigured: diagnosticSnapshot.runtimeEnabled,
         inputCount: warmupComposingText.input.count,
@@ -1766,7 +1746,7 @@ private let backgroundWarmupRunner = BackgroundWarmupRunner()
         inputCount: warmupComposingText.input.count,
         hiraganaLength: warmupComposingText.convertTarget.count,
         useZenzai: useZenzai
-    ) + ";warmup_input_style=\(inputStyle.label);background=true"
+    ) + ";warmup_input_style=direct;background=true"
 
     return WarmupExecutionSnapshot(
         requestId: currentRequestId,
@@ -1780,7 +1760,6 @@ private let backgroundWarmupRunner = BackgroundWarmupRunner()
         profile: (config["profile"] as? String) ?? "",
         context: contextString,
         input: input,
-        inputStyle: inputStyle,
         useZenzai: useZenzai,
         diagnosticDetails: diagnosticDetails
     )

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -8,7 +8,9 @@ private func row(_ input: String, _ output: String, _ next: String = "") -> Roma
     RomajiTableRow(input: input, output: output, next_input: next)
 }
 
-private func makeTemporaryCustomInputStyle(_ rows: [RomajiTableRow]) throws -> InputStyle {
+// InputStyleManager uses a process-wide unsynchronized dictionary. Keep test
+// registrations on the same actor as every ComposingText lookup.
+@MainActor private func makeTemporaryCustomInputStyle(_ rows: [RomajiTableRow]) throws -> InputStyle {
     let fileURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("azookey-romaji-test-\(UUID().uuidString).tsv")
     let content = try #require(buildCustomRomajiTableContent(rows: rows))
@@ -1025,9 +1027,8 @@ private func testCandidate(
         row("nya", "にゃ"),
         row("-", "ー"),
     ]
-    let inputStyle = try makeTemporaryCustomInputStyle(rows)
-
-    let result = await MainActor.run {
+    let result = try await MainActor.run {
+        let inputStyle = try makeTemporaryCustomInputStyle(rows)
         var source = ComposingText()
         source.insertAtCursorPosition("kagen", inputStyle: inputStyle)
         let preview = makeCandidatePreviewComposingText(from: source)
@@ -1048,9 +1049,8 @@ private func testCandidate(
         row("nya", "にゃ"),
         row("ta", "た"),
     ]
-    let inputStyle = try makeTemporaryCustomInputStyle(rows)
-
-    let convertTarget = await MainActor.run {
+    let convertTarget = try await MainActor.run {
+        let inputStyle = try makeTemporaryCustomInputStyle(rows)
         var source = ComposingText()
         source.insertAtCursorPosition("nta", inputStyle: inputStyle)
         return source.convertTarget
@@ -1180,9 +1180,8 @@ private func testCandidate(
         row("q", "く"),
         row("qa", "くぁ"),
     ]
-    let inputStyle = try makeTemporaryCustomInputStyle(rows)
-
-    let preview = await MainActor.run {
+    let preview = try await MainActor.run {
+        let inputStyle = try makeTemporaryCustomInputStyle(rows)
         var source = ComposingText()
         source.insertAtCursorPosition("q", inputStyle: inputStyle)
         return makeCandidatePreviewComposingText(from: source)
@@ -1190,6 +1189,35 @@ private func testCandidate(
 
     #expect(preview.syntheticEndOfText == false)
     #expect(preview.composingText.convertTarget == "q")
+}
+
+@Test func backgroundWarmupAvoidsSharedInputStyleRegistry() async {
+    let metrics = await MainActor.run {
+        let disabled = makeBackgroundWarmupComposingText(zenzaiRuntimeEnabled: false)
+        let enabled = makeBackgroundWarmupComposingText(zenzaiRuntimeEnabled: true)
+        return (disabled: disabled, enabled: enabled)
+    }
+
+    #expect(metrics.disabled.convertTarget == "あ")
+    #expect(metrics.enabled.convertTarget == "にほんご")
+    #expect(metrics.disabled.input.count == 1)
+    #expect(metrics.enabled.input.count == 4)
+    #expect(metrics.disabled.input.allSatisfy { $0.inputStyle == .direct })
+    #expect(metrics.enabled.input.allSatisfy { $0.inputStyle == .direct })
+    #expect(
+        effectiveZenzaiEnabledForCandidates(
+            isConfigured: true,
+            inputCount: metrics.disabled.input.count,
+            hiraganaCount: metrics.disabled.convertTarget.count
+        ) == false
+    )
+    #expect(
+        effectiveZenzaiEnabledForCandidates(
+            isConfigured: true,
+            inputCount: metrics.enabled.input.count,
+            hiraganaCount: metrics.enabled.convertTarget.count
+        )
+    )
 }
 
 @Test func cursorPrefixCandidatesSupplementFirstClauseWithMainResultsForSameBoundary() async throws {


### PR DESCRIPTION
## Summary
- Swift Testing の通常並列実行で発生していた custom romaji table の共有 Dictionary 競合を除去しました。
- background warmup は共有 input style registry を参照しない direct hiragana input に変更し、本番の設定再読込との競合も解消しました。
- Windows VM helper に fresh-process 反復実行を追加し、CI の `--no-parallel` 暫定回避を外しました。

## Background
- Issue: #135
- Issue close: 対象リリース公開・成果物確認後
- `InputStyleManager.shared` の table Dictionary は同期されておらず、3つの custom romaji test が actor 外で同時登録していました。また本番でも background warmup の読取と設定再読込の登録が重なる可能性がありました。

## Changes
- Swift tests: custom romaji table の登録と利用を MainActor の同一区間へ隔離
- Swift server: background warmup を `.direct` の「あ」/「にほんご」にし、辞書・Zenzai warmup を維持しつつ共有 table registry への off-actor access を除去
- VM test helper: `SWIFT_TEST_ITERATIONS` による fresh-process 反復実行を追加
- GitHub Actions: Swift 全テストを通常並列実行へ復帰

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/30050477347
- [x] Windows VM Swift tests
  - 修正前相当: parallel 58 tests pass（既存失敗証跡では `0xC0000005`）
  - 修正後: parallel 59 tests × 10 fresh processes pass
  - log: `.local/logs/vm-client-test-20260724-072140.log`
  - test start order: 10 distinct sequences / 10 runs
- [x] Windows VM確認
  - 通常並列59 testsをfresh processで10回実行し、全590件pass
  - 最終統合installerの手動確認は全P1 merge後に実施

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
