### PR TITLE
Use UTF-16 units for TSF text ranges

### DIFF
--- a/crates/client/src/extension.rs
+++ b/crates/client/src/extension.rs
@@ -11,6 +11,14 @@ use windows::{
 
 use crate::check_win32_err;
 
+pub fn utf16_code_unit_len(value: &str) -> anyhow::Result<i32> {
+    value
+        .encode_utf16()
+        .count()
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("UTF-16 text length exceeds the TSF i32 offset range"))
+}
+
 // string extension
 pub trait StringExt {
     fn to_wide_16(&self) -> Vec<u16>;
@@ -136,7 +144,7 @@ impl VKeyExt for VIRTUAL_KEY {
 
 #[cfg(test)]
 mod tests {
-    use super::StringExt as _;
+    use super::{utf16_code_unit_len, StringExt as _};
 
     #[test]
     fn win32_wide_boundary_registry_string_is_even_length_and_nul_terminated() {
@@ -151,5 +159,12 @@ mod tests {
         assert_eq!(bytes, expected);
         assert_eq!(bytes.len() % 2, 0);
         assert_eq!(bytes.last_chunk::<2>(), Some(&[0, 0]));
+    }
+
+    #[test]
+    fn utf16_tsf_boundary_counts_supplementary_characters_as_surrogate_pairs() {
+        assert_eq!(utf16_code_unit_len("😀かな").unwrap(), 4);
+        assert_eq!(utf16_code_unit_len("か😀な").unwrap(), 4);
+        assert_eq!(utf16_code_unit_len("かな𠮷").unwrap(), 4);
     }
 }

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -19,7 +19,7 @@ use anyhow::Result;
 
 use crate::{
     engine::{ipc_service::current_input_trace_request_id, state::IMEState},
-    extension::StringExt as _,
+    extension::{utf16_code_unit_len, StringExt as _},
     globals::GUID_DISPLAY_ATTRIBUTE,
 };
 use shared::proto::WindowPosition;
@@ -258,13 +258,8 @@ fn close_composition_callback(
         if discard_text {
             range.SetText(cookie, TF_ST_CORRECTION, &[])?;
         } else {
-            let mut text = vec![0; 1024];
-            let mut text_len = 1024;
-
             let range_new = range.Clone()?;
-            range_new.GetText(cookie, TF_TF_MOVESTART, &mut text, &mut text_len)?;
-
-            text = text[..text_len as usize].to_vec();
+            let text = read_all_range_text(cookie, &range_new)?;
             range.SetText(cookie, TF_ST_CORRECTION, &text)?;
         }
 
@@ -284,6 +279,44 @@ fn close_composition_callback(
         composition.EndComposition(cookie)?;
         Ok(())
     })
+}
+
+const RANGE_TEXT_CHUNK_CODE_UNITS: usize = 1024;
+
+fn collect_range_text(
+    mut read: impl FnMut(&mut [u16]) -> anyhow::Result<usize>,
+) -> anyhow::Result<Vec<u16>> {
+    let mut text = Vec::new();
+    loop {
+        let mut chunk = [0u16; RANGE_TEXT_CHUNK_CODE_UNITS];
+        let length = read(&mut chunk)?;
+        if length > chunk.len() {
+            anyhow::bail!(
+                "ITfRange::GetText returned {length} UTF-16 code units for a {}-unit buffer",
+                chunk.len()
+            );
+        }
+        if length == 0 {
+            return Ok(text);
+        }
+        text.extend_from_slice(&chunk[..length]);
+    }
+}
+
+fn read_all_range_text(cookie: u32, range: &ITfRange) -> anyhow::Result<Vec<u16>> {
+    collect_range_text(|chunk| unsafe {
+        let mut length = 0;
+        range.GetText(cookie, TF_TF_MOVESTART, chunk, &mut length)?;
+        usize::try_from(length)
+            .map_err(|_| anyhow::anyhow!("ITfRange::GetText returned a negative length"))
+    })
+}
+
+fn prepare_set_text(text: &str, subtext: &str) -> anyhow::Result<(i32, Vec<u16>)> {
+    Ok((
+        utf16_code_unit_len(text)?,
+        format!("{text}{subtext}").as_str().to_wide_16_unpadded(),
+    ))
 }
 
 fn has_same_com_identity<I: Interface>(left: &I, right: &I) -> bool {
@@ -547,10 +580,7 @@ impl TextServiceFactory {
                 text_service.tid,
                 text_service.context()?,
                 Rc::new({
-                    let text_len = text.chars().count() as i32;
-
-                    // unpadded is all you need!
-                    let text = format!("{text}{subtext}").as_str().to_wide_16_unpadded();
+                    let (text_len, text) = prepare_set_text(text, subtext)?;
                     let context = text_service.context::<ITfContext>()?;
                     let display_attribute_atom = text_service.display_attribute_atom.clone();
 
@@ -601,7 +631,7 @@ impl TextServiceFactory {
                 text_service.tid,
                 text_service.context()?,
                 Rc::new({
-                    let text_len = text.chars().count() as i32;
+                    let text_len = utf16_code_unit_len(text)?;
                     let subtext = subtext.to_wide_16_unpadded();
                     let context = text_service.context::<ITfContext>()?;
                     let display_attribute_atom = text_service.display_attribute_atom.clone();
@@ -1027,16 +1057,65 @@ impl TextServiceFactory {
 #[cfg(test)]
 mod tests {
     use super::{
-        caret_position_or_none, commit_shift_start_after_prepare,
+        caret_position_or_none, collect_range_text, commit_shift_start_after_prepare,
         complete_async_edit_session_request, complete_async_position_request,
-        complete_sync_edit_session, is_non_destructive_edit_session_error, AsyncEditSession,
-        EditSessionFailure,
+        complete_sync_edit_session, is_non_destructive_edit_session_error, prepare_set_text,
+        AsyncEditSession, EditSessionFailure,
     };
     use std::{cell::Cell, rc::Rc};
     use windows::{
         core::HRESULT,
         Win32::UI::TextServices::{TF_E_DISCONNECTED, TF_E_LOCKED, TF_S_ASYNC},
     };
+
+    fn collect_simulated_range_text(text: &[u16]) -> Vec<u16> {
+        let mut cursor = 0;
+        collect_range_text(|buffer| {
+            let length = (text.len() - cursor).min(buffer.len());
+            buffer[..length].copy_from_slice(&text[cursor..cursor + length]);
+            cursor += length;
+            Ok(length)
+        })
+        .expect("simulated range should be read completely")
+    }
+
+    #[test]
+    fn utf16_tsf_boundary_reads_1023_1024_and_1025_code_units_without_truncation() {
+        for length in [1023, 1024, 1025] {
+            let expected = "a".repeat(length).encode_utf16().collect::<Vec<_>>();
+            assert_eq!(collect_simulated_range_text(&expected), expected);
+        }
+    }
+
+    #[test]
+    fn utf16_tsf_boundary_preserves_surrogate_pair_split_across_chunks() {
+        let expected = format!("{}😀末尾", "a".repeat(1023))
+            .encode_utf16()
+            .collect::<Vec<_>>();
+
+        let actual = collect_simulated_range_text(&expected);
+
+        assert_eq!(actual, expected);
+        assert_eq!(
+            String::from_utf16(&actual).unwrap(),
+            format!("{}😀末尾", "a".repeat(1023))
+        );
+    }
+
+    #[test]
+    fn utf16_tsf_boundary_prepares_display_range_and_suffix_in_code_units() {
+        for text in ["😀かな", "か😀な", "かな𠮷"] {
+            let (display_length, combined) =
+                prepare_set_text(text, "😀後").expect("composition text should be prepared");
+
+            assert_eq!(display_length, 4);
+            assert_eq!(
+                String::from_utf16(&combined).unwrap(),
+                format!("{text}😀後")
+            );
+            assert_eq!(combined.len(), 7);
+        }
+    }
 
     #[test]
     fn sync_edit_session_returns_callback_value_after_both_results_succeed() {

--- a/crates/client/src/tsf/surrounded_text.rs
+++ b/crates/client/src/tsf/surrounded_text.rs
@@ -13,9 +13,16 @@ use windows::{
     },
 };
 
-use crate::engine::{ipc_service::current_input_trace_request_id, state::IMEState};
+use crate::{
+    engine::{ipc_service::current_input_trace_request_id, state::IMEState},
+    extension::utf16_code_unit_len,
+};
 
 use super::{edit_session::read_edit_session, factory::TextServiceFactory};
+
+fn preview_end_shift(preview: &str) -> anyhow::Result<i32> {
+    Ok(-utf16_code_unit_len(preview)?)
+}
 
 impl TextServiceFactory {
     fn log_update_context_performance(
@@ -134,12 +141,11 @@ impl TextServiceFactory {
             };
 
             let edit_session_start = trace_request_id.map(|_| Instant::now());
+            let preview_end_shift = preview_end_shift(preview)?;
             let preceding_text = read_edit_session::<String>(
                 tid,
                 parent_context.clone(),
                 Rc::new({
-                    let preview_count = preview.chars().count() as i32;
-
                     move |cookie| {
                         // 2. Get the selection from the parent context.
                         let mut pselection: [TF_SELECTION; 1] = [TF_SELECTION::default()];
@@ -179,7 +185,7 @@ impl TextServiceFactory {
 
                         preceding_range.ShiftEnd(
                             cookie,
-                            -preview_count,
+                            preview_end_shift,
                             &mut preceding_range_shifted,
                             &halt_cond,
                         )?;
@@ -267,5 +273,17 @@ impl TextServiceFactory {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::preview_end_shift;
+
+    #[test]
+    fn utf16_tsf_boundary_surrounded_text_excludes_preview_by_code_units() {
+        assert_eq!(preview_end_shift("😀かな").unwrap(), -4);
+        assert_eq!(preview_end_shift("か😀な").unwrap(), -4);
+        assert_eq!(preview_end_shift("かな𠮷").unwrap(), -4);
     }
 }


### PR DESCRIPTION
## Summary
- TSFへ渡すtext length・range offsetをUTF-16 code unit基準へ統一します。
- composition確定時のtext取得を1024-unit chunkで終端まで繰り返し、長文の切り詰めを防ぎます。

## Background
- Issue: #134
- Issue close: 対象リリース公開・成果物確認後
- RustのUnicode scalar数とTSFのUTF-16 code unit数の差により、BMP外文字で表示属性・cursor・surrounded text範囲がずれる可能性がありました。

## Changes
- checked `utf16_code_unit_len` helperを追加
- `set_text`、`shift_start`、surrounded preview除外offsetをUTF-16単位化
- `ITfRange::GetText(TF_TF_MOVESTART)` を0件まで反復し、元rangeへ完全なUTF-16列を再設定
- BMP外文字の先頭・中央・末尾、1023/1024/1025 units、chunk境界surrogate pairの回帰testを追加

## Verification
- [x] Windows x64 `cargo check --tests`
- [x] Windows x64 clippy `-D warnings`
- [x] Windows VM regression: 5 passed (`.local/logs/vm-client-test-20260724-152403.log`)
- [x] GitHub Actions run 30072404705: static/frontend・Windows Swift/Rust・installer build success
- [x] CI installer SHA-256 verified and VM silent install success (`.local/logs/win11-install-20260724-155222.log`)
- [x] Notepad: `あ😀い` の未確定表示と確定bytesを確認
- [x] Notepad: 絵文字512個＋`あ`を単一compositionとして表示し、確定後も513 code points / 1025 UTF-16 units / emoji 512個を完全一致で確認
- [x] Edge address bar: `あ😀い` の未確定表示を確認
- [x] 検証後にWindows VMを通常シャットダウン

## Checklist
- [x] 影響範囲を確認した
- [x] 回帰testを追加した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
