### PR TITLE
Enforce TSF edit session contracts

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -78,6 +78,10 @@ fn requires_server_resynchronization(error: &anyhow::Error) -> bool {
     is_edit_session_error(error)
 }
 
+fn language_bar_toggle_requires_deferred_replay(composition: &Composition) -> bool {
+    !composition.deferred_actions.is_empty() || !composition.deferred_inputs.is_empty()
+}
+
 fn mode_switch_request_is_current(
     requested_generation: u64,
     current_generation: u64,
@@ -4833,6 +4837,34 @@ impl TextServiceFactory {
             }
         }
         result
+    }
+
+    pub(crate) fn request_language_bar_input_mode_toggle(&self, mode: InputMode) -> Result<()> {
+        let composition = {
+            let text_service = self.borrow()?;
+            let composition = text_service.borrow_composition()?.clone();
+            composition
+        };
+        if !language_bar_toggle_requires_deferred_replay(&composition) {
+            return self.request_input_mode_switch_after_composition(mode);
+        }
+
+        // A pending asynchronous language-bar request must not overtake queued recovery input.
+        // Invalidate it, then enqueue this click behind the existing deferred actions so the
+        // normal handle_action path replays user input before applying SetIMEMode.
+        self.borrow_mut()?.invalidate_mode_switch_requests();
+        let config_snapshot = IMEState::app_config_snapshot()?;
+        let deferred = DeferredUserAction {
+            action: UserAction::ToggleInputMode,
+            is_shift_pressed: false,
+            is_shift_key: false,
+            shift_alphabet_shortcut: false,
+        };
+        if !self.enqueue_deferred_user_action(&composition, deferred, &config_snapshot)? {
+            tracing::warn!("Failed to plan deferred language-bar input mode toggle");
+            return Ok(());
+        }
+        self.flush_deferred_user_actions()
     }
 
     #[tracing::instrument]

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -4626,7 +4626,7 @@ impl TextServiceFactory {
         self.end_composition_async_best_effort();
 
         if let Ok(mut text_service) = self.borrow_mut() {
-            text_service.advance_mode_switch_generation();
+            text_service.invalidate_mode_switch_requests();
             if let Ok(mut composition) = text_service.borrow_mut_composition() {
                 *composition = Composition::default();
             }
@@ -4646,14 +4646,22 @@ impl TextServiceFactory {
 
     fn complete_input_mode_switch_best_effort(
         &self,
+        generation: u64,
         mode: InputMode,
         position: Option<shared::proto::WindowPosition>,
     ) {
-        if let Ok(text_service) = self.borrow() {
-            if let Ok(mut composition) = text_service.borrow_mut_composition() {
-                *composition = Composition::default();
-            }
+        let Ok(mut text_service) = self.borrow_mut() else {
+            tracing::warn!("Failed to complete deferred input mode switch due to borrow conflict");
+            return;
+        };
+        if !text_service.clear_pending_mode_switch(generation) {
+            tracing::debug!("Skip superseded deferred input mode switch");
+            return;
         }
+        if let Ok(mut composition) = text_service.borrow_mut_composition() {
+            *composition = Composition::default();
+        }
+        drop(text_service);
 
         if let Err(error) = IMEState::set_input_mode(mode.clone()) {
             tracing::warn!(?error, "Failed to apply deferred input mode switch");
@@ -4741,22 +4749,25 @@ impl TextServiceFactory {
         let (this, context, tip_composition, generation) = {
             let mut text_service = self.borrow_mut()?;
             let tip_composition = text_service.borrow_composition()?.tip_composition.clone();
-            let generation = text_service.advance_mode_switch_generation();
-            (
-                text_service.this::<ITfTextInputProcessor>()?,
-                text_service.context::<ITfContext>()?,
-                tip_composition,
-                generation,
-            )
+            let this = text_service.this::<ITfTextInputProcessor>()?;
+            let context = text_service.context::<ITfContext>()?;
+            let generation = text_service.begin_mode_switch(mode.clone());
+            (this, context, tip_composition, generation)
         };
 
         let Some(tip_composition) = tip_composition else {
             let on_complete = Rc::new({
+                let this = this.clone();
                 let context = context.clone();
+                let mode = mode.clone();
                 move |position| {
                     let factory = unsafe { this.as_impl() };
                     if factory.is_current_idle_mode_switch_request(generation, &context) {
-                        factory.complete_input_mode_switch_best_effort(mode.clone(), position);
+                        factory.complete_input_mode_switch_best_effort(
+                            generation,
+                            mode.clone(),
+                            position,
+                        );
                     } else {
                         tracing::debug!("Skip stale idle mode-switch completion");
                     }
@@ -4767,10 +4778,22 @@ impl TextServiceFactory {
                     ?error,
                     "Failed to queue caret lookup for language-bar mode switch"
                 );
+                let factory = unsafe { this.as_impl() };
+                if factory.is_current_idle_mode_switch_request(generation, &context) {
+                    factory.complete_input_mode_switch_best_effort(generation, mode, None);
+                }
             }
             return Ok(());
         };
-        let position = self.candidate_window_position()?;
+        let position = match self.candidate_window_position() {
+            Ok(position) => position,
+            Err(error) => {
+                if let Ok(mut text_service) = self.borrow_mut() {
+                    text_service.clear_pending_mode_switch(generation);
+                }
+                return Err(error);
+            }
+        };
 
         let is_current = Rc::new({
             let this = this.clone();
@@ -4783,9 +4806,15 @@ impl TextServiceFactory {
         });
         let on_success = Rc::new(move || {
             let factory = unsafe { this.as_impl() };
-            factory.complete_input_mode_switch_best_effort(mode.clone(), position);
+            factory.complete_input_mode_switch_best_effort(generation, mode.clone(), position);
         });
-        self.end_composition_async_on_success(is_current, on_success)
+        let result = self.end_composition_async_on_success(is_current, on_success);
+        if result.is_err() {
+            if let Ok(mut text_service) = self.borrow_mut() {
+                text_service.clear_pending_mode_switch(generation);
+            }
+        }
+        result
     }
 
     #[tracing::instrument]

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -4773,7 +4773,7 @@ impl TextServiceFactory {
                     }
                 }
             });
-            let on_cancel = Rc::new({
+            let on_terminal = Rc::new({
                 let this = this.clone();
                 move || {
                     let factory = unsafe { this.as_impl() };
@@ -4782,7 +4782,7 @@ impl TextServiceFactory {
                     }
                 }
             });
-            if let Err(error) = self.request_caret_window_position_async(on_complete, on_cancel) {
+            if let Err(error) = self.request_caret_window_position_async(on_complete, on_terminal) {
                 tracing::warn!(
                     ?error,
                     "Failed to queue caret lookup for language-bar mode switch"

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -83,6 +83,15 @@ fn mode_switch_request_is_current(
     requested_generation == current_generation && context_matches && composition_matches
 }
 
+fn idle_mode_switch_request_is_current(
+    requested_generation: u64,
+    current_generation: u64,
+    context_matches: bool,
+    composition_is_empty: bool,
+) -> bool {
+    requested_generation == current_generation && context_matches && composition_is_empty
+}
+
 fn has_same_com_identity<I: windows::core::Interface>(left: &I, right: &I) -> bool {
     match (left.cast::<IUnknown>(), right.cast::<IUnknown>()) {
         (Ok(left), Ok(right)) => left.as_raw() == right.as_raw(),
@@ -4612,7 +4621,9 @@ impl TextServiceFactory {
     pub(crate) fn end_composition_for_tsf_event(&self) {
         self.end_composition_async_best_effort();
 
-        if let Ok(text_service) = self.borrow() {
+        if let Ok(mut text_service) = self.borrow_mut() {
+            text_service.mode_switch_generation =
+                text_service.mode_switch_generation.wrapping_add(1);
             if let Ok(mut composition) = text_service.borrow_mut_composition() {
                 *composition = Composition::default();
             }
@@ -4701,6 +4712,25 @@ impl TextServiceFactory {
         )
     }
 
+    fn is_current_idle_mode_switch_request(&self, generation: u64, context: &ITfContext) -> bool {
+        let Ok(text_service) = self.borrow() else {
+            return false;
+        };
+        let context_matches = text_service
+            .context
+            .as_ref()
+            .is_some_and(|current| has_same_com_identity(current, context));
+        let composition_is_empty = text_service
+            .borrow_composition()
+            .is_ok_and(|composition| composition.tip_composition.is_none());
+        idle_mode_switch_request_is_current(
+            generation,
+            text_service.mode_switch_generation,
+            context_matches,
+            composition_is_empty,
+        )
+    }
+
     pub(crate) fn request_input_mode_switch_after_composition(
         &self,
         mode: InputMode,
@@ -4708,11 +4738,9 @@ impl TextServiceFactory {
         let (this, context, tip_composition, generation) = {
             let mut text_service = self.borrow_mut()?;
             let tip_composition = text_service.borrow_composition()?.tip_composition.clone();
-            let generation = tip_composition.as_ref().map(|_| {
-                text_service.mode_switch_generation =
-                    text_service.mode_switch_generation.wrapping_add(1);
-                text_service.mode_switch_generation
-            });
+            text_service.mode_switch_generation =
+                text_service.mode_switch_generation.wrapping_add(1);
+            let generation = text_service.mode_switch_generation;
             (
                 text_service.this::<ITfTextInputProcessor>()?,
                 text_service.context::<ITfContext>()?,
@@ -4722,9 +4750,16 @@ impl TextServiceFactory {
         };
 
         let Some(tip_composition) = tip_composition else {
-            let on_complete = Rc::new(move |position| {
-                let factory = unsafe { this.as_impl() };
-                factory.complete_input_mode_switch_best_effort(mode.clone(), position);
+            let on_complete = Rc::new({
+                let context = context.clone();
+                move |position| {
+                    let factory = unsafe { this.as_impl() };
+                    if factory.is_current_idle_mode_switch_request(generation, &context) {
+                        factory.complete_input_mode_switch_best_effort(mode.clone(), position);
+                    } else {
+                        tracing::debug!("Skip stale idle mode-switch completion");
+                    }
+                }
             });
             if let Err(error) = self.request_caret_window_position_async(on_complete) {
                 tracing::warn!(
@@ -4734,7 +4769,6 @@ impl TextServiceFactory {
             }
             return Ok(());
         };
-        let generation = generation.context("mode switch generation is missing")?;
         let position = self.candidate_window_position()?;
 
         let is_current = Rc::new({

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -35,7 +35,7 @@ use shared::{
     LIVE_CONVERSION_READING_VERTICAL_ADJUSTMENT_MAX,
     LIVE_CONVERSION_READING_VERTICAL_ADJUSTMENT_MIN,
 };
-use windows::core::{w, IUnknown, Interface as _, PCWSTR};
+use windows::core::{w, AsImpl as _, IUnknown, Interface as _, PCWSTR};
 use windows::Win32::{
     Foundation::{LPARAM, WPARAM},
     System::Com::CoTaskMemFree,
@@ -46,9 +46,9 @@ use windows::Win32::{
             VK_MENU, VK_RCONTROL, VK_RMENU, VK_RSHIFT, VK_SHIFT,
         },
         TextServices::{
-            ITfComposition, ITfCompositionSink_Impl, ITfContext, ITfInputScope, InputScope,
-            GUID_PROP_INPUTSCOPE, IS_NUMERIC_PASSWORD, IS_PASSWORD, IS_PRIVATE,
-            TF_DEFAULT_SELECTION, TF_SELECTION,
+            ITfComposition, ITfCompositionSink_Impl, ITfContext, ITfInputScope,
+            ITfTextInputProcessor, InputScope, GUID_PROP_INPUTSCOPE, IS_NUMERIC_PASSWORD,
+            IS_PASSWORD, IS_PRIVATE, TF_DEFAULT_SELECTION, TF_SELECTION,
         },
     },
 };
@@ -4598,6 +4598,63 @@ impl TextServiceFactory {
         }
     }
 
+    fn complete_input_mode_switch_best_effort(
+        &self,
+        mode: InputMode,
+        position: Option<shared::proto::WindowPosition>,
+    ) {
+        if let Ok(text_service) = self.borrow() {
+            if let Ok(mut composition) = text_service.borrow_mut_composition() {
+                *composition = Composition::default();
+            }
+        }
+
+        if let Err(error) = IMEState::set_input_mode(mode.clone()) {
+            tracing::warn!(?error, "Failed to apply deferred input mode switch");
+        }
+        if let Err(error) = self.update_lang_bar() {
+            tracing::warn!(?error, "Failed to update language bar after mode switch");
+        }
+
+        let mode_label = match mode {
+            InputMode::Latin => "A",
+            InputMode::Kana => "あ",
+        };
+        if let Ok(Some(mut ipc_service)) = IMEState::ipc_service() {
+            if let Err(error) = ipc_service.update_candidate_window_with_reading(
+                None,
+                position,
+                None,
+                None,
+                Some(mode_label),
+                Some(""),
+                Some(false),
+                None,
+            ) {
+                tracing::warn!(?error, "Failed to update candidate UI after mode switch");
+            }
+            ipc_service.discard_input_ledger();
+            if let Err(error) = ipc_service.clear_text() {
+                tracing::warn!(?error, "Failed to clear server text after mode switch");
+            }
+            if let Err(error) = IMEState::set_ipc_service(ipc_service) {
+                tracing::warn!(?error, "Failed to persist IPC state after mode switch");
+            }
+        }
+    }
+
+    pub(crate) fn request_input_mode_switch_after_composition(
+        &self,
+        mode: InputMode,
+    ) -> Result<()> {
+        let position = self.candidate_window_position()?;
+        let this = self.borrow()?.this::<ITfTextInputProcessor>()?;
+        self.end_composition_async_on_success(Rc::new(move || {
+            let factory = unsafe { this.as_impl() };
+            factory.complete_input_mode_switch_best_effort(mode.clone(), position);
+        }))
+    }
+
     #[tracing::instrument]
     pub fn handle_action(
         &self,
@@ -5762,7 +5819,7 @@ impl TextServiceFactory {
                     }
                     ClientAction::SetIMEMode(mode) => {
                         let position = self.candidate_window_position()?;
-                        self.end_composition_async_best_effort();
+                        self.end_composition()?;
 
                         IMEState::set_input_mode(mode.clone())?;
 

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -4773,7 +4773,16 @@ impl TextServiceFactory {
                     }
                 }
             });
-            if let Err(error) = self.request_caret_window_position_async(on_complete) {
+            let on_cancel = Rc::new({
+                let this = this.clone();
+                move || {
+                    let factory = unsafe { this.as_impl() };
+                    if let Ok(mut text_service) = factory.borrow_mut() {
+                        text_service.clear_pending_mode_switch(generation);
+                    }
+                }
+            });
+            if let Err(error) = self.request_caret_window_position_async(on_complete, on_cancel) {
                 tracing::warn!(
                     ?error,
                     "Failed to queue caret lookup for language-bar mode switch"
@@ -4804,11 +4813,20 @@ impl TextServiceFactory {
                 factory.is_current_mode_switch_request(generation, &context, &tip_composition)
             }
         });
-        let on_success = Rc::new(move || {
-            let factory = unsafe { this.as_impl() };
-            factory.complete_input_mode_switch_best_effort(generation, mode.clone(), position);
+        let on_success = Rc::new({
+            let this = this.clone();
+            move || {
+                let factory = unsafe { this.as_impl() };
+                factory.complete_input_mode_switch_best_effort(generation, mode.clone(), position);
+            }
         });
-        let result = self.end_composition_async_on_success(is_current, on_success);
+        let on_terminal = Rc::new(move || {
+            let factory = unsafe { this.as_impl() };
+            if let Ok(mut text_service) = factory.borrow_mut() {
+                text_service.clear_pending_mode_switch(generation);
+            }
+        });
+        let result = self.end_composition_async_on_success(is_current, on_success, on_terminal);
         if result.is_err() {
             if let Ok(mut text_service) = self.borrow_mut() {
                 text_service.clear_pending_mode_switch(generation);

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::tsf::edit_session::edit_session;
+use crate::tsf::edit_session::{is_non_destructive_edit_session_error, read_edit_session};
 use crate::{
     engine::user_action::UserAction,
     extension::VKeyExt as _,
@@ -2936,7 +2936,7 @@ impl TextServiceFactory {
     }
 
     fn context_has_sensitive_input_scope(tid: u32, context: ITfContext) -> Result<bool> {
-        Ok(edit_session::<bool>(
+        read_edit_session::<bool>(
             tid,
             context.clone(),
             Rc::new({
@@ -2967,8 +2967,7 @@ impl TextServiceFactory {
                     Ok(Self::input_scope_list_contains_sensitive(&input_scope))
                 }
             }),
-        )?
-        .unwrap_or(false))
+        )
     }
 
     fn current_context_has_sensitive_input_scope(&self) -> bool {
@@ -4320,10 +4319,13 @@ impl TextServiceFactory {
 
         match result {
             Ok(handled) => Ok(handled),
-            Err(error) if is_non_destructive_ipc_error(&error) => {
+            Err(error)
+                if is_non_destructive_ipc_error(&error)
+                    || is_non_destructive_edit_session_error(&error) =>
+            {
                 tracing::warn!(
                     ?error,
-                    "IPC operation failed without mutating server state; preserving composition"
+                    "Operation failed without invalidating local composition; preserving it"
                 );
                 Ok(true)
             }
@@ -4387,10 +4389,13 @@ impl TextServiceFactory {
 
         match result {
             Ok(handled) => Ok(handled),
-            Err(error) if is_non_destructive_ipc_error(&error) => {
+            Err(error)
+                if is_non_destructive_ipc_error(&error)
+                    || is_non_destructive_edit_session_error(&error) =>
+            {
                 tracing::warn!(
                     ?error,
-                    "IPC key-up operation failed without mutation; preserving composition"
+                    "Key-up operation failed without invalidating local composition; preserving it"
                 );
                 Ok(true)
             }
@@ -4488,10 +4493,13 @@ impl TextServiceFactory {
 
         match result {
             Ok(handled) => Ok(handled),
-            Err(error) if is_non_destructive_ipc_error(&error) => {
+            Err(error)
+                if is_non_destructive_ipc_error(&error)
+                    || is_non_destructive_edit_session_error(&error) =>
+            {
                 tracing::warn!(
                     ?error,
-                    "IPC shortcut operation failed without mutation; preserving composition"
+                    "Shortcut operation failed without invalidating local composition; preserving it"
                 );
                 Ok(true)
             }

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -4,7 +4,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::tsf::edit_session::{is_non_destructive_edit_session_error, read_edit_session};
+use crate::tsf::edit_session::{
+    is_edit_session_error, is_non_destructive_edit_session_error, read_edit_session,
+};
 use crate::{
     engine::user_action::UserAction,
     extension::VKeyExt as _,
@@ -69,7 +71,7 @@ fn deferred_action_suffix(
 }
 
 fn requires_action_recovery(error: &anyhow::Error) -> bool {
-    requires_ipc_recovery(error) || is_non_destructive_edit_session_error(error)
+    requires_ipc_recovery(error) || is_edit_session_error(error)
 }
 
 fn mode_switch_request_is_current(
@@ -4342,6 +4344,13 @@ impl TextServiceFactory {
                 );
                 Ok(true)
             }
+            Err(error) if is_edit_session_error(&error) => {
+                tracing::warn!(
+                    ?error,
+                    "Edit-session callback failed after possible document mutation; preserving composition for recovery"
+                );
+                Ok(true)
+            }
             Err(error) => {
                 tracing::error!("handle_key failed: {error:?}");
                 self.recover_after_key_error();
@@ -4409,6 +4418,13 @@ impl TextServiceFactory {
                 tracing::warn!(
                     ?error,
                     "Key-up operation failed without invalidating local composition; preserving it"
+                );
+                Ok(true)
+            }
+            Err(error) if is_edit_session_error(&error) => {
+                tracing::warn!(
+                    ?error,
+                    "Key-up edit-session callback failed after possible mutation; preserving composition for recovery"
                 );
                 Ok(true)
             }
@@ -4513,6 +4529,13 @@ impl TextServiceFactory {
                 tracing::warn!(
                     ?error,
                     "Shortcut operation failed without invalidating local composition; preserving it"
+                );
+                Ok(true)
+            }
+            Err(error) if is_edit_session_error(&error) => {
+                tracing::warn!(
+                    ?error,
+                    "Shortcut edit-session callback failed after possible mutation; preserving composition for recovery"
                 );
                 Ok(true)
             }
@@ -4682,27 +4705,37 @@ impl TextServiceFactory {
         &self,
         mode: InputMode,
     ) -> Result<()> {
-        let position = self.candidate_window_position()?;
-        let request = {
+        let (this, context, tip_composition, generation) = {
             let mut text_service = self.borrow_mut()?;
             let tip_composition = text_service.borrow_composition()?.tip_composition.clone();
-            tip_composition.map(|tip_composition| {
+            let generation = tip_composition.as_ref().map(|_| {
                 text_service.mode_switch_generation =
                     text_service.mode_switch_generation.wrapping_add(1);
-                (
-                    text_service.this::<ITfTextInputProcessor>(),
-                    text_service.context::<ITfContext>(),
-                    tip_composition,
-                    text_service.mode_switch_generation,
-                )
-            })
+                text_service.mode_switch_generation
+            });
+            (
+                text_service.this::<ITfTextInputProcessor>()?,
+                text_service.context::<ITfContext>()?,
+                tip_composition,
+                generation,
+            )
         };
-        let Some((this, context, tip_composition, generation)) = request else {
-            self.complete_input_mode_switch_best_effort(mode, position);
+
+        let Some(tip_composition) = tip_composition else {
+            let on_complete = Rc::new(move |position| {
+                let factory = unsafe { this.as_impl() };
+                factory.complete_input_mode_switch_best_effort(mode.clone(), position);
+            });
+            if let Err(error) = self.request_caret_window_position_async(on_complete) {
+                tracing::warn!(
+                    ?error,
+                    "Failed to queue caret lookup for language-bar mode switch"
+                );
+            }
             return Ok(());
         };
-        let this = this?;
-        let context = context?;
+        let generation = generation.context("mode switch generation is missing")?;
+        let position = self.candidate_window_position()?;
 
         let is_current = Rc::new({
             let this = this.clone();
@@ -5883,8 +5916,18 @@ impl TextServiceFactory {
                         }
                     }
                     ClientAction::SetIMEMode(mode) => {
-                        let position = self.candidate_window_position()?;
-                        self.end_composition()?;
+                        let composition_active = self
+                            .borrow()?
+                            .borrow_composition()?
+                            .tip_composition
+                            .is_some();
+                        let position = if composition_active {
+                            let position = self.candidate_window_position()?;
+                            self.end_composition()?;
+                            position
+                        } else {
+                            self.caret_window_position()?
+                        };
 
                         IMEState::set_input_mode(mode.clone())?;
 

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -82,6 +82,13 @@ fn language_bar_toggle_requires_deferred_replay(composition: &Composition) -> bo
     !composition.deferred_actions.is_empty() || !composition.deferred_inputs.is_empty()
 }
 
+fn language_bar_deferred_action(mode: &InputMode) -> UserAction {
+    match mode {
+        InputMode::Kana => UserAction::InputModeOn,
+        InputMode::Latin => UserAction::InputModeOff,
+    }
+}
+
 fn mode_switch_request_is_current(
     requested_generation: u64,
     current_generation: u64,
@@ -3850,6 +3857,7 @@ impl TextServiceFactory {
         composition: &Composition,
         input: DeferredUserAction,
         config_snapshot: &AppConfigSnapshot,
+        replace_pending_mode_switch: bool,
     ) -> Result<bool> {
         let mut projection = Self::deferred_projection(composition, IMEState::input_mode()?);
         let mut projected_composition = composition.clone();
@@ -3900,12 +3908,18 @@ impl TextServiceFactory {
             .collect::<Vec<_>>();
         Self::apply_actions_to_deferred_projection(&mut projection, &fallback);
 
-        let text_service = self.borrow()?;
+        let mut text_service = self.borrow_mut()?;
         let mut persisted = text_service.borrow_mut_composition()?;
         persisted
             .deferred_inputs
             .push_back(DeferredInputEvent::User { input, fallback });
         persisted.deferred_projection = Some(projection);
+        drop(persisted);
+        if replace_pending_mode_switch {
+            // Queueing and invalidating the superseded async request happen under the same
+            // TextService borrow. Any earlier error leaves the pending request untouched.
+            text_service.invalidate_mode_switch_requests();
+        }
         Ok(true)
     }
 
@@ -4131,6 +4145,7 @@ impl TextServiceFactory {
                     &composition,
                     deferred_user_action,
                     &config_snapshot,
+                    false,
                 )? {
                     self.clear_temporary_latin_shift_pending_if_needed(should_clear_shift_pending)?;
                     return Ok(None);
@@ -4259,28 +4274,32 @@ impl TextServiceFactory {
                 self.borrow()?.borrow_mut_composition()?.deferred_projection = None;
                 return Ok(());
             };
-            self.borrow()?
-                .borrow_mut_composition()?
-                .deferred_inputs
-                .pop_front();
 
             match event {
                 DeferredInputEvent::Actions(actions) => {
-                    self.borrow()?
-                        .borrow_mut_composition()?
-                        .deferred_actions
-                        .extend(actions);
+                    let text_service = self.borrow()?;
+                    let mut composition = text_service.borrow_mut_composition()?;
+                    composition.deferred_inputs.pop_front();
+                    composition.deferred_actions.extend(actions);
                 }
                 DeferredInputEvent::User { input, fallback } => {
+                    // Keep the user event queued until every fallible prerequisite for
+                    // replanning has succeeded. A transient configuration or mode lookup
+                    // failure must not discard the user's input.
                     let config_snapshot = IMEState::app_config_snapshot()?;
                     let mode = IMEState::input_mode()?;
-                    if let Some((transition, actions)) = Self::plan_deferred_user_action(
+                    let planned = Self::plan_deferred_user_action(
                         &composition,
                         &input,
                         &mode,
                         config_snapshot.app_config(),
                         config_snapshot.romaji_lookup(),
-                    ) {
+                    );
+                    self.borrow()?
+                        .borrow_mut_composition()?
+                        .deferred_inputs
+                        .pop_front();
+                    if let Some((transition, actions)) = planned {
                         self.handle_action_with_config_snapshot(
                             &actions,
                             transition,
@@ -4512,7 +4531,12 @@ impl TextServiceFactory {
                 shift_alphabet_shortcut: false,
             };
             if !composition.deferred_actions.is_empty() || !composition.deferred_inputs.is_empty() {
-                if !self.enqueue_deferred_user_action(&composition, deferred, &config_snapshot)? {
+                if !self.enqueue_deferred_user_action(
+                    &composition,
+                    deferred,
+                    &config_snapshot,
+                    false,
+                )? {
                     return Ok(false);
                 }
                 self.flush_deferred_user_actions()?;
@@ -4850,17 +4874,16 @@ impl TextServiceFactory {
         }
 
         // A pending asynchronous language-bar request must not overtake queued recovery input.
-        // Invalidate it, then enqueue this click behind the existing deferred actions so the
-        // normal handle_action path replays user input before applying SetIMEMode.
-        self.borrow_mut()?.invalidate_mode_switch_requests();
+        // Preserve the absolute target computed from that pending request, and only invalidate
+        // the request after the replacement has been queued successfully.
         let config_snapshot = IMEState::app_config_snapshot()?;
         let deferred = DeferredUserAction {
-            action: UserAction::ToggleInputMode,
+            action: language_bar_deferred_action(&mode),
             is_shift_pressed: false,
             is_shift_key: false,
             shift_alphabet_shortcut: false,
         };
-        if !self.enqueue_deferred_user_action(&composition, deferred, &config_snapshot)? {
+        if !self.enqueue_deferred_user_action(&composition, deferred, &config_snapshot, true)? {
             tracing::warn!("Failed to plan deferred language-bar input mode toggle");
             return Ok(());
         }

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -72,7 +72,16 @@ fn requires_action_recovery(error: &anyhow::Error) -> bool {
     requires_ipc_recovery(error) || is_non_destructive_edit_session_error(error)
 }
 
-fn has_same_com_identity(left: &ITfComposition, right: &ITfComposition) -> bool {
+fn mode_switch_request_is_current(
+    requested_generation: u64,
+    current_generation: u64,
+    context_matches: bool,
+    composition_matches: bool,
+) -> bool {
+    requested_generation == current_generation && context_matches && composition_matches
+}
+
+fn has_same_com_identity<I: windows::core::Interface>(left: &I, right: &I) -> bool {
     match (left.cast::<IUnknown>(), right.cast::<IUnknown>()) {
         (Ok(left), Ok(right)) => left.as_raw() == right.as_raw(),
         (Err(left_error), Err(right_error)) => {
@@ -4643,16 +4652,72 @@ impl TextServiceFactory {
         }
     }
 
+    fn is_current_mode_switch_request(
+        &self,
+        generation: u64,
+        context: &ITfContext,
+        tip_composition: &ITfComposition,
+    ) -> bool {
+        let Ok(text_service) = self.borrow() else {
+            return false;
+        };
+        let context_matches = text_service
+            .context
+            .as_ref()
+            .is_some_and(|current| has_same_com_identity(current, context));
+        let composition_matches = text_service
+            .borrow_composition()
+            .ok()
+            .and_then(|composition| composition.tip_composition.clone())
+            .is_some_and(|current| has_same_com_identity(&current, tip_composition));
+        mode_switch_request_is_current(
+            generation,
+            text_service.mode_switch_generation,
+            context_matches,
+            composition_matches,
+        )
+    }
+
     pub(crate) fn request_input_mode_switch_after_composition(
         &self,
         mode: InputMode,
     ) -> Result<()> {
         let position = self.candidate_window_position()?;
-        let this = self.borrow()?.this::<ITfTextInputProcessor>()?;
-        self.end_composition_async_on_success(Rc::new(move || {
+        let request = {
+            let mut text_service = self.borrow_mut()?;
+            let tip_composition = text_service.borrow_composition()?.tip_composition.clone();
+            tip_composition.map(|tip_composition| {
+                text_service.mode_switch_generation =
+                    text_service.mode_switch_generation.wrapping_add(1);
+                (
+                    text_service.this::<ITfTextInputProcessor>(),
+                    text_service.context::<ITfContext>(),
+                    tip_composition,
+                    text_service.mode_switch_generation,
+                )
+            })
+        };
+        let Some((this, context, tip_composition, generation)) = request else {
+            self.complete_input_mode_switch_best_effort(mode, position);
+            return Ok(());
+        };
+        let this = this?;
+        let context = context?;
+
+        let is_current = Rc::new({
+            let this = this.clone();
+            let context = context.clone();
+            let tip_composition = tip_composition.clone();
+            move || {
+                let factory = unsafe { this.as_impl() };
+                factory.is_current_mode_switch_request(generation, &context, &tip_composition)
+            }
+        });
+        let on_success = Rc::new(move || {
             let factory = unsafe { this.as_impl() };
             factory.complete_input_mode_switch_best_effort(mode.clone(), position);
-        }))
+        });
+        self.end_composition_async_on_success(is_current, on_success)
     }
 
     #[tracing::instrument]

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -82,10 +82,17 @@ fn language_bar_toggle_requires_deferred_replay(composition: &Composition) -> bo
     !composition.deferred_actions.is_empty() || !composition.deferred_inputs.is_empty()
 }
 
-fn language_bar_deferred_action(mode: &InputMode) -> UserAction {
-    match mode {
-        InputMode::Kana => UserAction::InputModeOn,
-        InputMode::Latin => UserAction::InputModeOff,
+fn language_bar_deferred_action(
+    mode: &InputMode,
+    replaces_pending_mode_switch: bool,
+) -> UserAction {
+    if replaces_pending_mode_switch {
+        match mode {
+            InputMode::Kana => UserAction::InputModeOn,
+            InputMode::Latin => UserAction::InputModeOff,
+        }
+    } else {
+        UserAction::ToggleInputMode
     }
 }
 
@@ -4864,10 +4871,11 @@ impl TextServiceFactory {
     }
 
     pub(crate) fn request_language_bar_input_mode_toggle(&self, mode: InputMode) -> Result<()> {
-        let composition = {
+        let (composition, replaces_pending_mode_switch) = {
             let text_service = self.borrow()?;
             let composition = text_service.borrow_composition()?.clone();
-            composition
+            let replaces_pending_mode_switch = text_service.pending_mode_switch().is_some();
+            (composition, replaces_pending_mode_switch)
         };
         if !language_bar_toggle_requires_deferred_replay(&composition) {
             return self.request_input_mode_switch_after_composition(mode);
@@ -4878,12 +4886,17 @@ impl TextServiceFactory {
         // the request after the replacement has been queued successfully.
         let config_snapshot = IMEState::app_config_snapshot()?;
         let deferred = DeferredUserAction {
-            action: language_bar_deferred_action(&mode),
+            action: language_bar_deferred_action(&mode, replaces_pending_mode_switch),
             is_shift_pressed: false,
             is_shift_key: false,
             shift_alphabet_shortcut: false,
         };
-        if !self.enqueue_deferred_user_action(&composition, deferred, &config_snapshot, true)? {
+        if !self.enqueue_deferred_user_action(
+            &composition,
+            deferred,
+            &config_snapshot,
+            replaces_pending_mode_switch,
+        )? {
             tracing::warn!("Failed to plan deferred language-bar input mode toggle");
             return Ok(());
         }

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -4626,8 +4626,7 @@ impl TextServiceFactory {
         self.end_composition_async_best_effort();
 
         if let Ok(mut text_service) = self.borrow_mut() {
-            text_service.mode_switch_generation =
-                text_service.mode_switch_generation.wrapping_add(1);
+            text_service.advance_mode_switch_generation();
             if let Ok(mut composition) = text_service.borrow_mut_composition() {
                 *composition = Composition::default();
             }
@@ -4742,9 +4741,7 @@ impl TextServiceFactory {
         let (this, context, tip_composition, generation) = {
             let mut text_service = self.borrow_mut()?;
             let tip_composition = text_service.borrow_composition()?.tip_composition.clone();
-            text_service.mode_switch_generation =
-                text_service.mode_switch_generation.wrapping_add(1);
-            let generation = text_service.mode_switch_generation;
+            let generation = text_service.advance_mode_switch_generation();
             (
                 text_service.this::<ITfTextInputProcessor>()?,
                 text_service.context::<ITfContext>()?,

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -74,6 +74,10 @@ fn requires_action_recovery(error: &anyhow::Error) -> bool {
     requires_ipc_recovery(error) || is_edit_session_error(error)
 }
 
+fn requires_server_resynchronization(error: &anyhow::Error) -> bool {
+    is_edit_session_error(error)
+}
+
 fn mode_switch_request_is_current(
     requested_generation: u64,
     current_generation: u64,
@@ -6516,7 +6520,17 @@ impl TextServiceFactory {
                 if let Some(snapshot) = failed_ledger_snapshot.take() {
                     ipc_service.restore_input_ledger(snapshot);
                 }
-                ipc_service.ensure_server_restart_requested();
+                if result
+                    .as_ref()
+                    .is_err_and(requires_server_resynchronization)
+                {
+                    // A TSF callback can fail after the server-side action has already mutated
+                    // its composition. Restart before replaying the deferred action so both
+                    // sides are rebuilt from the restored client ledger.
+                    ipc_service.require_server_recovery("edit_session_action");
+                } else {
+                    ipc_service.ensure_server_restart_requested();
+                }
                 let _ = IMEState::set_ipc_service(ipc_service);
             }
         }

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -68,6 +68,10 @@ fn deferred_action_suffix(
     actions.get(failed_index..).unwrap_or_default().to_vec()
 }
 
+fn requires_action_recovery(error: &anyhow::Error) -> bool {
+    requires_ipc_recovery(error) || is_non_destructive_edit_session_error(error)
+}
+
 fn has_same_com_identity(left: &ITfComposition, right: &ITfComposition) -> bool {
     match (left.cast::<IUnknown>(), right.cast::<IUnknown>()) {
         (Ok(left), Ok(right)) => left.as_raw() == right.as_raw(),
@@ -4573,6 +4577,27 @@ impl TextServiceFactory {
         }
     }
 
+    pub(crate) fn end_composition_for_tsf_event(&self) {
+        self.end_composition_async_best_effort();
+
+        if let Ok(text_service) = self.borrow() {
+            if let Ok(mut composition) = text_service.borrow_mut_composition() {
+                *composition = Composition::default();
+            }
+        }
+
+        if let Ok(Some(mut ipc_service)) = IMEState::ipc_service() {
+            ipc_service.discard_input_ledger();
+            if let Ok(delivery) =
+                ipc_service.update_candidate_window(Some(false), None, Some(vec![]), Some(0), None)
+            {
+                self.remember_candidate_window_visibility_if_sent(delivery, Some(false));
+            }
+            let _ = ipc_service.clear_text();
+            let _ = IMEState::set_ipc_service(ipc_service);
+        }
+    }
+
     #[tracing::instrument]
     pub fn handle_action(
         &self,
@@ -5736,9 +5761,8 @@ impl TextServiceFactory {
                         }
                     }
                     ClientAction::SetIMEMode(mode) => {
-                        self.start_composition()?;
                         let position = self.candidate_window_position()?;
-                        self.end_composition()?;
+                        self.end_composition_async_best_effort();
 
                         IMEState::set_input_mode(mode.clone())?;
 
@@ -6279,7 +6303,7 @@ impl TextServiceFactory {
             Ok(())
         })();
 
-        if result.as_ref().is_err_and(requires_ipc_recovery) {
+        if result.as_ref().is_err_and(requires_action_recovery) {
             if let Some(actions) = retry_actions.as_ref() {
                 let deferred = deferred_action_suffix(actions, failed_action_index);
                 if let Ok(text_service) = self.borrow() {

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,9 +1,9 @@
 use super::{
-    deferred_action_suffix, Candidates, CapsLockKeyboardLayout, ClauseActionBackend,
-    ClauseActionEffect, ClauseActionStateMut, ClauseAdvance, ClauseNavigationReadyUiSync,
-    ClauseSnapshot, ClauseState, Composition, CompositionReducer, CompositionState,
-    DeferredClientAction, DeferredProjection, DeferredUserAction, FutureClauseSnapshot,
-    TextServiceFactory,
+    deferred_action_suffix, requires_action_recovery, Candidates, CapsLockKeyboardLayout,
+    ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut, ClauseAdvance,
+    ClauseNavigationReadyUiSync, ClauseSnapshot, ClauseState, Composition, CompositionReducer,
+    CompositionState, DeferredClientAction, DeferredProjection, DeferredUserAction,
+    FutureClauseSnapshot, TextServiceFactory,
 };
 use crate::engine::{
     client_action::{
@@ -13,8 +13,9 @@ use crate::engine::{
     ipc_service::{ClauseSnapshotOperation, WindowRpcDelivery},
     user_action::{Function, Navigation, UserAction},
 };
+use crate::tsf::edit_session::EditSessionFailure;
 use shared::{get_default_romaji_rows, AppConfig, PunctuationStyle, RomajiRule, WidthMode};
-use windows::Win32::Foundation::LPARAM;
+use windows::Win32::{Foundation::LPARAM, UI::TextServices::TF_E_LOCKED};
 
 #[test]
 fn deadline_recovery_defers_all_actions_from_failure_point() {
@@ -45,6 +46,24 @@ fn deadline_recovery_defers_all_actions_from_failure_point() {
     assert_eq!(deferred, actions[1..]);
     assert_eq!(deferred[1].transition, CompositionState::Selecting);
     assert_eq!(deferred[3].transition, CompositionState::None);
+}
+
+#[test]
+fn edit_session_lock_failure_defers_mutated_action_for_server_resynchronization() {
+    let actions = vec![
+        DeferredClientAction {
+            action: ClientAction::AppendText("a".to_string()),
+            transition: CompositionState::Composing,
+        },
+        DeferredClientAction {
+            action: ClientAction::AppendText("i".to_string()),
+            transition: CompositionState::Composing,
+        },
+    ];
+    let error = anyhow::Error::new(EditSessionFailure::Session(TF_E_LOCKED));
+
+    assert!(requires_action_recovery(&error));
+    assert_eq!(deferred_action_suffix(&actions, 0), actions);
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -102,14 +102,14 @@ fn second_language_bar_click_preserves_absolute_target_during_deferred_replay() 
     // absolutely instead of toggling the still-actual Latin state to Kana again.
     let target = InputMode::Latin;
     assert_eq!(
-        language_bar_deferred_action(&target),
+        language_bar_deferred_action(&target, true),
         UserAction::InputModeOff
     );
 
     let app_config = AppConfig::default();
     let romaji_lookup = super::RomajiLookup::from_rows(&app_config.romaji_table.rows);
     let deferred = DeferredUserAction {
-        action: language_bar_deferred_action(&target),
+        action: language_bar_deferred_action(&target, true),
         is_shift_pressed: false,
         is_shift_key: false,
         shift_alphabet_shortcut: false,
@@ -124,6 +124,50 @@ fn second_language_bar_click_preserves_absolute_target_during_deferred_replay() 
     .expect("an absolute mode target must remain plannable");
 
     assert_eq!(actions, vec![ClientAction::SetIMEMode(InputMode::Latin)]);
+}
+
+#[test]
+fn queued_language_bar_clicks_without_pending_request_preserve_toggle_parity() {
+    assert_eq!(
+        language_bar_deferred_action(&InputMode::Kana, false),
+        UserAction::ToggleInputMode
+    );
+
+    let app_config = AppConfig::default();
+    let romaji_lookup = super::RomajiLookup::from_rows(&app_config.romaji_table.rows);
+    let deferred = DeferredUserAction {
+        action: language_bar_deferred_action(&InputMode::Kana, false),
+        is_shift_pressed: false,
+        is_shift_key: false,
+        shift_alphabet_shortcut: false,
+    };
+    let mut projection = DeferredProjection {
+        // The first queued click already projected actual Latin to Kana.
+        mode: InputMode::Kana,
+        state: CompositionState::None,
+        raw_input: String::new(),
+        temporary_latin: false,
+        temporary_latin_shift_pending: false,
+        reliable: true,
+    };
+    let (_, actions) = TextServiceFactory::plan_deferred_user_action(
+        &Composition::default(),
+        &deferred,
+        &projection.mode,
+        &app_config,
+        &romaji_lookup,
+    )
+    .expect("the second queued click must remain plannable");
+    let deferred_actions = actions
+        .into_iter()
+        .map(|action| DeferredClientAction {
+            action,
+            transition: CompositionState::None,
+        })
+        .collect::<Vec<_>>();
+    TextServiceFactory::apply_actions_to_deferred_projection(&mut projection, &deferred_actions);
+
+    assert_eq!(projection.mode, InputMode::Latin);
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,9 +1,10 @@
 use super::{
-    deferred_action_suffix, mode_switch_request_is_current, requires_action_recovery, Candidates,
-    CapsLockKeyboardLayout, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut,
-    ClauseAdvance, ClauseNavigationReadyUiSync, ClauseSnapshot, ClauseState, Composition,
-    CompositionReducer, CompositionState, DeferredClientAction, DeferredProjection,
-    DeferredUserAction, FutureClauseSnapshot, TextServiceFactory,
+    deferred_action_suffix, idle_mode_switch_request_is_current, mode_switch_request_is_current,
+    requires_action_recovery, Candidates, CapsLockKeyboardLayout, ClauseActionBackend,
+    ClauseActionEffect, ClauseActionStateMut, ClauseAdvance, ClauseNavigationReadyUiSync,
+    ClauseSnapshot, ClauseState, Composition, CompositionReducer, CompositionState,
+    DeferredClientAction, DeferredProjection, DeferredUserAction, FutureClauseSnapshot,
+    TextServiceFactory,
 };
 use crate::engine::{
     client_action::{
@@ -72,6 +73,14 @@ fn deferred_mode_switch_rejects_focus_composition_and_generation_changes() {
     assert!(!mode_switch_request_is_current(7, 7, false, true));
     assert!(!mode_switch_request_is_current(7, 7, true, false));
     assert!(!mode_switch_request_is_current(7, 8, true, true));
+}
+
+#[test]
+fn idle_mode_switch_rejects_focus_new_composition_and_generation_changes() {
+    assert!(idle_mode_switch_request_is_current(7, 7, true, true));
+    assert!(!idle_mode_switch_request_is_current(7, 7, false, true));
+    assert!(!idle_mode_switch_request_is_current(7, 7, true, false));
+    assert!(!idle_mode_switch_request_is_current(7, 8, true, true));
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,10 +1,11 @@
 use super::{
-    deferred_action_suffix, idle_mode_switch_request_is_current, mode_switch_request_is_current,
+    deferred_action_suffix, idle_mode_switch_request_is_current,
+    language_bar_toggle_requires_deferred_replay, mode_switch_request_is_current,
     requires_action_recovery, requires_server_resynchronization, Candidates,
     CapsLockKeyboardLayout, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut,
     ClauseAdvance, ClauseNavigationReadyUiSync, ClauseSnapshot, ClauseState, Composition,
-    CompositionReducer, CompositionState, DeferredClientAction, DeferredProjection,
-    DeferredUserAction, FutureClauseSnapshot, TextServiceFactory,
+    CompositionReducer, CompositionState, DeferredClientAction, DeferredInputEvent,
+    DeferredProjection, DeferredUserAction, FutureClauseSnapshot, TextServiceFactory,
 };
 use crate::engine::{
     client_action::{
@@ -73,6 +74,25 @@ fn edit_session_callback_failure_requires_server_resynchronization_before_replay
 
     assert!(requires_action_recovery(&error));
     assert!(requires_server_resynchronization(&error));
+}
+
+#[test]
+fn language_bar_toggle_joins_deferred_action_and_input_replay() {
+    let deferred_action = DeferredClientAction {
+        action: ClientAction::AppendText("a".to_string()),
+        transition: CompositionState::Composing,
+    };
+    let mut composition = Composition::default();
+    assert!(!language_bar_toggle_requires_deferred_replay(&composition));
+
+    composition.deferred_actions.push(deferred_action.clone());
+    assert!(language_bar_toggle_requires_deferred_replay(&composition));
+
+    composition.deferred_actions.clear();
+    composition
+        .deferred_inputs
+        .push_back(DeferredInputEvent::Actions(vec![deferred_action]));
+    assert!(language_bar_toggle_requires_deferred_replay(&composition));
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,10 +1,10 @@
 use super::{
     deferred_action_suffix, idle_mode_switch_request_is_current, mode_switch_request_is_current,
-    requires_action_recovery, Candidates, CapsLockKeyboardLayout, ClauseActionBackend,
-    ClauseActionEffect, ClauseActionStateMut, ClauseAdvance, ClauseNavigationReadyUiSync,
-    ClauseSnapshot, ClauseState, Composition, CompositionReducer, CompositionState,
-    DeferredClientAction, DeferredProjection, DeferredUserAction, FutureClauseSnapshot,
-    TextServiceFactory,
+    requires_action_recovery, requires_server_resynchronization, Candidates,
+    CapsLockKeyboardLayout, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut,
+    ClauseAdvance, ClauseNavigationReadyUiSync, ClauseSnapshot, ClauseState, Composition,
+    CompositionReducer, CompositionState, DeferredClientAction, DeferredProjection,
+    DeferredUserAction, FutureClauseSnapshot, TextServiceFactory,
 };
 use crate::engine::{
     client_action::{
@@ -65,6 +65,14 @@ fn edit_session_lock_failure_defers_mutated_action_for_server_resynchronization(
 
     assert!(requires_action_recovery(&error));
     assert_eq!(deferred_action_suffix(&actions, 0), actions);
+}
+
+#[test]
+fn edit_session_callback_failure_requires_server_resynchronization_before_replay() {
+    let error = anyhow::Error::new(EditSessionFailure::Callback(TF_E_LOCKED));
+
+    assert!(requires_action_recovery(&error));
+    assert!(requires_server_resynchronization(&error));
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    deferred_action_suffix, idle_mode_switch_request_is_current,
+    deferred_action_suffix, idle_mode_switch_request_is_current, language_bar_deferred_action,
     language_bar_toggle_requires_deferred_replay, mode_switch_request_is_current,
     requires_action_recovery, requires_server_resynchronization, Candidates,
     CapsLockKeyboardLayout, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut,
@@ -93,6 +93,37 @@ fn language_bar_toggle_joins_deferred_action_and_input_replay() {
         .deferred_inputs
         .push_back(DeferredInputEvent::Actions(vec![deferred_action]));
     assert!(language_bar_toggle_requires_deferred_replay(&composition));
+}
+
+#[test]
+fn second_language_bar_click_preserves_absolute_target_during_deferred_replay() {
+    // Actual mode is Latin, while the first click has a pending Kana request. The language-bar
+    // computes Latin for the second click. Replaying that click must therefore set Latin
+    // absolutely instead of toggling the still-actual Latin state to Kana again.
+    let target = InputMode::Latin;
+    assert_eq!(
+        language_bar_deferred_action(&target),
+        UserAction::InputModeOff
+    );
+
+    let app_config = AppConfig::default();
+    let romaji_lookup = super::RomajiLookup::from_rows(&app_config.romaji_table.rows);
+    let deferred = DeferredUserAction {
+        action: language_bar_deferred_action(&target),
+        is_shift_pressed: false,
+        is_shift_key: false,
+        shift_alphabet_shortcut: false,
+    };
+    let (_, actions) = TextServiceFactory::plan_deferred_user_action(
+        &Composition::default(),
+        &deferred,
+        &InputMode::Latin,
+        &app_config,
+        &romaji_lookup,
+    )
+    .expect("an absolute mode target must remain plannable");
+
+    assert_eq!(actions, vec![ClientAction::SetIMEMode(InputMode::Latin)]);
 }
 
 #[test]

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1,9 +1,9 @@
 use super::{
-    deferred_action_suffix, requires_action_recovery, Candidates, CapsLockKeyboardLayout,
-    ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut, ClauseAdvance,
-    ClauseNavigationReadyUiSync, ClauseSnapshot, ClauseState, Composition, CompositionReducer,
-    CompositionState, DeferredClientAction, DeferredProjection, DeferredUserAction,
-    FutureClauseSnapshot, TextServiceFactory,
+    deferred_action_suffix, mode_switch_request_is_current, requires_action_recovery, Candidates,
+    CapsLockKeyboardLayout, ClauseActionBackend, ClauseActionEffect, ClauseActionStateMut,
+    ClauseAdvance, ClauseNavigationReadyUiSync, ClauseSnapshot, ClauseState, Composition,
+    CompositionReducer, CompositionState, DeferredClientAction, DeferredProjection,
+    DeferredUserAction, FutureClauseSnapshot, TextServiceFactory,
 };
 use crate::engine::{
     client_action::{
@@ -64,6 +64,14 @@ fn edit_session_lock_failure_defers_mutated_action_for_server_resynchronization(
 
     assert!(requires_action_recovery(&error));
     assert_eq!(deferred_action_suffix(&actions, 0), actions);
+}
+
+#[test]
+fn deferred_mode_switch_rejects_focus_composition_and_generation_changes() {
+    assert!(mode_switch_request_is_current(7, 7, true, true));
+    assert!(!mode_switch_request_is_current(7, 7, false, true));
+    assert!(!mode_switch_request_is_current(7, 7, true, false));
+    assert!(!mode_switch_request_is_current(7, 8, true, true));
 }
 
 #[test]

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -647,6 +647,10 @@ impl IPCService {
         }
     }
 
+    pub(crate) fn require_server_recovery(&self, operation: &'static str) {
+        Self::mark_server_recovery_required(&self.recovery, operation);
+    }
+
     pub(crate) fn recovery_restart_ready(&self) -> bool {
         let generation = self.recovery.generation.load(Ordering::Acquire);
         restart_generation_ready(

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -349,13 +349,14 @@ fn complete_async_position_request(
     request_accepted: bool,
     position: Option<WindowPosition>,
     on_complete: &dyn Fn(Option<WindowPosition>),
-    on_cancel: &dyn Fn(),
+    on_terminal: &dyn Fn(),
 ) -> bool {
     if callback_succeeded {
         on_complete(position);
+        on_terminal();
         false
     } else if request_accepted {
-        on_cancel();
+        on_terminal();
         false
     } else {
         // RequestEditSession may release the COM object before returning its rejection.
@@ -692,7 +693,7 @@ impl TextServiceFactory {
     pub(crate) fn request_caret_window_position_async(
         &self,
         on_complete: Rc<dyn Fn(Option<WindowPosition>)>,
-        on_cancel: Rc<dyn Fn()>,
+        on_terminal: Rc<dyn Fn()>,
     ) -> Result<()> {
         let (tid, context) = {
             let text_service = self.borrow()?;
@@ -719,14 +720,14 @@ impl TextServiceFactory {
         let completion = Rc::new({
             let request_accepted = request_accepted.clone();
             let cancel_before_request_result = cancel_before_request_result.clone();
-            let on_cancel = on_cancel.clone();
+            let on_terminal = on_terminal.clone();
             move || {
                 cancel_before_request_result.set(complete_async_position_request(
                     callback_succeeded.get(),
                     request_accepted.get(),
                     position.get(),
                     on_complete.as_ref(),
-                    on_cancel.as_ref(),
+                    on_terminal.as_ref(),
                 ));
             }
         });
@@ -734,7 +735,7 @@ impl TextServiceFactory {
         if result.is_ok() {
             request_accepted.set(true);
             if cancel_before_request_result.replace(false) {
-                on_cancel();
+                on_terminal();
             }
         }
         result
@@ -1212,40 +1213,40 @@ mod tests {
     }
 
     #[test]
-    fn async_position_completion_routes_success_and_cancellation_separately() {
+    fn async_position_completion_runs_terminal_cleanup_after_success_or_cancellation() {
         let completion_count = Cell::new(0);
-        let cancellation_count = Cell::new(0);
+        let terminal_count = Cell::new(0);
         let on_complete = |_| completion_count.set(completion_count.get() + 1);
-        let on_cancel = || cancellation_count.set(cancellation_count.get() + 1);
+        let on_terminal = || terminal_count.set(terminal_count.get() + 1);
 
         assert!(complete_async_position_request(
             false,
             false,
             None,
             &on_complete,
-            &on_cancel,
+            &on_terminal,
         ));
         assert_eq!(completion_count.get(), 0);
-        assert_eq!(cancellation_count.get(), 0);
+        assert_eq!(terminal_count.get(), 0);
 
         assert!(!complete_async_position_request(
             false,
             true,
             None,
             &on_complete,
-            &on_cancel,
+            &on_terminal,
         ));
-        assert_eq!(cancellation_count.get(), 1);
+        assert_eq!(terminal_count.get(), 1);
 
         assert!(!complete_async_position_request(
             true,
             true,
             None,
             &on_complete,
-            &on_cancel,
+            &on_terminal,
         ));
         assert_eq!(completion_count.get(), 1);
-        assert_eq!(cancellation_count.get(), 1);
+        assert_eq!(terminal_count.get(), 2);
     }
 
     #[test]

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -1,18 +1,19 @@
 use macros::anyhow;
 use windows::{
-    core::{implement, AsImpl, VARIANT},
+    core::{implement, AsImpl, HRESULT, VARIANT},
     Win32::{
         Foundation::RECT,
         UI::TextServices::{
             ITfComposition, ITfCompositionSink, ITfContext, ITfContextComposition, ITfEditSession,
-            ITfEditSession_Impl, ITfInsertAtSelection, ITfRange, GUID_PROP_ATTRIBUTE, TF_AE_NONE,
-            TF_ANCHOR_END, TF_ANCHOR_START, TF_ES_READWRITE, TF_IAS_QUERYONLY, TF_SELECTION,
-            TF_SELECTIONSTYLE, TF_ST_CORRECTION, TF_TF_MOVESTART,
+            ITfEditSession_Impl, ITfInsertAtSelection, ITfRange, ITfTextInputProcessor,
+            GUID_PROP_ATTRIBUTE, TF_AE_NONE, TF_ANCHOR_END, TF_ANCHOR_START, TF_ES_ASYNC,
+            TF_ES_READ, TF_ES_READWRITE, TF_ES_SYNC, TF_IAS_QUERYONLY, TF_SELECTION,
+            TF_SELECTIONSTYLE, TF_ST_CORRECTION, TF_S_ASYNC, TF_TF_MOVESTART,
         },
     },
 };
 
-use std::{cell::Cell, mem::ManuallyDrop, rc::Rc, time::Instant};
+use std::{cell::Cell, fmt, mem::ManuallyDrop, rc::Rc, time::Instant};
 
 use anyhow::Result;
 
@@ -38,12 +39,75 @@ struct EditSession<'a, T> {
     phantom: std::marker::PhantomData<&'a T>,
 }
 
-// edit action will be performed within this function
-pub fn edit_session<T>(
+#[implement(ITfEditSession)]
+struct AsyncEditSession {
+    callback: Rc<dyn Fn(u32) -> anyhow::Result<()>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EditSessionFailure {
+    Request(HRESULT),
+    Session(HRESULT),
+    UnexpectedAsync,
+    CallbackNotCompleted,
+}
+
+impl fmt::Display for EditSessionFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Request(hresult) => {
+                write!(formatter, "RequestEditSession failed: {hresult:?}")
+            }
+            Self::Session(hresult) => {
+                write!(formatter, "edit session was rejected: {hresult:?}")
+            }
+            Self::UnexpectedAsync => {
+                write!(formatter, "synchronous edit session was deferred")
+            }
+            Self::CallbackNotCompleted => {
+                write!(formatter, "edit session completed without callback result")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EditSessionFailure {}
+
+pub(crate) fn is_non_destructive_edit_session_error(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<EditSessionFailure>().is_some()
+}
+
+fn complete_sync_edit_session<T>(
+    request_result: std::result::Result<HRESULT, HRESULT>,
+    callback_result: Option<T>,
+) -> Result<T> {
+    let session_result = request_result
+        .map_err(|hresult| anyhow::Error::new(EditSessionFailure::Request(hresult)))?;
+    if session_result == TF_S_ASYNC {
+        return Err(anyhow::Error::new(EditSessionFailure::UnexpectedAsync));
+    }
+    session_result
+        .ok()
+        .map_err(|_| anyhow::Error::new(EditSessionFailure::Session(session_result)))?;
+    callback_result.ok_or_else(|| anyhow::Error::new(EditSessionFailure::CallbackNotCompleted))
+}
+
+fn complete_async_edit_session_request(
+    request_result: std::result::Result<HRESULT, HRESULT>,
+) -> Result<()> {
+    let session_result = request_result
+        .map_err(|hresult| anyhow::Error::new(EditSessionFailure::Request(hresult)))?;
+    session_result
+        .ok()
+        .map_err(|_| anyhow::Error::new(EditSessionFailure::Session(session_result)))
+}
+
+fn sync_edit_session<T>(
     client_id: u32,
     context: ITfContext,
+    access: windows::Win32::UI::TextServices::TF_CONTEXT_EDIT_CONTEXT_FLAGS,
     callback: Rc<dyn Fn(u32) -> anyhow::Result<T>>,
-) -> Result<Option<T>> {
+) -> Result<T> {
     let session: ITfEditSession = EditSession {
         callback,
         result: Cell::new(None),
@@ -51,15 +115,40 @@ pub fn edit_session<T>(
     }
     .into();
 
-    let result = unsafe { context.RequestEditSession(client_id, &session, TF_ES_READWRITE) };
+    let request_result =
+        unsafe { context.RequestEditSession(client_id, &session, access | TF_ES_SYNC) }
+            .map_err(|error| error.code());
+    let session: &EditSession<'_, T> =
+        unsafe { <ITfEditSession as AsImpl<EditSession<'_, T>>>::as_impl(&session) };
+    complete_sync_edit_session(request_result, session.result.take())
+}
 
-    match result {
-        Ok(_) => {
-            let session = unsafe { session.as_impl() };
-            Ok(session.result.take())
-        }
-        Err(e) => Err(anyhow::Error::new(e)),
-    }
+pub fn read_edit_session<T>(
+    client_id: u32,
+    context: ITfContext,
+    callback: Rc<dyn Fn(u32) -> anyhow::Result<T>>,
+) -> Result<T> {
+    sync_edit_session(client_id, context, TF_ES_READ, callback)
+}
+
+pub fn write_edit_session<T>(
+    client_id: u32,
+    context: ITfContext,
+    callback: Rc<dyn Fn(u32) -> anyhow::Result<T>>,
+) -> Result<T> {
+    sync_edit_session(client_id, context, TF_ES_READWRITE, callback)
+}
+
+fn request_async_read_edit_session(
+    client_id: u32,
+    context: ITfContext,
+    callback: Rc<dyn Fn(u32) -> anyhow::Result<()>>,
+) -> Result<()> {
+    let session: ITfEditSession = AsyncEditSession { callback }.into();
+    let request_result =
+        unsafe { context.RequestEditSession(client_id, &session, TF_ES_READ | TF_ES_ASYNC) }
+            .map_err(|error| error.code());
+    complete_async_edit_session_request(request_result)
 }
 
 impl<'a, T> ITfEditSession_Impl for EditSession_Impl<'a, T> {
@@ -68,6 +157,13 @@ impl<'a, T> ITfEditSession_Impl for EditSession_Impl<'a, T> {
         let result = (self.callback)(cookie)?;
         self.result.set(Some(result));
         Ok(())
+    }
+}
+
+impl ITfEditSession_Impl for AsyncEditSession_Impl {
+    #[anyhow]
+    fn DoEditSession(&self, cookie: u32) -> Result<()> {
+        (self.callback)(cookie)
     }
 }
 
@@ -93,7 +189,7 @@ impl TextServiceFactory {
         let text_service = self.borrow()?;
 
         if let Some(composition) = text_service.borrow_composition()?.tip_composition.clone() {
-            edit_session(
+            write_edit_session(
                 text_service.tid,
                 text_service.context()?,
                 Rc::new({
@@ -162,7 +258,7 @@ impl TextServiceFactory {
             return Ok(());
         }
 
-        let composition = edit_session::<ITfComposition>(
+        let composition = write_edit_session::<ITfComposition>(
             text_service.tid,
             context,
             Rc::new({
@@ -177,7 +273,7 @@ impl TextServiceFactory {
         )?;
 
         tracing::debug!("Composition started {composition:?}");
-        text_service.borrow_mut_composition()?.tip_composition = composition;
+        text_service.borrow_mut_composition()?.tip_composition = Some(composition);
 
         Ok(())
     }
@@ -205,7 +301,7 @@ impl TextServiceFactory {
         let text_service = self.borrow()?;
 
         if let Some(composition) = text_service.borrow_composition()?.tip_composition.clone() {
-            edit_session(
+            write_edit_session(
                 text_service.tid,
                 text_service.context()?,
                 Rc::new({
@@ -259,7 +355,7 @@ impl TextServiceFactory {
         let text_service = self.borrow()?;
 
         if let Some(composition) = text_service.borrow_composition()?.tip_composition.clone() {
-            edit_session(
+            write_edit_session(
                 text_service.tid,
                 text_service.context()?,
                 Rc::new({
@@ -388,7 +484,7 @@ impl TextServiceFactory {
             };
 
             if let Some(tip_composition) = tip_composition {
-                let position = edit_session(
+                let position = read_edit_session(
                     tid,
                     context.clone(),
                     Rc::new({
@@ -411,7 +507,7 @@ impl TextServiceFactory {
                         }
                     }),
                 )?;
-                Ok(position)
+                Ok(Some(position))
             } else {
                 Ok(None)
             }
@@ -457,6 +553,93 @@ impl TextServiceFactory {
         self.candidate_window_position_with_mode(CandidateWindowPositionMode::Throttled)
     }
 
+    fn finish_update_pos(&self) {
+        match self.borrow_mut() {
+            Ok(mut text_service) => {
+                text_service.update_pos_state.finish_update(Instant::now());
+            }
+            Err(error) => {
+                tracing::warn!("Failed to reset update_pos guard: {error:?}");
+            }
+        }
+    }
+
+    pub(crate) fn request_update_pos_async(&self) -> Result<()> {
+        let (tid, context, tip_composition, this) = {
+            let mut text_service = self.borrow_mut()?;
+            let tip_composition = text_service.borrow_composition()?.tip_composition.clone();
+            let Some(tip_composition) = tip_composition else {
+                return Ok(());
+            };
+            let tid = text_service.tid;
+            let context = text_service.context::<ITfContext>()?;
+            let this = text_service.this::<ITfTextInputProcessor>()?;
+
+            let now = Instant::now();
+            if text_service
+                .candidate_window_position_state
+                .should_throttle(now)
+            {
+                tracing::debug!("Skip throttled asynchronous candidate position update");
+                return Ok(());
+            }
+            if !text_service.update_pos_state.try_begin_update(now) {
+                tracing::debug!("Skip re-entrant asynchronous candidate position update");
+                return Ok(());
+            }
+            text_service
+                .candidate_window_position_state
+                .mark_attempt(now);
+
+            (tid, context, tip_composition, this)
+        };
+
+        let callback = Rc::new({
+            let context = context.clone();
+
+            move |cookie| {
+                let result: Result<()> = (|| unsafe {
+                    let view = context.GetActiveView()?;
+                    let range = tip_composition.GetRange()?;
+
+                    let mut rect = RECT::default();
+                    let mut clipped = false.into();
+                    view.GetTextExt(cookie, &range, &mut rect, &mut clipped)?;
+
+                    if let Some(mut ipc_service) = IMEState::ipc_service()? {
+                        let position = WindowPosition {
+                            top: rect.top,
+                            left: rect.left,
+                            bottom: rect.bottom,
+                            right: rect.right,
+                        };
+                        ipc_service.update_candidate_window(
+                            None,
+                            Some(position),
+                            None,
+                            None,
+                            None,
+                        )?;
+                        IMEState::set_ipc_service(ipc_service)?;
+                    }
+                    Ok(())
+                })();
+
+                let factory = unsafe { this.as_impl() };
+                factory.finish_update_pos();
+                result
+            }
+        });
+
+        match request_async_read_edit_session(tid, context, callback) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.finish_update_pos();
+                Err(error)
+            }
+        }
+    }
+
     #[tracing::instrument]
     pub fn update_pos(&self) -> Result<()> {
         if let Some(position) = self.candidate_window_position_for_update()? {
@@ -466,5 +649,118 @@ impl TextServiceFactory {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        complete_async_edit_session_request, complete_sync_edit_session,
+        is_non_destructive_edit_session_error, AsyncEditSession, EditSessionFailure,
+    };
+    use std::{cell::Cell, rc::Rc};
+    use windows::{
+        core::HRESULT,
+        Win32::UI::TextServices::{TF_E_DISCONNECTED, TF_E_LOCKED, TF_S_ASYNC},
+    };
+
+    #[test]
+    fn sync_edit_session_returns_callback_value_after_both_results_succeed() {
+        let value = complete_sync_edit_session(Ok(HRESULT(0)), Some("completed".to_string()))
+            .expect("completed callback result");
+
+        assert_eq!(value, "completed");
+    }
+
+    #[test]
+    fn sync_edit_session_keeps_lock_rejection_distinct_from_request_failure() {
+        let error = complete_sync_edit_session::<()>(Ok(TF_E_LOCKED), None)
+            .expect_err("lock rejection must fail the session");
+
+        assert_eq!(
+            error.downcast_ref::<EditSessionFailure>(),
+            Some(&EditSessionFailure::Session(TF_E_LOCKED))
+        );
+        assert!(is_non_destructive_edit_session_error(&error));
+    }
+
+    #[test]
+    fn sync_edit_session_rejects_unexpected_async_completion() {
+        let error = complete_sync_edit_session::<()>(Ok(TF_S_ASYNC), None)
+            .expect_err("synchronous contract must not read a deferred result");
+
+        assert_eq!(
+            error.downcast_ref::<EditSessionFailure>(),
+            Some(&EditSessionFailure::UnexpectedAsync)
+        );
+    }
+
+    #[test]
+    fn sync_edit_session_reports_context_destruction_as_request_failure() {
+        let error = complete_sync_edit_session::<()>(Err(TF_E_DISCONNECTED), None)
+            .expect_err("destroyed context must fail the outer request");
+
+        assert_eq!(
+            error.downcast_ref::<EditSessionFailure>(),
+            Some(&EditSessionFailure::Request(TF_E_DISCONNECTED))
+        );
+        assert!(is_non_destructive_edit_session_error(&error));
+    }
+
+    #[test]
+    fn sync_edit_session_requires_callback_completion() {
+        let error = complete_sync_edit_session::<()>(Ok(HRESULT(0)), None)
+            .expect_err("successful session without callback completion is invalid");
+
+        assert_eq!(
+            error.downcast_ref::<EditSessionFailure>(),
+            Some(&EditSessionFailure::CallbackNotCompleted)
+        );
+    }
+
+    #[test]
+    fn async_edit_session_runs_work_only_when_tsf_invokes_the_callback() {
+        let callback_invoked = Rc::new(Cell::new(false));
+        let session: windows::Win32::UI::TextServices::ITfEditSession = AsyncEditSession {
+            callback: Rc::new({
+                let callback_invoked = callback_invoked.clone();
+                move |_| {
+                    callback_invoked.set(true);
+                    Ok(())
+                }
+            }),
+        }
+        .into();
+
+        assert!(!callback_invoked.get());
+        unsafe {
+            session
+                .DoEditSession(0)
+                .expect("async callback should complete");
+        }
+        assert!(callback_invoked.get());
+    }
+
+    #[test]
+    fn async_edit_session_accepts_deferred_completion_without_reading_a_result() {
+        complete_async_edit_session_request(Ok(TF_S_ASYNC))
+            .expect("deferred async session is an accepted request");
+    }
+
+    #[test]
+    fn async_edit_session_reports_request_and_lock_failures_separately() {
+        let request_error = complete_async_edit_session_request(Err(TF_E_DISCONNECTED))
+            .expect_err("destroyed context must reject the outer request");
+        assert_eq!(
+            request_error.downcast_ref::<EditSessionFailure>(),
+            Some(&EditSessionFailure::Request(TF_E_DISCONNECTED))
+        );
+
+        let session_error = complete_async_edit_session_request(Ok(TF_E_LOCKED))
+            .expect_err("lock rejection must reject the async session");
+        assert_eq!(
+            session_error.downcast_ref::<EditSessionFailure>(),
+            Some(&EditSessionFailure::Session(TF_E_LOCKED))
+        );
     }
 }

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -359,6 +359,16 @@ fn complete_async_position_request(
     }
 }
 
+fn caret_position_or_none(result: Result<Option<WindowPosition>>) -> Option<WindowPosition> {
+    match result {
+        Ok(position) => position,
+        Err(error) => {
+            tracing::warn!("Failed to obtain caret window position: {error:?}");
+            None
+        }
+    }
+}
+
 impl TextServiceFactory {
     fn log_candidate_window_position_performance(
         request_id: u64,
@@ -679,7 +689,11 @@ impl TextServiceFactory {
             let position = position.clone();
             let callback_succeeded = callback_succeeded.clone();
             move |cookie| {
-                position.set(caret_window_position_for_cookie(&context, cookie)?);
+                // Position is optional UI metadata. A host that cannot expose its caret must not
+                // cause the requested input-mode change itself to be dropped.
+                position.set(caret_position_or_none(caret_window_position_for_cookie(
+                    &context, cookie,
+                )));
                 callback_succeeded.set(true);
                 Ok(())
             }
@@ -980,9 +994,10 @@ impl TextServiceFactory {
 #[cfg(test)]
 mod tests {
     use super::{
-        commit_shift_start_after_prepare, complete_async_edit_session_request,
-        complete_async_position_request, complete_sync_edit_session,
-        is_non_destructive_edit_session_error, AsyncEditSession, EditSessionFailure,
+        caret_position_or_none, commit_shift_start_after_prepare,
+        complete_async_edit_session_request, complete_async_position_request,
+        complete_sync_edit_session, is_non_destructive_edit_session_error, AsyncEditSession,
+        EditSessionFailure,
     };
     use std::{cell::Cell, rc::Rc};
     use windows::{
@@ -1151,6 +1166,13 @@ mod tests {
 
         complete_async_position_request(true, None, &on_complete);
         assert_eq!(completion_count.get(), 1);
+    }
+
+    #[test]
+    fn async_caret_read_failure_falls_back_to_an_unpositioned_mode_switch() {
+        let position = caret_position_or_none(Err(anyhow::anyhow!("text extent unavailable")));
+
+        assert!(position.is_none());
     }
 
     #[test]

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -36,6 +36,7 @@ enum CandidateWindowPositionMode {
 struct EditSession<'a, T> {
     callback: Rc<dyn Fn(u32) -> anyhow::Result<T>>,
     pub result: Cell<Option<T>>,
+    callback_started: Cell<bool>,
     phantom: std::marker::PhantomData<&'a T>,
 }
 
@@ -64,6 +65,7 @@ impl Drop for AsyncEditSession {
 pub(crate) enum EditSessionFailure {
     Request(HRESULT),
     Session(HRESULT),
+    Callback(HRESULT),
     UnexpectedAsync,
     CallbackNotCompleted,
 }
@@ -76,6 +78,9 @@ impl fmt::Display for EditSessionFailure {
             }
             Self::Session(hresult) => {
                 write!(formatter, "edit session was rejected: {hresult:?}")
+            }
+            Self::Callback(hresult) => {
+                write!(formatter, "edit session callback failed: {hresult:?}")
             }
             Self::UnexpectedAsync => {
                 write!(formatter, "synchronous edit session was deferred")
@@ -90,11 +95,24 @@ impl fmt::Display for EditSessionFailure {
 impl std::error::Error for EditSessionFailure {}
 
 pub(crate) fn is_non_destructive_edit_session_error(error: &anyhow::Error) -> bool {
+    matches!(
+        error.downcast_ref::<EditSessionFailure>(),
+        Some(
+            EditSessionFailure::Request(_)
+                | EditSessionFailure::Session(_)
+                | EditSessionFailure::UnexpectedAsync
+                | EditSessionFailure::CallbackNotCompleted
+        )
+    )
+}
+
+pub(crate) fn is_edit_session_error(error: &anyhow::Error) -> bool {
     error.downcast_ref::<EditSessionFailure>().is_some()
 }
 
 fn complete_sync_edit_session<T>(
     request_result: std::result::Result<HRESULT, HRESULT>,
+    callback_started: bool,
     callback_result: Option<T>,
 ) -> Result<T> {
     let session_result = request_result
@@ -102,9 +120,14 @@ fn complete_sync_edit_session<T>(
     if session_result == TF_S_ASYNC {
         return Err(anyhow::Error::new(EditSessionFailure::UnexpectedAsync));
     }
-    session_result
-        .ok()
-        .map_err(|_| anyhow::Error::new(EditSessionFailure::Session(session_result)))?;
+    session_result.ok().map_err(|_| {
+        let failure = if callback_started {
+            EditSessionFailure::Callback(session_result)
+        } else {
+            EditSessionFailure::Session(session_result)
+        };
+        anyhow::Error::new(failure)
+    })?;
     callback_result.ok_or_else(|| anyhow::Error::new(EditSessionFailure::CallbackNotCompleted))
 }
 
@@ -127,6 +150,7 @@ fn sync_edit_session<T>(
     let session: ITfEditSession = EditSession {
         callback,
         result: Cell::new(None),
+        callback_started: Cell::new(false),
         phantom: std::marker::PhantomData,
     }
     .into();
@@ -136,7 +160,11 @@ fn sync_edit_session<T>(
             .map_err(|error| error.code());
     let session: &EditSession<'_, T> =
         unsafe { <ITfEditSession as AsImpl<EditSession<'_, T>>>::as_impl(&session) };
-    complete_sync_edit_session(request_result, session.result.take())
+    complete_sync_edit_session(
+        request_result,
+        session.callback_started.get(),
+        session.result.take(),
+    )
 }
 
 pub fn read_edit_session<T>(
@@ -200,6 +228,7 @@ fn request_async_write_edit_session(
 impl<'a, T> ITfEditSession_Impl for EditSession_Impl<'a, T> {
     #[anyhow]
     fn DoEditSession(&self, cookie: u32) -> Result<()> {
+        self.callback_started.set(true);
         let result = (self.callback)(cookie)?;
         self.result.set(Some(result));
         Ok(())
@@ -268,6 +297,50 @@ fn has_same_com_identity<I: Interface>(left: &I, right: &I) -> bool {
     }
 }
 
+fn window_position_for_range(
+    context: &ITfContext,
+    cookie: u32,
+    range: &ITfRange,
+) -> Result<WindowPosition> {
+    unsafe {
+        let view = context.GetActiveView()?;
+        let mut rect = RECT::default();
+        let mut clipped = false.into();
+        view.GetTextExt(cookie, range, &mut rect, &mut clipped)?;
+        Ok(WindowPosition {
+            top: rect.top,
+            left: rect.left,
+            bottom: rect.bottom,
+            right: rect.right,
+        })
+    }
+}
+
+fn caret_window_position_for_cookie(
+    context: &ITfContext,
+    cookie: u32,
+) -> Result<Option<WindowPosition>> {
+    unsafe {
+        let mut selection = [TF_SELECTION::default()];
+        let mut fetched = 0;
+        context.GetSelection(
+            cookie,
+            windows::Win32::UI::TextServices::TF_DEFAULT_SELECTION,
+            &mut selection,
+            &mut fetched,
+        )?;
+        if fetched == 0 {
+            return Ok(None);
+        }
+        let Some(range) = selection[0].range.as_ref() else {
+            return Ok(None);
+        };
+        let range = range.Clone()?;
+        range.Collapse(cookie, TF_ANCHOR_END)?;
+        window_position_for_range(context, cookie, &range).map(Some)
+    }
+}
+
 impl TextServiceFactory {
     fn log_candidate_window_position_performance(
         request_id: u64,
@@ -326,12 +399,6 @@ impl TextServiceFactory {
 
         if let Err(error) = request_result {
             tracing::warn!(?error, "Failed to request best-effort composition end");
-        }
-
-        if let Ok(text_service) = self.borrow() {
-            if let Ok(mut composition) = text_service.borrow_mut_composition() {
-                composition.tip_composition = None;
-            }
         }
     }
 
@@ -536,6 +603,45 @@ impl TextServiceFactory {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn caret_window_position(&self) -> Result<Option<WindowPosition>> {
+        let (tid, context) = {
+            let text_service = self.borrow()?;
+            (text_service.tid, text_service.context::<ITfContext>()?)
+        };
+        match read_edit_session(
+            tid,
+            context.clone(),
+            Rc::new(move |cookie| caret_window_position_for_cookie(&context, cookie)),
+        ) {
+            Ok(position) => Ok(position),
+            Err(error) => {
+                tracing::warn!("Failed to obtain caret window position: {error:?}");
+                Ok(None)
+            }
+        }
+    }
+
+    pub(crate) fn request_caret_window_position_async(
+        &self,
+        on_complete: Rc<dyn Fn(Option<WindowPosition>)>,
+    ) -> Result<()> {
+        let (tid, context) = {
+            let text_service = self.borrow()?;
+            (text_service.tid, text_service.context::<ITfContext>()?)
+        };
+        let position = Rc::new(Cell::new(None));
+        let callback = Rc::new({
+            let context = context.clone();
+            let position = position.clone();
+            move |cookie| {
+                position.set(caret_window_position_for_cookie(&context, cookie)?);
+                Ok(())
+            }
+        });
+        let completion = Rc::new(move || on_complete(position.get()));
+        request_async_read_edit_session(tid, context, callback, completion)
     }
 
     fn candidate_window_position_with_mode(
@@ -835,7 +941,7 @@ mod tests {
 
     #[test]
     fn sync_edit_session_returns_callback_value_after_both_results_succeed() {
-        let value = complete_sync_edit_session(Ok(HRESULT(0)), Some("completed".to_string()))
+        let value = complete_sync_edit_session(Ok(HRESULT(0)), true, Some("completed".to_string()))
             .expect("completed callback result");
 
         assert_eq!(value, "completed");
@@ -843,7 +949,7 @@ mod tests {
 
     #[test]
     fn sync_edit_session_keeps_lock_rejection_distinct_from_request_failure() {
-        let error = complete_sync_edit_session::<()>(Ok(TF_E_LOCKED), None)
+        let error = complete_sync_edit_session::<()>(Ok(TF_E_LOCKED), false, None)
             .expect_err("lock rejection must fail the session");
 
         assert_eq!(
@@ -855,7 +961,7 @@ mod tests {
 
     #[test]
     fn sync_edit_session_rejects_unexpected_async_completion() {
-        let error = complete_sync_edit_session::<()>(Ok(TF_S_ASYNC), None)
+        let error = complete_sync_edit_session::<()>(Ok(TF_S_ASYNC), false, None)
             .expect_err("synchronous contract must not read a deferred result");
 
         assert_eq!(
@@ -866,7 +972,7 @@ mod tests {
 
     #[test]
     fn sync_edit_session_reports_context_destruction_as_request_failure() {
-        let error = complete_sync_edit_session::<()>(Err(TF_E_DISCONNECTED), None)
+        let error = complete_sync_edit_session::<()>(Err(TF_E_DISCONNECTED), false, None)
             .expect_err("destroyed context must fail the outer request");
 
         assert_eq!(
@@ -878,13 +984,25 @@ mod tests {
 
     #[test]
     fn sync_edit_session_requires_callback_completion() {
-        let error = complete_sync_edit_session::<()>(Ok(HRESULT(0)), None)
+        let error = complete_sync_edit_session::<()>(Ok(HRESULT(0)), false, None)
             .expect_err("successful session without callback completion is invalid");
 
         assert_eq!(
             error.downcast_ref::<EditSessionFailure>(),
             Some(&EditSessionFailure::CallbackNotCompleted)
         );
+    }
+
+    #[test]
+    fn sync_edit_session_marks_callback_hresult_as_potentially_destructive() {
+        let error = complete_sync_edit_session::<()>(Ok(TF_E_LOCKED), true, None)
+            .expect_err("callback HRESULT must remain distinct from lock rejection");
+
+        assert_eq!(
+            error.downcast_ref::<EditSessionFailure>(),
+            Some(&EditSessionFailure::Callback(TF_E_LOCKED))
+        );
+        assert!(!is_non_destructive_edit_session_error(&error));
     }
 
     #[test]

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -1,6 +1,6 @@
 use macros::anyhow;
 use windows::{
-    core::{implement, AsImpl, HRESULT, VARIANT},
+    core::{implement, AsImpl, IUnknown, Interface, HRESULT, VARIANT},
     Win32::{
         Foundation::RECT,
         UI::TextServices::{
@@ -42,10 +42,26 @@ struct EditSession<'a, T> {
 #[implement(ITfEditSession)]
 struct AsyncEditSession {
     callback: Rc<dyn Fn(u32) -> anyhow::Result<()>>,
+    completion: Rc<dyn Fn()>,
+    completed: Cell<bool>,
+}
+
+impl AsyncEditSession {
+    fn complete(&self) {
+        if !self.completed.replace(true) {
+            (self.completion)();
+        }
+    }
+}
+
+impl Drop for AsyncEditSession {
+    fn drop(&mut self) {
+        self.complete();
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EditSessionFailure {
+pub(crate) enum EditSessionFailure {
     Request(HRESULT),
     Session(HRESULT),
     UnexpectedAsync,
@@ -139,16 +155,46 @@ pub fn write_edit_session<T>(
     sync_edit_session(client_id, context, TF_ES_READWRITE, callback)
 }
 
+fn request_async_edit_session(
+    client_id: u32,
+    context: ITfContext,
+    access: windows::Win32::UI::TextServices::TF_CONTEXT_EDIT_CONTEXT_FLAGS,
+    callback: Rc<dyn Fn(u32) -> anyhow::Result<()>>,
+    completion: Rc<dyn Fn()>,
+) -> Result<()> {
+    let session: ITfEditSession = AsyncEditSession {
+        callback,
+        completion,
+        completed: Cell::new(false),
+    }
+    .into();
+    let request_result =
+        unsafe { context.RequestEditSession(client_id, &session, access | TF_ES_ASYNC) }
+            .map_err(|error| error.code());
+    complete_async_edit_session_request(request_result)
+}
+
 fn request_async_read_edit_session(
     client_id: u32,
     context: ITfContext,
     callback: Rc<dyn Fn(u32) -> anyhow::Result<()>>,
+    completion: Rc<dyn Fn()>,
 ) -> Result<()> {
-    let session: ITfEditSession = AsyncEditSession { callback }.into();
-    let request_result =
-        unsafe { context.RequestEditSession(client_id, &session, TF_ES_READ | TF_ES_ASYNC) }
-            .map_err(|error| error.code());
-    complete_async_edit_session_request(request_result)
+    request_async_edit_session(client_id, context, TF_ES_READ, callback, completion)
+}
+
+fn request_async_write_edit_session(
+    client_id: u32,
+    context: ITfContext,
+    callback: Rc<dyn Fn(u32) -> anyhow::Result<()>>,
+) -> Result<()> {
+    request_async_edit_session(
+        client_id,
+        context,
+        TF_ES_READWRITE,
+        callback,
+        Rc::new(|| {}),
+    )
 }
 
 impl<'a, T> ITfEditSession_Impl for EditSession_Impl<'a, T> {
@@ -163,7 +209,62 @@ impl<'a, T> ITfEditSession_Impl for EditSession_Impl<'a, T> {
 impl ITfEditSession_Impl for AsyncEditSession_Impl {
     #[anyhow]
     fn DoEditSession(&self, cookie: u32) -> Result<()> {
-        (self.callback)(cookie)
+        let result = (self.callback)(cookie);
+        self.complete();
+        result
+    }
+}
+
+fn close_composition_callback(
+    composition: ITfComposition,
+    context: ITfContext,
+    discard_text: bool,
+) -> Rc<dyn Fn(u32) -> anyhow::Result<()>> {
+    Rc::new(move |cookie| unsafe {
+        let range: ITfRange = composition.GetRange()?;
+
+        if discard_text {
+            range.SetText(cookie, TF_ST_CORRECTION, &[])?;
+        } else {
+            let mut text = vec![0; 1024];
+            let mut text_len = 1024;
+
+            let range_new = range.Clone()?;
+            range_new.GetText(cookie, TF_TF_MOVESTART, &mut text, &mut text_len)?;
+
+            text = text[..text_len as usize].to_vec();
+            range.SetText(cookie, TF_ST_CORRECTION, &text)?;
+        }
+
+        let prop = context.GetProperty(&GUID_PROP_ATTRIBUTE)?;
+        prop.Clear(cookie, &range)?;
+
+        range.Collapse(cookie, TF_ANCHOR_END)?;
+        let selection = TF_SELECTION {
+            range: ManuallyDrop::new(Some(range.clone())),
+            style: TF_SELECTIONSTYLE {
+                ase: TF_AE_NONE,
+                fInterimChar: false.into(),
+            },
+        };
+
+        context.SetSelection(cookie, &[selection])?;
+        composition.EndComposition(cookie)?;
+        Ok(())
+    })
+}
+
+fn has_same_com_identity<I: Interface>(left: &I, right: &I) -> bool {
+    match (left.cast::<IUnknown>(), right.cast::<IUnknown>()) {
+        (Ok(left), Ok(right)) => left.as_raw() == right.as_raw(),
+        (Err(left_error), Err(right_error)) => {
+            tracing::warn!(?left_error, ?right_error, "Failed to query COM identities");
+            false
+        }
+        (Err(error), _) | (_, Err(error)) => {
+            tracing::warn!(?error, "Failed to query COM identity");
+            false
+        }
     }
 }
 
@@ -192,42 +293,11 @@ impl TextServiceFactory {
             write_edit_session(
                 text_service.tid,
                 text_service.context()?,
-                Rc::new({
-                    let context = text_service.context::<ITfContext>()?;
-
-                    move |cookie| unsafe {
-                        let range: ITfRange = composition.GetRange()?;
-
-                        if discard_text {
-                            range.SetText(cookie, TF_ST_CORRECTION, &[])?;
-                        } else {
-                            let mut text = vec![0; 1024];
-                            let mut text_len = 1024;
-
-                            let range_new = range.Clone()?;
-                            range_new.GetText(cookie, TF_TF_MOVESTART, &mut text, &mut text_len)?;
-
-                            text = text[..text_len as usize].to_vec();
-                            range.SetText(cookie, TF_ST_CORRECTION, &text)?;
-                        }
-
-                        let prop = context.GetProperty(&GUID_PROP_ATTRIBUTE)?;
-                        prop.Clear(cookie, &range)?;
-
-                        range.Collapse(cookie, TF_ANCHOR_END)?;
-                        let selection = TF_SELECTION {
-                            range: ManuallyDrop::new(Some(range.clone())),
-                            style: TF_SELECTIONSTYLE {
-                                ase: TF_AE_NONE,
-                                fInterimChar: false.into(),
-                            },
-                        };
-
-                        context.SetSelection(cookie, &[selection])?;
-                        composition.EndComposition(cookie)?;
-                        Ok(())
-                    }
-                }),
+                close_composition_callback(
+                    composition,
+                    text_service.context::<ITfContext>()?,
+                    discard_text,
+                ),
             )?;
         } else {
             tracing::warn!("Composition is not started");
@@ -236,6 +306,33 @@ impl TextServiceFactory {
         text_service.borrow_mut_composition()?.tip_composition = None;
 
         Ok(())
+    }
+
+    pub(crate) fn end_composition_async_best_effort(&self) {
+        let request_result: Result<()> = (|| {
+            let text_service = self.borrow()?;
+            let Some(composition) = text_service.borrow_composition()?.tip_composition.clone()
+            else {
+                return Ok(());
+            };
+            let context = text_service.context::<ITfContext>()?;
+            let tid = text_service.tid;
+            request_async_write_edit_session(
+                tid,
+                context.clone(),
+                close_composition_callback(composition, context, false),
+            )
+        })();
+
+        if let Err(error) = request_result {
+            tracing::warn!(?error, "Failed to request best-effort composition end");
+        }
+
+        if let Ok(text_service) = self.borrow() {
+            if let Ok(mut composition) = text_service.borrow_mut_composition() {
+                composition.tip_composition = None;
+            }
+        }
     }
 
     #[tracing::instrument]
@@ -564,8 +661,36 @@ impl TextServiceFactory {
         }
     }
 
-    pub(crate) fn request_update_pos_async(&self) -> Result<()> {
-        let (tid, context, tip_composition, this) = {
+    fn is_current_update_pos_request(
+        &self,
+        generation: u64,
+        context: &ITfContext,
+        tip_composition: &ITfComposition,
+    ) -> bool {
+        let Ok(text_service) = self.borrow() else {
+            return false;
+        };
+        if text_service.update_pos_generation != generation {
+            return false;
+        }
+        let Some(current_context) = text_service.context.as_ref() else {
+            return false;
+        };
+        if !has_same_com_identity(current_context, context) {
+            return false;
+        }
+        text_service
+            .borrow_composition()
+            .ok()
+            .and_then(|composition| composition.tip_composition.clone())
+            .is_some_and(|current| has_same_com_identity(&current, tip_composition))
+    }
+
+    pub(crate) fn request_update_pos_async(
+        &self,
+        layout_context: Option<&ITfContext>,
+    ) -> Result<()> {
+        let (tid, context, tip_composition, this, generation) = {
             let mut text_service = self.borrow_mut()?;
             let tip_composition = text_service.borrow_composition()?.tip_composition.clone();
             let Some(tip_composition) = tip_composition else {
@@ -574,6 +699,12 @@ impl TextServiceFactory {
             let tid = text_service.tid;
             let context = text_service.context::<ITfContext>()?;
             let this = text_service.this::<ITfTextInputProcessor>()?;
+            if layout_context
+                .is_some_and(|layout_context| !has_same_com_identity(&context, layout_context))
+            {
+                tracing::debug!("Skip layout update for a stale TSF context");
+                return Ok(());
+            }
 
             let now = Instant::now();
             if text_service
@@ -590,14 +721,24 @@ impl TextServiceFactory {
             text_service
                 .candidate_window_position_state
                 .mark_attempt(now);
+            text_service.update_pos_generation = text_service.update_pos_generation.wrapping_add(1);
+            let generation = text_service.update_pos_generation;
 
-            (tid, context, tip_composition, this)
+            (tid, context, tip_composition, this, generation)
         };
 
         let callback = Rc::new({
             let context = context.clone();
+            let tip_composition = tip_composition.clone();
+            let this = this.clone();
 
             move |cookie| {
+                let factory = unsafe { this.as_impl() };
+                if !factory.is_current_update_pos_request(generation, &context, &tip_composition) {
+                    tracing::debug!("Skip stale asynchronous candidate position callback");
+                    return Ok(());
+                }
+
                 let result: Result<()> = (|| unsafe {
                     let view = context.GetActiveView()?;
                     let range = tip_composition.GetRange()?;
@@ -624,20 +765,19 @@ impl TextServiceFactory {
                     }
                     Ok(())
                 })();
-
-                let factory = unsafe { this.as_impl() };
-                factory.finish_update_pos();
                 result
             }
         });
 
-        match request_async_read_edit_session(tid, context, callback) {
-            Ok(()) => Ok(()),
-            Err(error) => {
-                self.finish_update_pos();
-                Err(error)
+        let completion = Rc::new({
+            let this = this.clone();
+            move || {
+                let factory = unsafe { this.as_impl() };
+                factory.finish_update_pos();
             }
-        }
+        });
+
+        request_async_read_edit_session(tid, context, callback, completion)
     }
 
     #[tracing::instrument]
@@ -721,6 +861,7 @@ mod tests {
     #[test]
     fn async_edit_session_runs_work_only_when_tsf_invokes_the_callback() {
         let callback_invoked = Rc::new(Cell::new(false));
+        let completion_count = Rc::new(Cell::new(0));
         let session: windows::Win32::UI::TextServices::ITfEditSession = AsyncEditSession {
             callback: Rc::new({
                 let callback_invoked = callback_invoked.clone();
@@ -729,6 +870,11 @@ mod tests {
                     Ok(())
                 }
             }),
+            completion: Rc::new({
+                let completion_count = completion_count.clone();
+                move || completion_count.set(completion_count.get() + 1)
+            }),
+            completed: Cell::new(false),
         }
         .into();
 
@@ -739,6 +885,26 @@ mod tests {
                 .expect("async callback should complete");
         }
         assert!(callback_invoked.get());
+        assert_eq!(completion_count.get(), 1);
+        drop(session);
+        assert_eq!(completion_count.get(), 1);
+    }
+
+    #[test]
+    fn async_edit_session_releases_completion_guard_when_callback_never_runs() {
+        let completion_count = Rc::new(Cell::new(0));
+        let session: windows::Win32::UI::TextServices::ITfEditSession = AsyncEditSession {
+            callback: Rc::new(|_| panic!("callback must not run")),
+            completion: Rc::new({
+                let completion_count = completion_count.clone();
+                move || completion_count.set(completion_count.get() + 1)
+            }),
+            completed: Cell::new(false),
+        }
+        .into();
+
+        drop(session);
+        assert_eq!(completion_count.get(), 1);
     }
 
     #[test]

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -341,6 +341,16 @@ fn caret_window_position_for_cookie(
     }
 }
 
+fn complete_async_position_request(
+    callback_succeeded: bool,
+    position: Option<WindowPosition>,
+    on_complete: &dyn Fn(Option<WindowPosition>),
+) {
+    if callback_succeeded {
+        on_complete(position);
+    }
+}
+
 impl TextServiceFactory {
     fn log_candidate_window_position_performance(
         request_id: u64,
@@ -632,15 +642,24 @@ impl TextServiceFactory {
             (text_service.tid, text_service.context::<ITfContext>()?)
         };
         let position = Rc::new(Cell::new(None));
+        let callback_succeeded = Rc::new(Cell::new(false));
         let callback = Rc::new({
             let context = context.clone();
             let position = position.clone();
+            let callback_succeeded = callback_succeeded.clone();
             move |cookie| {
                 position.set(caret_window_position_for_cookie(&context, cookie)?);
+                callback_succeeded.set(true);
                 Ok(())
             }
         });
-        let completion = Rc::new(move || on_complete(position.get()));
+        let completion = Rc::new(move || {
+            complete_async_position_request(
+                callback_succeeded.get(),
+                position.get(),
+                on_complete.as_ref(),
+            );
+        });
         request_async_read_edit_session(tid, context, callback, completion)
     }
 
@@ -930,8 +949,9 @@ impl TextServiceFactory {
 #[cfg(test)]
 mod tests {
     use super::{
-        complete_async_edit_session_request, complete_sync_edit_session,
-        is_non_destructive_edit_session_error, AsyncEditSession, EditSessionFailure,
+        complete_async_edit_session_request, complete_async_position_request,
+        complete_sync_edit_session, is_non_destructive_edit_session_error, AsyncEditSession,
+        EditSessionFailure,
     };
     use std::{cell::Cell, rc::Rc};
     use windows::{
@@ -1051,6 +1071,18 @@ mod tests {
         .into();
 
         drop(session);
+        assert_eq!(completion_count.get(), 1);
+    }
+
+    #[test]
+    fn async_position_completion_ignores_callback_failure_or_cancellation() {
+        let completion_count = Cell::new(0);
+        let on_complete = |_| completion_count.set(completion_count.get() + 1);
+
+        complete_async_position_request(false, None, &on_complete);
+        assert_eq!(completion_count.get(), 0);
+
+        complete_async_position_request(true, None, &on_complete);
         assert_eq!(completion_count.get(), 1);
     }
 

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -453,7 +453,7 @@ impl TextServiceFactory {
     pub fn start_composition(&self) -> Result<()> {
         tracing::debug!("start_composition");
 
-        let text_service = self.borrow_mut()?;
+        let mut text_service = self.borrow_mut()?;
         let context = text_service.context()?;
         let context_composition = text_service.context::<ITfContextComposition>()?;
         let sink = text_service.this::<ITfCompositionSink>()?;
@@ -465,6 +465,7 @@ impl TextServiceFactory {
         };
 
         if tip_exists {
+            drop(text_service);
             self.end_composition()?;
             return Ok(());
         }
@@ -485,6 +486,10 @@ impl TextServiceFactory {
 
         tracing::debug!("Composition started {composition:?}");
         text_service.borrow_mut_composition()?.tip_composition = Some(composition);
+        // An idle mode-switch request may still be waiting for its asynchronous caret read.
+        // Starting a composition makes that request stale even if this composition ends before
+        // the callback arrives.
+        text_service.advance_mode_switch_generation();
 
         Ok(())
     }

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -335,10 +335,16 @@ impl TextServiceFactory {
         }
     }
 
-    pub(crate) fn end_composition_async_on_success(&self, on_success: Rc<dyn Fn()>) -> Result<()> {
+    pub(crate) fn end_composition_async_on_success(
+        &self,
+        is_current: Rc<dyn Fn() -> bool>,
+        on_success: Rc<dyn Fn()>,
+    ) -> Result<()> {
         let text_service = self.borrow()?;
         let Some(composition) = text_service.borrow_composition()?.tip_composition.clone() else {
-            on_success();
+            if is_current() {
+                on_success();
+            }
             return Ok(());
         };
         let context = text_service.context::<ITfContext>()?;
@@ -347,6 +353,10 @@ impl TextServiceFactory {
             text_service.tid,
             context,
             Rc::new(move |cookie| {
+                if !is_current() {
+                    tracing::debug!("Skip stale asynchronous composition end callback");
+                    return Ok(());
+                }
                 close(cookie)?;
                 on_success();
                 Ok(())

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -577,16 +577,6 @@ impl TextServiceFactory {
 
                     move |cookie| unsafe {
                         let composition_range = composition.GetRange()?;
-                        let new_start_range = composition_range.Clone()?;
-                        let mut shifted: i32 = 0;
-
-                        new_start_range.Collapse(cookie, TF_ANCHOR_START)?;
-                        new_start_range.ShiftStart(
-                            cookie,
-                            text_len,
-                            &mut shifted,
-                            std::ptr::null(),
-                        )?;
 
                         commit_shift_start_after_prepare(
                             || {
@@ -594,6 +584,7 @@ impl TextServiceFactory {
                                 prop.Clear(cookie, &composition_range)?;
 
                                 let suffix_range = composition_range.Clone()?;
+                                let mut shifted = 0;
                                 suffix_range.ShiftStart(
                                     cookie,
                                     text_len,
@@ -625,6 +616,17 @@ impl TextServiceFactory {
                             || {
                                 // Keep the non-idempotent boundary change last. If any preparation
                                 // fails, replaying the deferred action must not shift twice.
+                                // Reacquire the dynamic range after SetText so anchor gravity cannot
+                                // move a previously cloned boundary to a host-dependent position.
+                                let new_start_range = composition.GetRange()?;
+                                let mut shifted = 0;
+                                new_start_range.Collapse(cookie, TF_ANCHOR_START)?;
+                                new_start_range.ShiftStart(
+                                    cookie,
+                                    text_len,
+                                    &mut shifted,
+                                    std::ptr::null(),
+                                )?;
                                 composition.ShiftStart(cookie, &new_start_range)?;
                                 Ok(())
                             },

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -499,7 +499,7 @@ impl TextServiceFactory {
         // An idle mode-switch request may still be waiting for its asynchronous caret read.
         // Starting a composition makes that request stale even if this composition ends before
         // the callback arrives.
-        text_service.advance_mode_switch_generation();
+        text_service.invalidate_mode_switch_requests();
 
         Ok(())
     }

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -335,6 +335,25 @@ impl TextServiceFactory {
         }
     }
 
+    pub(crate) fn end_composition_async_on_success(&self, on_success: Rc<dyn Fn()>) -> Result<()> {
+        let text_service = self.borrow()?;
+        let Some(composition) = text_service.borrow_composition()?.tip_composition.clone() else {
+            on_success();
+            return Ok(());
+        };
+        let context = text_service.context::<ITfContext>()?;
+        let close = close_composition_callback(composition, context.clone(), false);
+        request_async_write_edit_session(
+            text_service.tid,
+            context,
+            Rc::new(move |cookie| {
+                close(cookie)?;
+                on_success();
+                Ok(())
+            }),
+        )
+    }
+
     #[tracing::instrument]
     pub fn start_composition(&self) -> Result<()> {
         tracing::debug!("start_composition");

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -141,6 +141,14 @@ fn complete_async_edit_session_request(
         .map_err(|_| anyhow::Error::new(EditSessionFailure::Session(session_result)))
 }
 
+fn commit_shift_start_after_prepare(
+    prepare_suffix: impl FnOnce() -> Result<()>,
+    shift_composition_start: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    prepare_suffix()?;
+    shift_composition_start()
+}
+
 fn sync_edit_session<T>(
     client_id: u32,
     context: ITfContext,
@@ -568,43 +576,59 @@ impl TextServiceFactory {
                     let display_attribute_atom = text_service.display_attribute_atom.clone();
 
                     move |cookie| unsafe {
-                        // first, shift the start of the composition
-                        let range = composition.GetRange()?;
+                        let composition_range = composition.GetRange()?;
+                        let new_start_range = composition_range.Clone()?;
                         let mut shifted: i32 = 0;
 
-                        // and clear the display attribute
-                        let prop = context.GetProperty(&GUID_PROP_ATTRIBUTE)?;
-                        prop.Clear(cookie, &range)?;
+                        new_start_range.Collapse(cookie, TF_ANCHOR_START)?;
+                        new_start_range.ShiftStart(
+                            cookie,
+                            text_len,
+                            &mut shifted,
+                            std::ptr::null(),
+                        )?;
 
-                        range.Collapse(cookie, TF_ANCHOR_START)?;
-                        range.ShiftStart(cookie, text_len, &mut shifted, std::ptr::null())?;
+                        commit_shift_start_after_prepare(
+                            || {
+                                let prop = context.GetProperty(&GUID_PROP_ATTRIBUTE)?;
+                                prop.Clear(cookie, &composition_range)?;
 
-                        composition.ShiftStart(cookie, &range)?;
+                                let suffix_range = composition_range.Clone()?;
+                                suffix_range.ShiftStart(
+                                    cookie,
+                                    text_len,
+                                    &mut shifted,
+                                    std::ptr::null(),
+                                )?;
+                                suffix_range.SetText(cookie, TF_ST_CORRECTION, &subtext)?;
 
-                        // then, set the display attribute
-                        let range = composition.GetRange()?;
+                                let display_attribute =
+                                    display_attribute_atom.get(&GUID_DISPLAY_ATTRIBUTE);
+                                if let Some(display_attribute) = display_attribute {
+                                    let pvar = VARIANT::from(*display_attribute as i32);
+                                    let prop = context.GetProperty(&GUID_PROP_ATTRIBUTE)?;
+                                    prop.SetValue(cookie, &suffix_range, &pvar)?;
+                                }
 
-                        range.SetText(cookie, TF_ST_CORRECTION, &subtext)?;
+                                suffix_range.Collapse(cookie, TF_ANCHOR_END)?;
+                                let selection = TF_SELECTION {
+                                    range: ManuallyDrop::new(Some(suffix_range)),
+                                    style: TF_SELECTIONSTYLE {
+                                        ase: TF_AE_NONE,
+                                        fInterimChar: false.into(),
+                                    },
+                                };
 
-                        let display_attribute = display_attribute_atom.get(&GUID_DISPLAY_ATTRIBUTE);
-                        if let Some(display_attribute) = display_attribute {
-                            let pvar = VARIANT::from(*display_attribute as i32);
-                            let prop = context.GetProperty(&GUID_PROP_ATTRIBUTE)?;
-                            prop.SetValue(cookie, &range, &pvar)?;
-                        }
-
-                        range.Collapse(cookie, TF_ANCHOR_END)?;
-                        let selection = TF_SELECTION {
-                            range: ManuallyDrop::new(Some(range)),
-                            style: TF_SELECTIONSTYLE {
-                                ase: TF_AE_NONE,
-                                fInterimChar: false.into(),
+                                context.SetSelection(cookie, &[selection])?;
+                                Ok(())
                             },
-                        };
-
-                        context.SetSelection(cookie, &[selection])?;
-
-                        Ok(())
+                            || {
+                                // Keep the non-idempotent boundary change last. If any preparation
+                                // fails, replaying the deferred action must not shift twice.
+                                composition.ShiftStart(cookie, &new_start_range)?;
+                                Ok(())
+                            },
+                        )
                     }
                 }),
             )?;
@@ -949,9 +973,9 @@ impl TextServiceFactory {
 #[cfg(test)]
 mod tests {
     use super::{
-        complete_async_edit_session_request, complete_async_position_request,
-        complete_sync_edit_session, is_non_destructive_edit_session_error, AsyncEditSession,
-        EditSessionFailure,
+        commit_shift_start_after_prepare, complete_async_edit_session_request,
+        complete_async_position_request, complete_sync_edit_session,
+        is_non_destructive_edit_session_error, AsyncEditSession, EditSessionFailure,
     };
     use std::{cell::Cell, rc::Rc};
     use windows::{
@@ -1023,6 +1047,42 @@ mod tests {
             Some(&EditSessionFailure::Callback(TF_E_LOCKED))
         );
         assert!(!is_non_destructive_edit_session_error(&error));
+    }
+
+    #[test]
+    fn shift_start_does_not_move_composition_boundary_when_preparation_fails() {
+        let shift_count = Cell::new(0);
+        let error = commit_shift_start_after_prepare(
+            || anyhow::bail!("selection update failed"),
+            || {
+                shift_count.set(shift_count.get() + 1);
+                Ok(())
+            },
+        )
+        .expect_err("failed preparation must abort the boundary change");
+
+        assert_eq!(error.to_string(), "selection update failed");
+        assert_eq!(shift_count.get(), 0);
+    }
+
+    #[test]
+    fn shift_start_moves_composition_boundary_only_after_preparation() {
+        let operation_order = Cell::new(0);
+        commit_shift_start_after_prepare(
+            || {
+                assert_eq!(operation_order.get(), 0);
+                operation_order.set(1);
+                Ok(())
+            },
+            || {
+                assert_eq!(operation_order.get(), 1);
+                operation_order.set(2);
+                Ok(())
+            },
+        )
+        .expect("successful preparation should commit the boundary change");
+
+        assert_eq!(operation_order.get(), 2);
     }
 
     #[test]

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -223,14 +223,9 @@ fn request_async_write_edit_session(
     client_id: u32,
     context: ITfContext,
     callback: Rc<dyn Fn(u32) -> anyhow::Result<()>>,
+    completion: Rc<dyn Fn()>,
 ) -> Result<()> {
-    request_async_edit_session(
-        client_id,
-        context,
-        TF_ES_READWRITE,
-        callback,
-        Rc::new(|| {}),
-    )
+    request_async_edit_session(client_id, context, TF_ES_READWRITE, callback, completion)
 }
 
 impl<'a, T> ITfEditSession_Impl for EditSession_Impl<'a, T> {
@@ -351,11 +346,21 @@ fn caret_window_position_for_cookie(
 
 fn complete_async_position_request(
     callback_succeeded: bool,
+    request_accepted: bool,
     position: Option<WindowPosition>,
     on_complete: &dyn Fn(Option<WindowPosition>),
-) {
+    on_cancel: &dyn Fn(),
+) -> bool {
     if callback_succeeded {
         on_complete(position);
+        false
+    } else if request_accepted {
+        on_cancel();
+        false
+    } else {
+        // RequestEditSession may release the COM object before returning its rejection.
+        // Let the caller handle that error; only route cancellation after acceptance.
+        true
     }
 }
 
@@ -422,6 +427,7 @@ impl TextServiceFactory {
                 tid,
                 context.clone(),
                 close_composition_callback(composition, context, false),
+                Rc::new(|| {}),
             )
         })();
 
@@ -434,18 +440,26 @@ impl TextServiceFactory {
         &self,
         is_current: Rc<dyn Fn() -> bool>,
         on_success: Rc<dyn Fn()>,
+        on_terminal: Rc<dyn Fn()>,
     ) -> Result<()> {
-        let text_service = self.borrow()?;
-        let Some(composition) = text_service.borrow_composition()?.tip_composition.clone() else {
+        let (tid, context, composition) = {
+            let text_service = self.borrow()?;
+            let tid = text_service.tid;
+            let context = text_service.context::<ITfContext>()?;
+            let composition = text_service.borrow_composition()?.tip_composition.clone();
+            (tid, context, composition)
+        };
+        let Some(composition) = composition else {
             if is_current() {
                 on_success();
+            } else {
+                on_terminal();
             }
             return Ok(());
         };
-        let context = text_service.context::<ITfContext>()?;
         let close = close_composition_callback(composition, context.clone(), false);
         request_async_write_edit_session(
-            text_service.tid,
+            tid,
             context,
             Rc::new(move |cookie| {
                 if !is_current() {
@@ -456,6 +470,7 @@ impl TextServiceFactory {
                 on_success();
                 Ok(())
             }),
+            on_terminal,
         )
     }
 
@@ -677,6 +692,7 @@ impl TextServiceFactory {
     pub(crate) fn request_caret_window_position_async(
         &self,
         on_complete: Rc<dyn Fn(Option<WindowPosition>)>,
+        on_cancel: Rc<dyn Fn()>,
     ) -> Result<()> {
         let (tid, context) = {
             let text_service = self.borrow()?;
@@ -684,6 +700,8 @@ impl TextServiceFactory {
         };
         let position = Rc::new(Cell::new(None));
         let callback_succeeded = Rc::new(Cell::new(false));
+        let request_accepted = Rc::new(Cell::new(false));
+        let cancel_before_request_result = Rc::new(Cell::new(false));
         let callback = Rc::new({
             let context = context.clone();
             let position = position.clone();
@@ -698,14 +716,28 @@ impl TextServiceFactory {
                 Ok(())
             }
         });
-        let completion = Rc::new(move || {
-            complete_async_position_request(
-                callback_succeeded.get(),
-                position.get(),
-                on_complete.as_ref(),
-            );
+        let completion = Rc::new({
+            let request_accepted = request_accepted.clone();
+            let cancel_before_request_result = cancel_before_request_result.clone();
+            let on_cancel = on_cancel.clone();
+            move || {
+                cancel_before_request_result.set(complete_async_position_request(
+                    callback_succeeded.get(),
+                    request_accepted.get(),
+                    position.get(),
+                    on_complete.as_ref(),
+                    on_cancel.as_ref(),
+                ));
+            }
         });
-        request_async_read_edit_session(tid, context, callback, completion)
+        let result = request_async_read_edit_session(tid, context, callback, completion);
+        if result.is_ok() {
+            request_accepted.set(true);
+            if cancel_before_request_result.replace(false) {
+                on_cancel();
+            }
+        }
+        result
     }
 
     fn candidate_window_position_with_mode(
@@ -1140,6 +1172,29 @@ mod tests {
     }
 
     #[test]
+    fn async_edit_session_runs_terminal_cleanup_when_callback_fails() {
+        let completion_count = Rc::new(Cell::new(0));
+        let session: windows::Win32::UI::TextServices::ITfEditSession = AsyncEditSession {
+            callback: Rc::new(|_| anyhow::bail!("composition close failed")),
+            completion: Rc::new({
+                let completion_count = completion_count.clone();
+                move || completion_count.set(completion_count.get() + 1)
+            }),
+            completed: Cell::new(false),
+        }
+        .into();
+
+        unsafe {
+            session
+                .DoEditSession(0)
+                .expect_err("callback failure must propagate");
+        }
+        assert_eq!(completion_count.get(), 1);
+        drop(session);
+        assert_eq!(completion_count.get(), 1);
+    }
+
+    #[test]
     fn async_edit_session_releases_completion_guard_when_callback_never_runs() {
         let completion_count = Rc::new(Cell::new(0));
         let session: windows::Win32::UI::TextServices::ITfEditSession = AsyncEditSession {
@@ -1157,15 +1212,40 @@ mod tests {
     }
 
     #[test]
-    fn async_position_completion_ignores_callback_failure_or_cancellation() {
+    fn async_position_completion_routes_success_and_cancellation_separately() {
         let completion_count = Cell::new(0);
+        let cancellation_count = Cell::new(0);
         let on_complete = |_| completion_count.set(completion_count.get() + 1);
+        let on_cancel = || cancellation_count.set(cancellation_count.get() + 1);
 
-        complete_async_position_request(false, None, &on_complete);
+        assert!(complete_async_position_request(
+            false,
+            false,
+            None,
+            &on_complete,
+            &on_cancel,
+        ));
         assert_eq!(completion_count.get(), 0);
+        assert_eq!(cancellation_count.get(), 0);
 
-        complete_async_position_request(true, None, &on_complete);
+        assert!(!complete_async_position_request(
+            false,
+            true,
+            None,
+            &on_complete,
+            &on_cancel,
+        ));
+        assert_eq!(cancellation_count.get(), 1);
+
+        assert!(!complete_async_position_request(
+            true,
+            true,
+            None,
+            &on_complete,
+            &on_cancel,
+        ));
         assert_eq!(completion_count.get(), 1);
+        assert_eq!(cancellation_count.get(), 1);
     }
 
     #[test]

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -111,7 +111,7 @@ impl TextServiceFactory_Impl {
         };
         let mode = toggled_input_mode(base_mode);
 
-        self.request_input_mode_switch_after_composition(mode)
+        self.request_language_bar_input_mode_toggle(mode)
     }
 
     fn handle_right_click(&self, pt: &POINT) -> Result<()> {

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -38,10 +38,7 @@ use windows::{
 };
 
 use crate::{
-    engine::{
-        client_action::ClientAction, composition::CompositionState, input_mode::InputMode,
-        state::IMEState, theme::get_theme,
-    },
+    engine::{input_mode::InputMode, state::IMEState, theme::get_theme},
     extension::StringExt as _,
     globals::{DllModule, GUID_TEXT_SERVICE, TEXTSERVICE_LANGBARITEMSINK_COOKIE},
     launcher_control,
@@ -105,20 +102,7 @@ impl TextServiceFactory_Impl {
             InputMode::Kana => InputMode::Latin,
         };
 
-        let composition_active = self
-            .borrow()?
-            .borrow_composition()?
-            .tip_composition
-            .is_some();
-        if composition_active {
-            self.request_input_mode_switch_after_composition(mode)?;
-            return Ok(());
-        }
-
-        let actions = vec![ClientAction::SetIMEMode(mode)];
-        self.handle_action(&actions, CompositionState::None)?;
-
-        Ok(())
+        self.request_input_mode_switch_after_composition(mode)
     }
 
     fn handle_right_click(&self, pt: &POINT) -> Result<()> {

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -105,6 +105,16 @@ impl TextServiceFactory_Impl {
             InputMode::Kana => InputMode::Latin,
         };
 
+        let composition_active = self
+            .borrow()?
+            .borrow_composition()?
+            .tip_composition
+            .is_some();
+        if composition_active {
+            self.request_input_mode_switch_after_composition(mode)?;
+            return Ok(());
+        }
+
         let actions = vec![ClientAction::SetIMEMode(mode)];
         self.handle_action(&actions, CompositionState::None)?;
 

--- a/crates/client/src/tsf/language_bar.rs
+++ b/crates/client/src/tsf/language_bar.rs
@@ -70,6 +70,13 @@ const SETTINGS_APP_MAIN_BINARY_NAME_VALUE: PCWSTR = w!("MainBinaryName");
 
 static MENU_OWNER_WINDOW_CLASS_SEQUENCE: AtomicU32 = AtomicU32::new(0);
 
+fn toggled_input_mode(mode: InputMode) -> InputMode {
+    match mode {
+        InputMode::Latin => InputMode::Kana,
+        InputMode::Kana => InputMode::Latin,
+    }
+}
+
 // you need to implement these three interfaces to create a language bar item
 // if not, you will get E_FAIL error in ITfLangBarItemMgr::AddItem
 
@@ -97,10 +104,12 @@ impl TextServiceFactory_Impl {
             return Ok(());
         }
 
-        let mode = match IMEState::input_mode()? {
-            InputMode::Latin => InputMode::Kana,
-            InputMode::Kana => InputMode::Latin,
+        let pending_mode = { self.borrow()?.pending_mode_switch() };
+        let base_mode = match pending_mode {
+            Some(mode) => mode,
+            None => IMEState::input_mode()?,
         };
+        let mode = toggled_input_mode(base_mode);
 
         self.request_input_mode_switch_after_composition(mode)
     }
@@ -711,8 +720,9 @@ impl ITfSource_Impl for TextServiceFactory_Impl {
 mod tests {
     use super::{
         resolve_settings_app_path_from_install_location, select_existing_settings_app_path,
-        trim_registry_string, SettingsAppPath,
+        toggled_input_mode, trim_registry_string, SettingsAppPath,
     };
+    use crate::engine::input_mode::InputMode;
     use crate::launcher_control::parse_launcher_response;
     use std::path::PathBuf;
 
@@ -810,5 +820,13 @@ mod tests {
     fn parse_launcher_response_rejects_launcher_error() {
         let error = parse_launcher_response(b"error:denied\n").unwrap_err();
         assert!(error.to_string().contains("denied"));
+    }
+
+    #[test]
+    fn two_pending_language_bar_toggles_return_to_the_original_mode() {
+        let first_target = toggled_input_mode(InputMode::Latin);
+        let second_target = toggled_input_mode(first_target);
+
+        assert_eq!(second_target, InputMode::Latin);
     }
 }

--- a/crates/client/src/tsf/surrounded_text.rs
+++ b/crates/client/src/tsf/surrounded_text.rs
@@ -15,7 +15,7 @@ use windows::{
 
 use crate::engine::{ipc_service::current_input_trace_request_id, state::IMEState};
 
-use super::{edit_session::edit_session, factory::TextServiceFactory};
+use super::{edit_session::read_edit_session, factory::TextServiceFactory};
 
 impl TextServiceFactory {
     fn log_update_context_performance(
@@ -134,7 +134,7 @@ impl TextServiceFactory {
             };
 
             let edit_session_start = trace_request_id.map(|_| Instant::now());
-            let preceding_text = edit_session::<String>(
+            let preceding_text = read_edit_session::<String>(
                 tid,
                 parent_context.clone(),
                 Rc::new({
@@ -205,16 +205,11 @@ impl TextServiceFactory {
                     "edit_session",
                     edit_session_start,
                     format!(
-                        "status=success;preview_len={};preceding_text_present={}",
-                        preview.chars().count(),
-                        preceding_text.is_some()
+                        "status=success;preview_len={};preceding_text_present=true",
+                        preview.chars().count()
                     ),
                 );
             }
-
-            let Some(preceding_text) = preceding_text else {
-                return Ok(());
-            };
 
             let Some(mut ipc_service) = IMEState::ipc_service()? else {
                 return Ok(());

--- a/crates/client/src/tsf/text_input_proccesor.rs
+++ b/crates/client/src/tsf/text_input_proccesor.rs
@@ -137,13 +137,13 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
         let mut dll_instance = DllModule::get()?;
         dll_instance.release();
 
+        // End composition before borrowing TextService for sink teardown. The event helper
+        // needs a mutable borrow to invalidate pending mode switches and clear local state.
+        self.end_composition_for_tsf_event();
+
         {
             let text_service = self.borrow()?;
             let thread_mgr = text_service.thread_mgr()?;
-
-            // End composition without blocking the remaining TSF cleanup if the
-            // document no longer grants a synchronous edit session.
-            self.end_composition_for_tsf_event();
 
             // remove key event sink
             tracing::debug!("UnadviseKeyEventSink");

--- a/crates/client/src/tsf/text_input_proccesor.rs
+++ b/crates/client/src/tsf/text_input_proccesor.rs
@@ -141,8 +141,9 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
             let text_service = self.borrow()?;
             let thread_mgr = text_service.thread_mgr()?;
 
-            // end composition
-            self.end_composition()?;
+            // End composition without blocking the remaining TSF cleanup if the
+            // document no longer grants a synchronous edit session.
+            self.end_composition_for_tsf_event();
 
             // remove key event sink
             tracing::debug!("UnadviseKeyEventSink");

--- a/crates/client/src/tsf/text_layout_sink.rs
+++ b/crates/client/src/tsf/text_layout_sink.rs
@@ -35,8 +35,8 @@ impl ITfTextLayoutSink_Impl for TextServiceFactory_Impl {
             return Ok(());
         }
 
-        if let Err(error) = self.update_pos() {
-            tracing::warn!("Failed to update position from OnLayoutChange: {error:?}");
+        if let Err(error) = self.request_update_pos_async() {
+            tracing::warn!("Failed to request position update from OnLayoutChange: {error:?}");
         }
 
         Ok(())

--- a/crates/client/src/tsf/text_layout_sink.rs
+++ b/crates/client/src/tsf/text_layout_sink.rs
@@ -16,7 +16,7 @@ impl ITfTextLayoutSink_Impl for TextServiceFactory_Impl {
     #[macros::anyhow]
     fn OnLayoutChange(
         &self,
-        _pic: Option<&ITfContext>,
+        pic: Option<&ITfContext>,
         _lcode: TfLayoutCode,
         _pview: Option<&ITfContextView>,
     ) -> Result<()> {
@@ -35,7 +35,7 @@ impl ITfTextLayoutSink_Impl for TextServiceFactory_Impl {
             return Ok(());
         }
 
-        if let Err(error) = self.request_update_pos_async() {
+        if let Err(error) = self.request_update_pos_async(pic) {
             tracing::warn!("Failed to request position update from OnLayoutChange: {error:?}");
         }
 

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -194,7 +194,7 @@ impl TextService {
     }
 
     pub(crate) fn clear_pending_mode_switch(&mut self, generation: u64) -> bool {
-        if self.mode_switch_generation != generation {
+        if self.mode_switch_generation != generation || self.pending_mode_switch.is_none() {
             return false;
         }
         self.pending_mode_switch = None;
@@ -264,6 +264,7 @@ mod tests {
         assert!(!text_service.clear_pending_mode_switch(first));
         assert_eq!(text_service.pending_mode_switch(), Some(InputMode::Latin));
         assert!(text_service.clear_pending_mode_switch(second));
+        assert!(!text_service.clear_pending_mode_switch(second));
         assert_eq!(text_service.pending_mode_switch(), None);
     }
 

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -171,12 +171,18 @@ impl TextService {
     pub fn borrow_mut_composition(&self) -> Result<RefMut<'_, Composition>> {
         Ok(self.composition.try_borrow_mut()?)
     }
+
+    pub(crate) fn advance_mode_switch_generation(&mut self) -> u64 {
+        self.mode_switch_generation = self.mode_switch_generation.wrapping_add(1);
+        self.mode_switch_generation
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
         CandidateWindowPositionState, CandidateWindowVisibilityState, SurroundingTextContextState,
+        TextService,
     };
     use std::time::{Duration, Instant};
 
@@ -218,5 +224,13 @@ mod tests {
 
         state.apply_visibility_update(Some(false));
         assert!(!state.should_update_position(true, None));
+    }
+
+    #[test]
+    fn mode_switch_generation_advances_across_composition_lifecycle_changes() {
+        let mut text_service = TextService::default();
+
+        assert_eq!(text_service.advance_mode_switch_generation(), 1);
+        assert_eq!(text_service.advance_mode_switch_generation(), 2);
     }
 }

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -134,6 +134,7 @@ pub struct TextService {
     pub layout_sink_context: Option<ITfContext>,
     pub composition: RefCell<Composition>,
     pub update_pos_state: UpdatePosState,
+    pub update_pos_generation: u64,
     pub candidate_window_position_state: CandidateWindowPositionState,
     pub candidate_window_visibility_state: CandidateWindowVisibilityState,
     pub surrounding_text_context_state: SurroundingTextContextState,

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -135,6 +135,7 @@ pub struct TextService {
     pub composition: RefCell<Composition>,
     pub update_pos_state: UpdatePosState,
     pub update_pos_generation: u64,
+    pub mode_switch_generation: u64,
     pub candidate_window_position_state: CandidateWindowPositionState,
     pub candidate_window_visibility_state: CandidateWindowVisibilityState,
     pub surrounding_text_context_state: SurroundingTextContextState,

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -136,6 +136,7 @@ pub struct TextService {
     pub update_pos_state: UpdatePosState,
     pub update_pos_generation: u64,
     pub mode_switch_generation: u64,
+    pending_mode_switch: Option<InputMode>,
     pub candidate_window_position_state: CandidateWindowPositionState,
     pub candidate_window_visibility_state: CandidateWindowVisibilityState,
     pub surrounding_text_context_state: SurroundingTextContextState,
@@ -172,9 +173,32 @@ impl TextService {
         Ok(self.composition.try_borrow_mut()?)
     }
 
-    pub(crate) fn advance_mode_switch_generation(&mut self) -> u64 {
+    fn advance_mode_switch_generation(&mut self) -> u64 {
         self.mode_switch_generation = self.mode_switch_generation.wrapping_add(1);
         self.mode_switch_generation
+    }
+
+    pub(crate) fn begin_mode_switch(&mut self, mode: InputMode) -> u64 {
+        let generation = self.advance_mode_switch_generation();
+        self.pending_mode_switch = Some(mode);
+        generation
+    }
+
+    pub(crate) fn invalidate_mode_switch_requests(&mut self) {
+        self.advance_mode_switch_generation();
+        self.pending_mode_switch = None;
+    }
+
+    pub(crate) fn pending_mode_switch(&self) -> Option<InputMode> {
+        self.pending_mode_switch.clone()
+    }
+
+    pub(crate) fn clear_pending_mode_switch(&mut self, generation: u64) -> bool {
+        if self.mode_switch_generation != generation {
+            return false;
+        }
+        self.pending_mode_switch = None;
+        true
     }
 }
 
@@ -184,6 +208,7 @@ mod tests {
         CandidateWindowPositionState, CandidateWindowVisibilityState, SurroundingTextContextState,
         TextService,
     };
+    use crate::engine::input_mode::InputMode;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -227,10 +252,30 @@ mod tests {
     }
 
     #[test]
-    fn mode_switch_generation_advances_across_composition_lifecycle_changes() {
+    fn pending_mode_switch_tracks_the_latest_toggle_generation() {
         let mut text_service = TextService::default();
 
-        assert_eq!(text_service.advance_mode_switch_generation(), 1);
-        assert_eq!(text_service.advance_mode_switch_generation(), 2);
+        let first = text_service.begin_mode_switch(InputMode::Kana);
+        let second = text_service.begin_mode_switch(InputMode::Latin);
+
+        assert_eq!(first, 1);
+        assert_eq!(second, 2);
+        assert_eq!(text_service.pending_mode_switch(), Some(InputMode::Latin));
+        assert!(!text_service.clear_pending_mode_switch(first));
+        assert_eq!(text_service.pending_mode_switch(), Some(InputMode::Latin));
+        assert!(text_service.clear_pending_mode_switch(second));
+        assert_eq!(text_service.pending_mode_switch(), None);
+    }
+
+    #[test]
+    fn composition_lifecycle_invalidates_pending_mode_switches() {
+        let mut text_service = TextService::default();
+        let generation = text_service.begin_mode_switch(InputMode::Kana);
+
+        text_service.invalidate_mode_switch_requests();
+
+        assert_eq!(generation, 1);
+        assert_eq!(text_service.mode_switch_generation, 2);
+        assert_eq!(text_service.pending_mode_switch(), None);
     }
 }

--- a/crates/client/src/tsf/thread_mgr_event_sink.rs
+++ b/crates/client/src/tsf/thread_mgr_event_sink.rs
@@ -4,11 +4,7 @@ use windows::Win32::UI::TextServices::{
 
 use anyhow::Result;
 
-use crate::engine::{
-    client_action::ClientAction,
-    composition::CompositionState,
-    state::{keyboard_disabled_from_context, IMEState},
-};
+use crate::engine::state::{keyboard_disabled_from_context, IMEState};
 
 use super::factory::{TextServiceFactory, TextServiceFactory_Impl};
 
@@ -83,14 +79,7 @@ impl ITfThreadMgrEventSink_Impl for TextServiceFactory_Impl {
         self.set_keyboard_disabled_for_document_mgr(focus)?;
         ensure_ipc_service_for_tsf_event("OnSetFocus");
 
-        let actions = vec![ClientAction::EndComposition];
-        if IMEState::ipc_service()?.is_some() {
-            self.handle_action(&actions, CompositionState::None)?;
-        } else {
-            tracing::debug!(
-                "Skipping focus composition cleanup because IPC service is unavailable"
-            );
-        }
+        self.end_composition_for_tsf_event();
 
         if focus.is_none() {
             let mut text_service = self.borrow_mut()?;


### PR DESCRIPTION
## Summary
- `RequestEditSession` の要求結果と edit-session 実行結果を分離し、即時値を使う処理へ `TF_ES_SYNC` を明示しました。
- layout 更新とTSFイベント由来の終了処理は専用の非同期 session とし、破棄時 cleanup・stale callback 抑止・失敗時の composition 保持と server 再同期を追加しました。

## Background
- Issue: #133
- Issue close: 対象リリース公開・成果物確認後
- 非同期実行可能な edit session の結果を要求直後に読む実装により、アプリ依存の composition 失敗や候補位置欠落が起こり得ました。

## Changes
- TSF edit session: READ/READWRITE と SYNC/ASYNC を用途別に分離し、outer HRESULT・`phrSession`・callback completion を個別に検証
- Layout update: callback 未実行で解放された場合も exactly-once cleanup を行い、Context・composition の COM identity と世代で古い座標更新を抑止
- Composition recovery: TSF callback failure 後は失敗アクション保留・input ledger 復元・server restart/rebuild を行ってから再実行
- Shift-start recovery: suffix・属性・選択を先に準備し、置換後に境界 range を再取得して非冪等な `ShiftStart` を最後に実行
- TSF lifecycle: focus change・Deactivate の終了処理を非同期/best-effort 化し、後続 cleanup を継続
- Language bar: active composition の終了成功後にのみ mode/state/UI を更新し、旧 Context/composition/generation の callback を拒否
- Tests: lock refusal、callback failure recovery、async completion、callback 未実行 release、context destruction、server resynchronization、stale mode switch を追加

## Verification
- [x] GitHub Actions
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/30068056275
  - static/frontend: success
  - Windows Rust/Swift tests: success
  - installer build: success
- [x] Windows VM
  - composition regression: 132 passed (`.local/logs/vm-client-test-20260724-111926.log`)
  - latest edit-session regression: 15 passed (`.local/logs/vm-client-test-20260724-122650.log`)
  - mode-switch regression: 5 passed (`.local/logs/vm-client-test-20260724-131230.log`)
  - latest async terminal regression: 1 passed (`.local/logs/vm-client-test-20260724-132525.log`)
  - latest language-bar deferred replay: 13 passed (`.local/logs/vm-client-test-20260724-135816.log`)
  - Windows x64 `cargo check` / clippy `-D warnings`: success
  - Installer build: `.local/artifacts/azookey-setup-fix_133-edit-session-contract-20260724-112542.exe`
  - Silent install: exit code 0 (`.local/logs/win11-install-20260724-120020.log`)
  - Notepad: `konnichiha` → `こんにちは` の未確定表示・確定・改行を確認。画面は `.local/vm-debug/issue133-notepad-candidate.png` と `.local/vm-debug/issue133-notepad-committed.png`

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
