### PR TITLE
Batch clause navigation RPCs

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -85,8 +85,32 @@ fn has_same_com_identity(left: &ITfComposition, right: &ITfComposition) -> bool 
 mod clause_state;
 pub(super) use clause_state::{
     CandidateSelection, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut,
-    ClauseCommand, ClauseState, ClauseTransitionInput, MoveClauseProgressMarker,
+    ClauseAdvance, ClauseCommand, ClauseState, ClauseTransitionInput,
 };
+
+struct PreparedClauseBackend {
+    advances: VecDeque<ClauseAdvance>,
+}
+
+impl ClauseActionBackend for PreparedClauseBackend {
+    fn move_cursor(&mut self, _offset: i32) -> Result<Candidates> {
+        anyhow::bail!("prepared clause navigation unexpectedly requested move_cursor")
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> Result<Candidates> {
+        anyhow::bail!("prepared clause navigation unexpectedly requested shrink_text")
+    }
+
+    fn advance_clause(
+        &mut self,
+        _offset: i32,
+        _previous_candidates: &Candidates,
+    ) -> Result<ClauseAdvance> {
+        self.advances
+            .pop_front()
+            .context("prepared clause navigation response was exhausted")
+    }
+}
 
 #[cfg(test)]
 pub(crate) struct CompositionReducer;
@@ -2427,16 +2451,18 @@ impl TextServiceFactory {
         future_clause_snapshots.push(split_snapshot);
     }
 
-    #[inline]
-    fn rebuild_future_clause_snapshots_from_backend<B: ClauseActionBackend>(
+    fn rebuild_future_clause_snapshots_from_prepared(
         state: &mut ClauseActionStateMut<'_>,
-        backend: &mut B,
+        prepared: Vec<ClauseAdvance>,
     ) -> Result<()> {
         if state.suffix.is_empty() {
             state.future_clause_snapshots.clear();
             return Ok(());
         }
 
+        let mut backend = PreparedClauseBackend {
+            advances: prepared.into(),
+        };
         let mut temp_preview = state.preview.clone();
         let mut temp_suffix = state.suffix.clone();
         let mut temp_raw_input = state.raw_input.clone();
@@ -2460,7 +2486,7 @@ impl TextServiceFactory {
         let initial_raw_hiragana = state.raw_hiragana.clone();
         let mut collected = Vec::new();
 
-        loop {
+        while !backend.advances.is_empty() {
             let (effect, made_progress) = {
                 let mut temp_state = ClauseActionStateMut {
                     preview: &mut temp_preview,
@@ -2481,15 +2507,15 @@ impl TextServiceFactory {
                     current_clause_split_group_id: &mut temp_current_clause_split_group_id,
                     next_split_group_id: &mut temp_next_split_group_id,
                 };
-                let before = MoveClauseProgressMarker::from_state(&temp_state);
+                let before = clause_state::MoveClauseProgressMarker::from_state(&temp_state);
                 let effect = ClauseState::transition_with_backend(
                     &mut temp_state,
                     ClauseCommand::MoveRight,
                     ClauseTransitionInput::default(),
-                    backend,
+                    &mut backend,
                 )?
                 .effect;
-                let after = MoveClauseProgressMarker::from_state(&temp_state);
+                let after = clause_state::MoveClauseProgressMarker::from_state(&temp_state);
                 (effect, before != after)
             };
             if !effect.applied || !made_progress {
@@ -2527,9 +2553,6 @@ impl TextServiceFactory {
                             &raw_hiragana_suffix,
                             initial_raw_input_suffix.chars().count() as i32,
                         );
-                        repaired_snapshot.is_split_derived = true;
-                        repaired_snapshot.is_direct_split_remainder = true;
-                        repaired_snapshot.has_split_left_neighbor = true;
                         repaired_snapshot.split_group_id = *state.current_clause_split_group_id;
                         snapshot = repaired_snapshot;
                     }
@@ -2545,12 +2568,6 @@ impl TextServiceFactory {
             if temp_suffix.is_empty() {
                 break;
             }
-        }
-
-        for _ in 0..temp_clause_snapshots.len() {
-            let previous_candidates = temp_candidates.clone();
-            backend
-                .update_composition_snapshot(ClauseSnapshotOperation::Pop, &previous_candidates)?;
         }
 
         state.future_clause_snapshots.clear();

--- a/crates/client/src/engine/composition/clause_state.rs
+++ b/crates/client/src/engine/composition/clause_state.rs
@@ -55,8 +55,7 @@ pub(crate) trait ClauseActionBackend {
             .hiragana
             .chars()
             .count()
-            .max(1)
-            .min(shared::MAX_PREPARED_CLAUSE_ADVANCES);
+            .clamp(1, shared::MAX_PREPARED_CLAUSE_ADVANCES);
 
         for _ in 0..max_steps {
             let advance = self.advance_clause(offset, &previous)?;

--- a/crates/client/src/engine/composition/clause_state.rs
+++ b/crates/client/src/engine/composition/clause_state.rs
@@ -20,9 +20,74 @@ pub(crate) struct CandidateSelection {
     pub(crate) candidate_id: u64,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct ClauseAdvance {
+    pub(crate) shrunk: Candidates,
+    pub(crate) navigation: Candidates,
+}
+
 pub(crate) trait ClauseActionBackend {
     fn move_cursor(&mut self, offset: i32) -> Result<Candidates>;
     fn shrink_text(&mut self, offset: i32) -> Result<Candidates>;
+
+    fn advance_clause(
+        &mut self,
+        offset: i32,
+        previous_candidates: &Candidates,
+    ) -> Result<ClauseAdvance> {
+        self.update_composition_snapshot(ClauseSnapshotOperation::Push, previous_candidates)?;
+        let shrunk = self.shrink_text_with_context(offset, previous_candidates)?;
+        let navigation = self.move_cursor(0)?;
+        Ok(ClauseAdvance { shrunk, navigation })
+    }
+
+    fn prepare_future_clauses(
+        &mut self,
+        initial_offset: i32,
+        previous_candidates: &Candidates,
+    ) -> Result<Vec<ClauseAdvance>> {
+        let mut offset = initial_offset;
+        let mut previous = previous_candidates.clone();
+        let mut advances = Vec::new();
+        let mut last_signature = None;
+        let mut snapshot_count = 0;
+        let max_steps = previous
+            .hiragana
+            .chars()
+            .count()
+            .max(1)
+            .min(shared::MAX_PREPARED_CLAUSE_ADVANCES);
+
+        for _ in 0..max_steps {
+            let advance = self.advance_clause(offset, &previous)?;
+            snapshot_count += 1;
+            let Some(selected) = TextServiceFactory::select_candidate(&advance.navigation, 0)
+            else {
+                break;
+            };
+            let is_last = selected.sub_text.is_empty();
+            let signature = (
+                advance.navigation.hiragana.clone(),
+                selected.corresponding_count,
+                selected.sub_text.clone(),
+            );
+            if last_signature.as_ref() == Some(&signature) {
+                break;
+            }
+            advances.push(advance.clone());
+            last_signature = Some(signature);
+            offset = selected.corresponding_count;
+            previous = advance.navigation;
+            if is_last {
+                break;
+            }
+        }
+
+        for _ in 0..snapshot_count {
+            self.update_composition_snapshot(ClauseSnapshotOperation::Pop, &previous)?;
+        }
+        Ok(advances)
+    }
 
     fn move_cursor_with_context(
         &mut self,
@@ -56,6 +121,22 @@ impl ClauseActionBackend for IPCService {
 
     fn shrink_text(&mut self, offset: i32) -> Result<Candidates> {
         IPCService::shrink_text(self, offset)
+    }
+
+    fn advance_clause(
+        &mut self,
+        offset: i32,
+        previous_candidates: &Candidates,
+    ) -> Result<ClauseAdvance> {
+        IPCService::advance_clause(self, offset, previous_candidates)
+    }
+
+    fn prepare_future_clauses(
+        &mut self,
+        initial_offset: i32,
+        previous_candidates: &Candidates,
+    ) -> Result<Vec<ClauseAdvance>> {
+        IPCService::prepare_future_clauses(self, initial_offset, previous_candidates)
     }
 
     fn move_cursor_with_context(
@@ -380,7 +461,9 @@ impl ClauseState {
         *state.current_clause_is_direct_split_remainder = false;
         *state.current_clause_has_split_left_neighbor = false;
         *state.current_clause_split_group_id = None;
-        TextServiceFactory::rebuild_future_clause_snapshots_from_backend(state, backend)?;
+        let prepared =
+            backend.prepare_future_clauses(selected.corresponding_count, state.candidates)?;
+        TextServiceFactory::rebuild_future_clause_snapshots_from_prepared(state, prepared)?;
         if let Some(set_type) = display_override_set_type {
             let suffix_raw_input = state
                 .future_clause_snapshots
@@ -483,12 +566,12 @@ impl ClauseState {
             let current_corresponding_count = *state.corresponding_count;
             let previous_candidates = state.candidates.clone();
 
-            backend
-                .update_composition_snapshot(ClauseSnapshotOperation::Push, &previous_candidates)?;
-            state.clause_snapshots.push(snapshot);
+            state.clause_snapshots.push(snapshot.clone());
 
-            *state.candidates = backend
-                .shrink_text_with_context(current_corresponding_count, &previous_candidates)?;
+            let advance =
+                backend.advance_clause(current_corresponding_count, &previous_candidates)?;
+            let navigation_candidates = advance.navigation;
+            *state.candidates = advance.shrunk;
             if state.candidates.is_empty_composition() {
                 return Ok(ClauseActionEffect::server_reset());
             }
@@ -538,7 +621,6 @@ impl ClauseState {
                 }
 
                 if state.future_clause_snapshots.is_empty() {
-                    let navigation_candidates = backend.move_cursor(0)?;
                     if let Some(navigation_selected) = TextServiceFactory::select_candidate(
                         &navigation_candidates,
                         *state.selection_index,
@@ -554,9 +636,31 @@ impl ClauseState {
                             state.raw_input,
                         ) || navigation_has_richer_current_candidates
                         {
-                            *state.candidates = navigation_candidates;
+                            *state.candidates = navigation_candidates.clone();
                             *state.selection_index = navigation_selected.index;
                         }
+                    }
+
+                    if let Some(raw_hiragana_suffix) =
+                        TextServiceFactory::recover_single_n_raw_hiragana_suffix(
+                            &snapshot.raw_hiragana,
+                            &navigation_candidates.hiragana,
+                        )
+                    {
+                        let raw_input_suffix = TextServiceFactory::current_raw_input_suffix(
+                            &snapshot.raw_input,
+                            snapshot.corresponding_count,
+                        );
+                        let repaired =
+                            TextServiceFactory::build_conservative_future_clause_snapshot(
+                                &snapshot.suffix,
+                                "",
+                                &raw_input_suffix,
+                                &raw_hiragana_suffix,
+                                raw_input_suffix.chars().count() as i32,
+                            );
+                        *state.candidates = repaired.candidates;
+                        *state.selection_index = repaired.selection_index;
                     }
                 }
 

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,8 +1,9 @@
 use super::{
     deferred_action_suffix, Candidates, CapsLockKeyboardLayout, ClauseActionBackend,
-    ClauseActionEffect, ClauseActionStateMut, ClauseNavigationReadyUiSync, ClauseSnapshot,
-    ClauseState, Composition, CompositionReducer, CompositionState, DeferredClientAction,
-    DeferredProjection, DeferredUserAction, FutureClauseSnapshot, TextServiceFactory,
+    ClauseActionEffect, ClauseActionStateMut, ClauseAdvance, ClauseNavigationReadyUiSync,
+    ClauseSnapshot, ClauseState, Composition, CompositionReducer, CompositionState,
+    DeferredClientAction, DeferredProjection, DeferredUserAction, FutureClauseSnapshot,
+    TextServiceFactory,
 };
 use crate::engine::{
     client_action::{
@@ -1263,6 +1264,81 @@ fn move_clause_to_last_stops_when_right_move_makes_no_progress() {
 struct NonProgressEnsureBackend {
     move_cursor_zero_calls: usize,
     shrink_calls: usize,
+    prepare_calls: usize,
+}
+
+struct BatchedClauseAdvanceBackend {
+    advance_calls: usize,
+}
+
+impl ClauseActionBackend for BatchedClauseAdvanceBackend {
+    fn move_cursor(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        panic!("move_cursor must be included in advance_clause")
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        panic!("shrink_text must be included in advance_clause")
+    }
+
+    fn advance_clause(
+        &mut self,
+        offset: i32,
+        _previous_candidates: &Candidates,
+    ) -> anyhow::Result<ClauseAdvance> {
+        self.advance_calls += 1;
+        assert_eq!(offset, 7);
+        let next = candidates(&["統一"], &[""], "とういつ", &[6]);
+        Ok(ClauseAdvance {
+            shrunk: next.clone(),
+            navigation: next,
+        })
+    }
+}
+
+#[test]
+fn move_clause_right_uses_one_batched_backend_operation() {
+    let mut preview = "いい加減".to_string();
+    let mut suffix = "統一".to_string();
+    let mut raw_input = "iikagentouitu".to_string();
+    let mut raw_hiragana = "いいかげんとういつ".to_string();
+    let mut fixed_prefix = String::new();
+    let mut corresponding_count = 7;
+    let mut selection_index = 0;
+    let mut current_candidates = candidates(&["いい加減"], &["統一"], "いいかげんとういつ", &[7]);
+    let mut clause_snapshots = Vec::new();
+    let mut future_clause_snapshots = Vec::new();
+    let mut current_clause_is_split_derived = true;
+    let mut current_clause_is_direct_split_remainder = false;
+    let mut current_clause_has_split_left_neighbor = false;
+    let mut current_clause_split_group_id = None;
+    let mut next_split_group_id = 1;
+    let mut backend = BatchedClauseAdvanceBackend { advance_calls: 0 };
+
+    let mut state = ClauseActionStateMut {
+        preview: &mut preview,
+        suffix: &mut suffix,
+        raw_input: &mut raw_input,
+        raw_hiragana: &mut raw_hiragana,
+        fixed_prefix: &mut fixed_prefix,
+        corresponding_count: &mut corresponding_count,
+        selection_index: &mut selection_index,
+        candidates: &mut current_candidates,
+        clause_snapshots: &mut clause_snapshots,
+        future_clause_snapshots: &mut future_clause_snapshots,
+        current_clause_is_split_derived: &mut current_clause_is_split_derived,
+        current_clause_is_direct_split_remainder: &mut current_clause_is_direct_split_remainder,
+        current_clause_has_split_left_neighbor: &mut current_clause_has_split_left_neighbor,
+        current_clause_split_group_id: &mut current_clause_split_group_id,
+        next_split_group_id: &mut next_split_group_id,
+    };
+
+    let effect = TextServiceFactory::apply_move_clause(&mut state, &mut backend, 1)
+        .expect("right move should use the batched operation");
+
+    assert!(effect.applied);
+    assert_eq!(backend.advance_calls, 1);
+    assert_eq!(preview, "いい加減統一");
+    assert_eq!(suffix, "");
 }
 
 impl ClauseActionBackend for NonProgressEnsureBackend {
@@ -1283,16 +1359,77 @@ impl ClauseActionBackend for NonProgressEnsureBackend {
 
     fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
         self.shrink_calls += 1;
-        assert!(
-            self.shrink_calls <= 1,
-            "future snapshot rebuild retried a non-progressing right move"
-        );
         Ok(Candidates::default())
+    }
+
+    fn prepare_future_clauses(
+        &mut self,
+        initial_offset: i32,
+        _previous_candidates: &Candidates,
+    ) -> anyhow::Result<Vec<ClauseAdvance>> {
+        self.prepare_calls += 1;
+        assert_eq!(initial_offset, 7);
+        Ok(Vec::new())
+    }
+}
+
+#[derive(Default)]
+struct BoundedPrepareBackend {
+    navigation_calls: usize,
+    pushes: usize,
+    pops: usize,
+}
+
+impl ClauseActionBackend for BoundedPrepareBackend {
+    fn move_cursor(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        self.navigation_calls += 1;
+        let remaining = 128usize.saturating_sub(self.navigation_calls);
+        Ok(candidates(
+            &["節"],
+            &["残り"],
+            &"あ".repeat(remaining.max(1)),
+            &[1],
+        ))
+    }
+
+    fn shrink_text(&mut self, _offset: i32) -> anyhow::Result<Candidates> {
+        Ok(candidates(&["節"], &["残り"], "あ", &[1]))
+    }
+
+    fn update_composition_snapshot(
+        &mut self,
+        operation: ClauseSnapshotOperation,
+        _previous_candidates: &Candidates,
+    ) -> anyhow::Result<()> {
+        match operation {
+            ClauseSnapshotOperation::Push => self.pushes += 1,
+            ClauseSnapshotOperation::Pop => self.pops += 1,
+            ClauseSnapshotOperation::Clear => {}
+        }
+        Ok(())
     }
 }
 
 #[test]
-fn ensure_clause_navigation_stops_rebuilding_future_on_non_progress_move() {
+fn prepare_future_clauses_bounds_suffix_clone_work() {
+    let previous = candidates(&["節"], &["残り"], &"あ".repeat(128), &[1]);
+    let mut backend = BoundedPrepareBackend::default();
+
+    let prepared = backend
+        .prepare_future_clauses(1, &previous)
+        .expect("bounded preparation should succeed");
+
+    assert_eq!(prepared.len(), shared::MAX_PREPARED_CLAUSE_ADVANCES);
+    assert_eq!(
+        backend.navigation_calls,
+        shared::MAX_PREPARED_CLAUSE_ADVANCES
+    );
+    assert_eq!(backend.pushes, shared::MAX_PREPARED_CLAUSE_ADVANCES);
+    assert_eq!(backend.pops, shared::MAX_PREPARED_CLAUSE_ADVANCES);
+}
+
+#[test]
+fn ensure_clause_navigation_uses_two_constant_backend_operations() {
     let mut preview = "いい加減統一".to_string();
     let mut suffix = String::new();
     let mut raw_input = "iikagentouitu".to_string();
@@ -1311,6 +1448,7 @@ fn ensure_clause_navigation_stops_rebuilding_future_on_non_progress_move() {
     let mut backend = NonProgressEnsureBackend {
         move_cursor_zero_calls: 0,
         shrink_calls: 0,
+        prepare_calls: 0,
     };
 
     let mut state = ClauseActionStateMut {
@@ -1335,7 +1473,9 @@ fn ensure_clause_navigation_stops_rebuilding_future_on_non_progress_move() {
         .expect("ensure clause navigation should return");
 
     assert!(effect.applied);
-    assert_eq!(backend.shrink_calls, 1);
+    assert_eq!(backend.move_cursor_zero_calls, 1);
+    assert_eq!(backend.prepare_calls, 1);
+    assert_eq!(backend.shrink_calls, 0);
     assert!(future_clause_snapshots.is_empty());
 }
 
@@ -1385,13 +1525,17 @@ struct FKeyDisplayEnsureBackend {
 
 impl ClauseActionBackend for FKeyDisplayEnsureBackend {
     fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
-        if offset == 0 && !self.shrunk {
-            return Ok(candidates(
-                &["加減", "下限", "かげん"],
-                &["統一", "統一", "統一"],
-                "かげんとういつ",
-                &[5, 5, 5],
-            ));
+        if offset == 0 {
+            return Ok(if self.shrunk {
+                candidates(&["統一"], &[""], "とういつ", &[6])
+            } else {
+                candidates(
+                    &["加減", "下限", "かげん"],
+                    &["統一", "統一", "統一"],
+                    "かげんとういつ",
+                    &[5, 5, 5],
+                )
+            });
         }
         Ok(Candidates::default())
     }

--- a/crates/client/src/engine/composition/tests/snapshot_restore.rs
+++ b/crates/client/src/engine/composition/tests/snapshot_restore.rs
@@ -189,7 +189,7 @@ fn move_clause_right_prefers_rich_navigation_candidates_after_two_clause_shrink(
 }
 
 #[test]
-fn auto_split_future_snapshot_preserves_rich_candidates_for_exact_two_clause_suffix() {
+fn auto_split_prepared_snapshot_preserves_rich_candidates_for_exact_two_clause_suffix() {
     let mut preview = "いい加減".to_string();
     let mut suffix = "統一しろ".to_string();
     let mut raw_input = "iikagentouitusiro".to_string();
@@ -229,13 +229,15 @@ fn auto_split_future_snapshot_preserves_rich_candidates_for_exact_two_clause_suf
         "とういつしろ",
         &[10, 10, 10, 10],
     );
-    let mut backend = RichNavigationAfterShrinkBackend {
-        shrink_candidates: suffix_candidates.clone(),
-        navigation_candidates: suffix_candidates,
-    };
 
-    TextServiceFactory::rebuild_future_clause_snapshots_from_backend(&mut state, &mut backend)
-        .expect("future snapshots should rebuild");
+    TextServiceFactory::rebuild_future_clause_snapshots_from_prepared(
+        &mut state,
+        vec![ClauseAdvance {
+            shrunk: suffix_candidates.clone(),
+            navigation: suffix_candidates,
+        }],
+    )
+    .expect("future snapshots should rebuild from the batch response");
 
     let snapshot = state
         .future_clause_snapshots

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -584,10 +584,14 @@ impl IPCService {
         Ok(())
     }
 
-    fn mark_server_timeout(recovery: &Arc<ServerRecoveryState>, operation: &'static str) {
+    fn mark_server_recovery_required(recovery: &Arc<ServerRecoveryState>, operation: &'static str) {
+        Self::mark_recovery_pending(recovery);
+        Self::request_server_restart(recovery, operation);
+    }
+
+    fn mark_recovery_pending(recovery: &ServerRecoveryState) {
         recovery.generation.fetch_add(1, Ordering::AcqRel);
         recovery.pending.store(true, Ordering::Release);
-        Self::request_server_restart(recovery, operation);
     }
 
     fn request_server_restart(recovery: &Arc<ServerRecoveryState>, operation: &'static str) {
@@ -754,7 +758,7 @@ impl IPCService {
     {
         let result = runtime.block_on(await_rpc_with_deadline(operation, deadline, future));
         if result.as_ref().is_err_and(is_ipc_deadline) {
-            Self::mark_server_timeout(recovery, operation);
+            Self::mark_server_recovery_required(recovery, operation);
         }
         result
     }
@@ -875,6 +879,15 @@ impl IPCService {
             previous.has_same_composition(refreshed_candidates)
                 && !refreshed_candidates.is_empty_composition()
         })
+    }
+
+    #[inline]
+    fn prepare_future_clauses_reconnect_state_is_valid(
+        previous_candidates: &Candidates,
+        refreshed_candidates: &Candidates,
+    ) -> bool {
+        !refreshed_candidates.is_empty_composition()
+            && previous_candidates.has_same_composition(refreshed_candidates)
     }
 
     fn run_non_idempotent_edit_with_reconnect(
@@ -1066,6 +1079,61 @@ impl IPCService {
         self.observe_server_session("shrink_text", response.server_session_id);
         self.invalidate_input_ledger();
         Self::candidates_from_composing_text(response.composing_text)
+    }
+
+    fn send_advance_clause(
+        &mut self,
+        offset: i32,
+        request_id: u64,
+    ) -> anyhow::Result<super::composition::ClauseAdvance> {
+        let mut request =
+            tonic::Request::new(shared::proto::AdvanceClauseRequest { offset, request_id });
+        request.set_timeout(INPUT_RPC_DEADLINE);
+        let response = Self::block_on_server_rpc(
+            self.runtime.as_ref(),
+            &self.recovery,
+            "advance_clause",
+            INPUT_RPC_DEADLINE,
+            self.azookey_client.advance_clause(request),
+        )?;
+        let response = response.into_inner();
+        self.observe_server_session("advance_clause", response.server_session_id);
+        self.invalidate_input_ledger();
+        Ok(super::composition::ClauseAdvance {
+            shrunk: Self::candidates_from_composing_text(response.shrunk_text)?,
+            navigation: Self::candidates_from_composing_text(response.navigation_text)?,
+        })
+    }
+
+    fn send_prepare_future_clauses(
+        &mut self,
+        initial_offset: i32,
+        request_id: u64,
+    ) -> anyhow::Result<Vec<super::composition::ClauseAdvance>> {
+        let mut request = tonic::Request::new(shared::proto::PrepareFutureClausesRequest {
+            initial_offset,
+            request_id,
+        });
+        request.set_timeout(INPUT_RPC_DEADLINE);
+        let response = Self::block_on_server_rpc(
+            self.runtime.as_ref(),
+            &self.recovery,
+            "prepare_future_clauses",
+            INPUT_RPC_DEADLINE,
+            self.azookey_client.prepare_future_clauses(request),
+        )?;
+        let response = response.into_inner();
+        self.observe_server_session("prepare_future_clauses", response.server_session_id);
+        response
+            .advances
+            .into_iter()
+            .map(|advance| {
+                Ok(super::composition::ClauseAdvance {
+                    shrunk: Self::candidates_from_composing_text(advance.shrunk_text)?,
+                    navigation: Self::candidates_from_composing_text(advance.navigation_text)?,
+                })
+            })
+            .collect()
     }
 
     fn send_move_cursor(&mut self, offset: i32, request_id: u64) -> anyhow::Result<Candidates> {
@@ -1630,6 +1698,122 @@ impl IPCService {
         Ok(candidates)
     }
 
+    #[tracing::instrument(skip(self, previous_candidates))]
+    pub(crate) fn advance_clause(
+        &mut self,
+        offset: i32,
+        previous_candidates: &Candidates,
+    ) -> anyhow::Result<super::composition::ClauseAdvance> {
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let mut completed_advance = None;
+        let result = self.run_non_idempotent_edit_with_reconnect(
+            "advance_clause",
+            request_id,
+            Some(previous_candidates),
+            |this| {
+                let advance = this.send_advance_clause(offset, request_id)?;
+                let navigation = advance.navigation.clone();
+                completed_advance = Some(advance);
+                Ok(navigation)
+            },
+        );
+        self.log_client_performance_from_start(
+            performance_start,
+            request_id,
+            "advance_clause",
+            "rpc_total",
+            || match &result {
+                Ok((_, recovery)) => format!(
+                    "status=success;recovery={};offset={offset}",
+                    recovery.log_value()
+                ),
+                Err(error) => format!("status=error;offset={offset};error={error:?}"),
+            },
+        );
+        let (navigation, _) = result?;
+        Ok(
+            completed_advance.unwrap_or_else(|| super::composition::ClauseAdvance {
+                // If the transport failed after the server had already advanced,
+                // refresh can recover only the current navigation candidates.
+                shrunk: navigation.clone(),
+                navigation,
+            }),
+        )
+    }
+
+    #[tracing::instrument(skip(self, previous_candidates))]
+    pub(crate) fn prepare_future_clauses(
+        &mut self,
+        initial_offset: i32,
+        previous_candidates: &Candidates,
+    ) -> anyhow::Result<Vec<super::composition::ClauseAdvance>> {
+        let request_id = current_or_next_request_id();
+        let performance_start = client_performance_start();
+        let result = self
+            .run_rpc_with_reconnect("prepare_future_clauses", |this| {
+                this.send_prepare_future_clauses(initial_offset, request_id)
+            })
+            .map_err(|error| {
+                if Self::should_reconnect_rpc_error(&error) {
+                    Self::mark_server_recovery_required(
+                        &self.recovery,
+                        "prepare_future_clauses_reconnect_failed",
+                    );
+                    preserve_recovery_error(error)
+                } else {
+                    error
+                }
+            })
+            .and_then(|(advances, reconnected)| {
+                if self.take_server_reset_recovered() {
+                    Self::mark_server_recovery_required(
+                        &self.recovery,
+                        "prepare_future_clauses_session_change",
+                    );
+                    return Err(preserve_recovery_error(anyhow::anyhow!(
+                        "prepare_future_clauses reached a different server session"
+                    )));
+                }
+
+                if reconnected {
+                    let refreshed = self
+                        .send_move_cursor(0, request_id)
+                        .map_err(preserve_recovery_error)?;
+                    if !Self::prepare_future_clauses_reconnect_state_is_valid(
+                        previous_candidates,
+                        &refreshed,
+                    ) {
+                        Self::mark_server_recovery_required(
+                            &self.recovery,
+                            "prepare_future_clauses_state_mismatch",
+                        );
+                        return Err(preserve_recovery_error(anyhow::anyhow!(
+                            "prepare_future_clauses composition changed after reconnect"
+                        )));
+                    }
+                }
+
+                Ok(advances)
+            });
+        self.log_client_performance_from_start(
+            performance_start,
+            request_id,
+            "prepare_future_clauses",
+            "rpc_total",
+            || match &result {
+                Ok(advances) => format!(
+                    "status=success;initial_offset={initial_offset};advance_count={}",
+                    advances.len()
+                ),
+                Err(error) => {
+                    format!("status=error;initial_offset={initial_offset};error={error:?}")
+                }
+            },
+        );
+        result
+    }
+
     #[tracing::instrument]
     pub fn move_cursor(&mut self, offset: i32) -> anyhow::Result<Candidates> {
         self.move_cursor_inner(offset, None)
@@ -2153,7 +2337,8 @@ mod tests {
         pop_input_segment_character, preserve_recovery_error, recovery_generation_is_current,
         requires_ipc_recovery, restart_generation_ready, restart_request_needed, Candidates,
         ClauseSnapshotOperation, CompositionOperation, IPCService, InputLedger,
-        IpcDeadlineExceeded, NonIdempotentEditAttempt, INPUT_STYLE_DIRECT, INPUT_STYLE_ROMAN2KANA,
+        IpcDeadlineExceeded, NonIdempotentEditAttempt, ServerRecoveryState, INPUT_STYLE_DIRECT,
+        INPUT_STYLE_ROMAN2KANA,
     };
     use std::{
         future::Future,
@@ -2235,6 +2420,16 @@ mod tests {
     fn server_restart_recovery_ignores_stale_generation_completion() {
         assert!(recovery_generation_is_current(7, 7));
         assert!(!recovery_generation_is_current(7, 8));
+    }
+
+    #[test]
+    fn explicit_recovery_marks_pending_and_advances_generation() {
+        let recovery = ServerRecoveryState::default();
+
+        IPCService::mark_recovery_pending(&recovery);
+
+        assert!(recovery.pending.load(Ordering::Acquire));
+        assert_eq!(recovery.generation.load(Ordering::Acquire), 1);
     }
 
     #[test]
@@ -2601,6 +2796,44 @@ mod tests {
         let error = anyhow::anyhow!("named pipe disconnected");
 
         assert!(IPCService::should_reconnect_rpc_error(&error));
+    }
+
+    #[test]
+    fn prepare_future_clauses_retry_accepts_unchanged_composition() {
+        let candidates = Candidates {
+            texts: vec!["いい加減".to_string()],
+            sub_texts: vec!["統一".to_string()],
+            hiragana: "いいかげんとういつ".to_string(),
+            corresponding_count: vec![7],
+            candidate_ids: vec![1],
+        };
+        let refreshed = Candidates {
+            candidate_ids: vec![2],
+            ..candidates.clone()
+        };
+
+        assert!(IPCService::prepare_future_clauses_reconnect_state_is_valid(
+            &candidates,
+            &refreshed
+        ));
+    }
+
+    #[test]
+    fn prepare_future_clauses_retry_rejects_reset_server_state() {
+        let previous = Candidates {
+            texts: vec!["いい加減".to_string()],
+            sub_texts: vec!["統一".to_string()],
+            hiragana: "いいかげんとういつ".to_string(),
+            corresponding_count: vec![7],
+            candidate_ids: vec![1],
+        };
+
+        assert!(
+            !IPCService::prepare_future_clauses_reconnect_state_is_valid(
+                &previous,
+                &Candidates::default()
+            )
+        );
     }
 
     #[test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1819,19 +1819,22 @@ impl AzookeyService for MyAzookeyService {
         let mut snapshot_count = 0usize;
         let mut last_signature = None;
 
-        let result = (|| -> Result<(), Status> {
+        let result = (|| -> Result<(), Box<Status>> {
             for _ in 0..shared::MAX_PREPARED_CLAUSE_ADVANCES {
                 unsafe {
                     PushComposingTextSnapshot();
                 }
                 snapshot_count += 1;
 
-                let shrunk_text = shrink_text(offset)
-                    .map_err(|error| status_from_error("prepare_future_clauses", error))?;
-                let navigation_text = move_cursor(0)
-                    .map_err(|error| status_from_error("prepare_future_clauses", error))?;
-                let navigation_composed = get_composed_text(true, request_id)
-                    .map_err(|error| status_from_error("prepare_future_clauses", error))?;
+                let shrunk_text = shrink_text(offset).map_err(|error| {
+                    Box::new(status_from_error("prepare_future_clauses", error))
+                })?;
+                let navigation_text = move_cursor(0).map_err(|error| {
+                    Box::new(status_from_error("prepare_future_clauses", error))
+                })?;
+                let navigation_composed = get_composed_text(true, request_id).map_err(|error| {
+                    Box::new(status_from_error("prepare_future_clauses", error))
+                })?;
 
                 let Some(selected) = navigation_composed.suggestions.first() else {
                     break;
@@ -1850,7 +1853,7 @@ impl AzookeyService for MyAzookeyService {
                     break;
                 }
                 last_signature = Some(signature);
-                offset = validate_shrink_offset(selected.corresponding_count)?;
+                offset = validate_shrink_offset(selected.corresponding_count).map_err(Box::new)?;
                 let navigation_composing_text = ComposingText {
                     hiragana: navigation_composed.hiragana.unwrap_or(navigation_text.text),
                     suggestions: navigation_composed.suggestions,
@@ -1874,7 +1877,7 @@ impl AzookeyService for MyAzookeyService {
                 PopComposingTextSnapshot();
             }
         }
-        result?;
+        result.map_err(|status| *status)?;
 
         performance_event_lazy!(
             request_id,

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -7,11 +7,13 @@ use windows::Win32::System::Threading::{GetCurrentProcess, SetPriorityClass, HIG
 
 use shared::proto::azookey_service_server::{AzookeyService, AzookeyServiceServer};
 use shared::proto::{
-    AppendTextRequest, AppendTextResponse, ClearTextRequest, ClearTextResponse, ComposingText,
-    CompositionOperationKind, CompositionSnapshotOperation, MoveCursorRequest, MoveCursorResponse,
-    PerformanceLogRequest, PerformanceLogResponse, RemoveTextRequest, RemoveTextResponse,
-    ReplaceCompositionRequest, ReplaceCompositionResponse, ShrinkTextRequest, ShrinkTextResponse,
-    Suggestion, UpdateCompositionSnapshotRequest, UpdateCompositionSnapshotResponse,
+    AdvanceClauseRequest, AdvanceClauseResponse, AppendTextRequest, AppendTextResponse,
+    ClearTextRequest, ClearTextResponse, ComposingText, CompositionOperationKind,
+    CompositionSnapshotOperation, MoveCursorRequest, MoveCursorResponse, PerformanceLogRequest,
+    PerformanceLogResponse, PrepareFutureClausesRequest, PrepareFutureClausesResponse,
+    PreparedClauseAdvance, RemoveTextRequest, RemoveTextResponse, ReplaceCompositionRequest,
+    ReplaceCompositionResponse, ShrinkTextRequest, ShrinkTextResponse, Suggestion,
+    UpdateCompositionSnapshotRequest, UpdateCompositionSnapshotResponse,
 };
 use shared::{AppConfig, SERVER_PIPE_PATH};
 
@@ -1332,6 +1334,33 @@ fn shrink_text(offset: i32) -> Result<RawComposingText, String> {
     }
 }
 
+struct CompositionSnapshotRollback {
+    armed: bool,
+}
+
+impl CompositionSnapshotRollback {
+    fn push() -> Self {
+        unsafe {
+            PushComposingTextSnapshot();
+        }
+        Self { armed: true }
+    }
+
+    fn commit(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CompositionSnapshotRollback {
+    fn drop(&mut self) {
+        if self.armed {
+            unsafe {
+                PopComposingTextSnapshot();
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct MyAzookeyService {
     mutation_lock: Arc<tokio::sync::Mutex<()>>,
@@ -1706,6 +1735,157 @@ impl AzookeyService for MyAzookeyService {
                 hiragana: composed_text.hiragana.unwrap_or(composing_text.text),
                 suggestions: composed_text.suggestions,
             }),
+            server_session_id: server_session_id(),
+        }))
+    }
+
+    async fn advance_clause(
+        &self,
+        request: Request<AdvanceClauseRequest>,
+    ) -> Result<Response<AdvanceClauseResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
+        let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(true);
+        let request_id = request_id_or_next(request.request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+        let raw_offset = validate_shrink_offset(request.offset)?;
+
+        let snapshot_rollback = CompositionSnapshotRollback::push();
+
+        let shrink_start = Instant::now();
+        let shrunk_text =
+            shrink_text(raw_offset).map_err(|error| status_from_error("advance_clause", error))?;
+        performance_event_lazy!(
+            request_id,
+            "advance_clause",
+            "swift_shrink_text",
+            elapsed_ms(shrink_start),
+            "offset={raw_offset};candidate_generation=deferred"
+        );
+
+        let move_start = Instant::now();
+        let navigation_text =
+            move_cursor(0).map_err(|error| status_from_error("advance_clause", error))?;
+        let navigation_composed = get_composed_text(true, request_id)
+            .map_err(|error| status_from_error("advance_clause", error))?;
+        performance_event_lazy!(
+            request_id,
+            "advance_clause",
+            "swift_move_cursor",
+            elapsed_ms(move_start),
+            "hiragana_len={};suggestions={}",
+            navigation_text.text.chars().count(),
+            navigation_composed.suggestions.len()
+        );
+
+        update_active_composition_state(&navigation_text.text);
+        performance_event_lazy!(
+            request_id,
+            "advance_clause",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success;offset={raw_offset};navigation_suggestions={}",
+            navigation_composed.suggestions.len()
+        );
+
+        let navigation_composing_text = ComposingText {
+            hiragana: navigation_composed.hiragana.unwrap_or(navigation_text.text),
+            suggestions: navigation_composed.suggestions,
+        };
+        snapshot_rollback.commit();
+        Ok(Response::new(AdvanceClauseResponse {
+            shrunk_text: Some(ComposingText {
+                hiragana: shrunk_text.text,
+                suggestions: Vec::new(),
+            }),
+            navigation_text: Some(navigation_composing_text),
+            server_session_id: server_session_id(),
+        }))
+    }
+
+    async fn prepare_future_clauses(
+        &self,
+        request: Request<PrepareFutureClausesRequest>,
+    ) -> Result<Response<PrepareFutureClausesResponse>, Status> {
+        let _mutation_guard = self.mutation_lock.lock().await;
+        let request = request.into_inner();
+        let _request_guard = ServerRequestGuard::begin(true);
+        let request_id = request_id_or_next(request.request_id);
+        set_request_id(request_id);
+        let handler_start = Instant::now();
+        let mut offset = validate_shrink_offset(request.initial_offset)?;
+        let mut advances = Vec::new();
+        let mut snapshot_count = 0usize;
+        let mut last_signature = None;
+
+        let result = (|| -> Result<(), Status> {
+            for _ in 0..shared::MAX_PREPARED_CLAUSE_ADVANCES {
+                unsafe {
+                    PushComposingTextSnapshot();
+                }
+                snapshot_count += 1;
+
+                let shrunk_text = shrink_text(offset)
+                    .map_err(|error| status_from_error("prepare_future_clauses", error))?;
+                let navigation_text = move_cursor(0)
+                    .map_err(|error| status_from_error("prepare_future_clauses", error))?;
+                let navigation_composed = get_composed_text(true, request_id)
+                    .map_err(|error| status_from_error("prepare_future_clauses", error))?;
+
+                let Some(selected) = navigation_composed.suggestions.first() else {
+                    break;
+                };
+                let is_last = selected.subtext.is_empty();
+                let signature = (
+                    navigation_composed
+                        .hiragana
+                        .as_deref()
+                        .unwrap_or(&navigation_text.text)
+                        .to_string(),
+                    selected.corresponding_count,
+                    selected.subtext.clone(),
+                );
+                if last_signature.as_ref() == Some(&signature) {
+                    break;
+                }
+                last_signature = Some(signature);
+                offset = validate_shrink_offset(selected.corresponding_count)?;
+                let navigation_composing_text = ComposingText {
+                    hiragana: navigation_composed.hiragana.unwrap_or(navigation_text.text),
+                    suggestions: navigation_composed.suggestions,
+                };
+                advances.push(PreparedClauseAdvance {
+                    shrunk_text: Some(ComposingText {
+                        hiragana: shrunk_text.text,
+                        suggestions: Vec::new(),
+                    }),
+                    navigation_text: Some(navigation_composing_text),
+                });
+                if is_last {
+                    break;
+                }
+            }
+            Ok(())
+        })();
+
+        for _ in 0..snapshot_count {
+            unsafe {
+                PopComposingTextSnapshot();
+            }
+        }
+        result?;
+
+        performance_event_lazy!(
+            request_id,
+            "prepare_future_clauses",
+            "total",
+            elapsed_ms(handler_start),
+            "status=success;advance_count={}",
+            advances.len()
+        );
+        Ok(Response::new(PrepareFutureClausesResponse {
+            advances,
             server_session_id: server_session_id(),
         }))
     }

--- a/crates/shared/service.proto
+++ b/crates/shared/service.proto
@@ -102,6 +102,34 @@ message ShrinkTextResponse {
   uint64 server_session_id = 2; // Identifies the current server process session.
 }
 
+// Advances clause navigation as one server-side transaction. The snapshot is
+// pushed before shrinking so moving left can restore the previous clause.
+message AdvanceClauseRequest {
+  int32 offset = 1;
+  uint64 request_id = 2;
+}
+
+message AdvanceClauseResponse {
+  ComposingText shrunk_text = 1;
+  ComposingText navigation_text = 2;
+  uint64 server_session_id = 3;
+}
+
+message PreparedClauseAdvance {
+  ComposingText shrunk_text = 1;
+  ComposingText navigation_text = 2;
+}
+
+message PrepareFutureClausesRequest {
+  int32 initial_offset = 1;
+  uint64 request_id = 2;
+}
+
+message PrepareFutureClausesResponse {
+  repeated PreparedClauseAdvance advances = 1;
+  uint64 server_session_id = 2;
+}
+
 // Response message for MoveCursor.
 message MoveCursorResponse {
   ComposingText composing_text = 1; // The resulting text and suggestions.
@@ -178,6 +206,8 @@ service AzookeyService {
   rpc ReplaceComposition (ReplaceCompositionRequest) returns (ReplaceCompositionResponse);
   rpc RemoveText (RemoveTextRequest) returns (RemoveTextResponse);
   rpc ShrinkText (ShrinkTextRequest) returns (ShrinkTextResponse);
+  rpc AdvanceClause (AdvanceClauseRequest) returns (AdvanceClauseResponse);
+  rpc PrepareFutureClauses (PrepareFutureClausesRequest) returns (PrepareFutureClausesResponse);
   rpc MoveCursor (MoveCursorRequest) returns (MoveCursorResponse);
   rpc UpdateCompositionSnapshot (UpdateCompositionSnapshotRequest) returns (UpdateCompositionSnapshotResponse);
   rpc ClearText (ClearTextRequest) returns (ClearTextResponse);

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -17,6 +17,9 @@ pub mod proto {
 // same session-local endpoint.
 pub const SERVER_PIPE_PATH: &str = r"\\.\pipe\LOCAL\azookey_server";
 pub const UI_PIPE_PATH: &str = r"\\.\pipe\LOCAL\azookey_ui";
+// Bounds the suffix-bearing candidate payload and snapshot cloning performed
+// when clause navigation starts. Longer compositions continue lazily.
+pub const MAX_PREPARED_CLAUSE_ADVANCES: usize = 16;
 
 #[cfg(windows)]
 pub fn open_named_pipe_client_handle(


### PR DESCRIPTION
## Summary
- 文節ナビゲーション開始時の将来文節解析を1回のserver transactionへ集約
- 通常の右移動もsnapshot・shrink・候補生成を1 RPCへ集約
- 再接続時のsession/composition不一致を検出してabsolute recoveryへ移行

## Background
- Issue: #130
- Issue close: 対象リリース公開・成果物確認後
- 初回文節移動で同期RPCと候補生成が繰り返され、Zenzai無効でも528 msを要していたため

## Changes
- shared/server: `AdvanceClause` と `PrepareFutureClauses` RPCを追加し、snapshot rollbackを保証
- client: 一括応答からfuture snapshotをローカル再構築し、初回Rightを2 RPCへ削減
- performance: suffix付き先読みを最大16文節に制限し、長文時のpayload/clone量を有界化
- recovery: 一括RPC再接続後のserver sessionとcompositionを照合
- tests: RPC操作数、先読み上限、rich candidates、既存#76互換シナリオの回帰テストを追加・更新

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/30057732793
- [x] Windows 実機確認
  - Windows VM composition tests: 130 passed / 0 failed
  - Windows x64 client/server cargo check: 成功
  - Zenzai OFF: 初回Right 2 RPC、85 ms（旧528 msから約84%短縮）
  - Zenzai ON: 初回Right最大待ち時間サンプル 386 ms
  - installer staging: 成功

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->