### PR TITLE
Handle Win32 wide string boundaries

### DIFF
--- a/crates/client/src/extension.rs
+++ b/crates/client/src/extension.rs
@@ -28,9 +28,9 @@ impl StringExt for &str {
     }
 
     fn to_wide(&self) -> Vec<u8> {
-        self.encode_utf16()
-            .flat_map(|c| c.to_le_bytes())
-            .chain(Some(0))
+        self.to_wide_16()
+            .into_iter()
+            .flat_map(u16::to_le_bytes)
             .collect()
     }
 }
@@ -131,5 +131,25 @@ pub trait VKeyExt {
 impl VKeyExt for VIRTUAL_KEY {
     fn is_pressed(self) -> bool {
         unsafe { GetKeyState(self.0 as i32) as u16 & 0x8000 != 0 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StringExt as _;
+
+    #[test]
+    fn win32_wide_boundary_registry_string_is_even_length_and_nul_terminated() {
+        let value = "azooKey 日本語 😀 𠮷";
+        let bytes = value.to_wide();
+        let expected = value
+            .encode_utf16()
+            .chain(Some(0))
+            .flat_map(u16::to_le_bytes)
+            .collect::<Vec<_>>();
+
+        assert_eq!(bytes, expected);
+        assert_eq!(bytes.len() % 2, 0);
+        assert_eq!(bytes.last_chunk::<2>(), Some(&[0, 0]));
     }
 }

--- a/crates/client/src/globals.rs
+++ b/crates/client/src/globals.rs
@@ -7,10 +7,10 @@ use std::{
     },
 };
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 
 use windows::{
-    core::GUID,
+    core::{Error as WindowsError, GUID},
     Win32::{
         Foundation::{FALSE, HMODULE, MAX_PATH},
         System::LibraryLoader::GetModuleFileNameW,
@@ -20,6 +20,9 @@ use windows::{
         },
     },
 };
+
+const INITIAL_MODULE_PATH_CAPACITY: usize = MAX_PATH as usize;
+const MAX_MODULE_PATH_CAPACITY: usize = 32_768;
 
 pub const CLSID_PREFIX: &str = "CLSID\\";
 pub const INPROC_SUFFIX: &str = "\\InProcServer32";
@@ -61,6 +64,34 @@ pub const TEXTSERVICE_LANGBARITEMSINK_COOKIE: u32 = 0;
 
 static DLL_MODULE_HANDLE: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
 static DLL_INSTANCE: OnceLock<Mutex<DllModule>> = OnceLock::new();
+
+fn read_module_path(mut read: impl FnMut(&mut [u16]) -> Result<usize>) -> anyhow::Result<String> {
+    let mut capacity = INITIAL_MODULE_PATH_CAPACITY;
+    loop {
+        let mut buffer = vec![0; capacity];
+        let length = read(&mut buffer)?;
+        if length == 0 {
+            anyhow::bail!("GetModuleFileNameW returned an empty module path");
+        }
+        if length > buffer.len() {
+            anyhow::bail!(
+                "GetModuleFileNameW returned invalid length {length} for buffer capacity {}",
+                buffer.len()
+            );
+        }
+        if length < buffer.len() {
+            return String::from_utf16(&buffer[..length])
+                .context("Module path returned by GetModuleFileNameW is not valid UTF-16");
+        }
+        if buffer.len() == MAX_MODULE_PATH_CAPACITY {
+            anyhow::bail!(
+                "Module path remained truncated at the Windows maximum buffer size of \
+                 {MAX_MODULE_PATH_CAPACITY} UTF-16 code units"
+            );
+        }
+        capacity = capacity.saturating_mul(2).min(MAX_MODULE_PATH_CAPACITY);
+    }
+}
 
 unsafe impl Sync for DllModule {}
 unsafe impl Send for DllModule {}
@@ -106,13 +137,16 @@ impl DllModule {
     }
 
     pub fn get_path() -> anyhow::Result<String> {
-        let path = {
-            let mut buffer: [u16; MAX_PATH as usize] = [0; MAX_PATH as usize];
-            let length = unsafe { GetModuleFileNameW(Self::module_handle()?, &mut buffer) };
-
-            String::from_utf16_lossy(&buffer[..length as usize])
-        };
-        Ok(path)
+        let module_handle = Self::module_handle()?;
+        read_module_path(|buffer| {
+            let length = unsafe { GetModuleFileNameW(module_handle, buffer) };
+            if length == 0 {
+                Err(anyhow::Error::new(WindowsError::from_win32()))
+                    .context("GetModuleFileNameW failed")
+            } else {
+                Ok(length as usize)
+            }
+        })
     }
 
     pub fn add_ref(&mut self) -> usize {
@@ -126,5 +160,52 @@ impl DllModule {
     #[allow(dead_code)]
     pub fn can_unload(&self) -> bool {
         self.ref_count.load(Ordering::SeqCst) == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{read_module_path, MAX_MODULE_PATH_CAPACITY};
+
+    #[test]
+    fn win32_wide_boundary_module_path_grows_past_max_path_without_truncation() {
+        let expected = format!(r"C:\{}\azookey.dll", "深い😀パス\\".repeat(80));
+        let encoded = expected.encode_utf16().collect::<Vec<_>>();
+        assert!(encoded.len() > 260);
+        let mut calls = 0;
+
+        let actual = read_module_path(|buffer| {
+            calls += 1;
+            if encoded.len() >= buffer.len() {
+                buffer.copy_from_slice(&encoded[..buffer.len()]);
+                Ok(buffer.len())
+            } else {
+                buffer[..encoded.len()].copy_from_slice(&encoded);
+                Ok(encoded.len())
+            }
+        })
+        .expect("long module path should be returned completely");
+
+        assert_eq!(actual, expected);
+        assert!(calls > 1);
+    }
+
+    #[test]
+    fn win32_wide_boundary_module_path_propagates_win32_failure() {
+        let error = read_module_path(|_| anyhow::bail!("simulated Win32 failure"))
+            .expect_err("failure must not be accepted as a module path");
+
+        assert!(error.to_string().contains("simulated Win32 failure"));
+    }
+
+    #[test]
+    fn win32_wide_boundary_module_path_rejects_persistent_truncation() {
+        let error = read_module_path(|buffer| Ok(buffer.len()))
+            .expect_err("persistent truncation must not be accepted as a module path");
+
+        assert!(error.to_string().contains("remained truncated"));
+        assert!(error
+            .to_string()
+            .contains(&MAX_MODULE_PATH_CAPACITY.to_string()));
     }
 }


### PR DESCRIPTION
## Summary
- `REG_SZ` の値を2-byte NUL終端されたUTF-16 byte列として保存します。
- DLL module pathを動的bufferで完全取得し、Win32 failureと上限切り詰めをerrorにします。

## Background
- Issue: #144
- Issue close: 対象リリース公開・成果物確認後
- 従来はregistry文字列が奇数byteで終端され、260文字を超えるDLL pathが切り詰められる可能性がありました。

## Changes
- 共通wide string helperでNUL code unit追加後にlittle-endian byte化
- `GetModuleFileNameW` bufferを`MAX_PATH`から32768 UTF-16 code unitまで拡張
- failure、invalid length、persistent truncation、invalid UTF-16を明示error化
- 非ASCII・絵文字REG_SZ、長いpath、failure、truncationの回帰testを追加

## Verification
- [x] Windows x64 `cargo check --tests`
- [x] Windows x64 clippy `-D warnings`
- [x] Windows VM unit tests: 4 passed (`.local/logs/vm-client-test-20260724-142322.log`)
- [x] Windows VM installer build: `.local/artifacts/azookey-setup-fix_144-win32-wide-string-boundaries-20260724-142750.exe`
- [x] silent install後、installer配置DLLを328文字pathから登録し `InProcServer32` 完全一致を確認（`.local/logs/win11-install-20260724-151857.log`）
- [x] GitHub Actions: https://github.com/batao9/azooKey-Windows/actions/runs/30069511260

## Checklist
- [x] 影響範囲を確認した
- [x] 回帰testを追加した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
