### PR TITLE
Serialize settings updates and debounce profile saves

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -71,6 +71,10 @@ jobs:
       working-directory: frontend
       run: npm run typecheck
 
+    - name: Test frontend config saving
+      working-directory: frontend
+      run: npm test
+
     - name: Test candidate scroller
       run: node --test crates/ui/tests/candidate_scroller.test.cjs
 

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -443,7 +443,7 @@ fn legacy_groups_from_symbol_fullwidth(
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct GeneralConfig {
     #[serde(default)]
     pub punctuation_style: PunctuationStyle,
@@ -488,7 +488,7 @@ impl Default for GeneralConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct RomajiRule {
     pub input: String,
     pub output: String,
@@ -909,7 +909,7 @@ mod tests {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct RomajiTableConfig {
     #[serde(default = "default_romaji_rows")]
     pub rows: Vec<RomajiRule>,
@@ -923,14 +923,14 @@ impl Default for RomajiTableConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct ZenzaiConfig {
     pub enable: bool,
     pub profile: String,
     pub backend: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct ShortcutConfig {
     #[serde(default = "default_shortcut_enabled")]
     pub ctrl_space_toggle: bool,
@@ -940,7 +940,7 @@ pub struct ShortcutConfig {
     pub eisu_toggle: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct DebugConfig {
     #[serde(default)]
     pub server_log_enabled: bool,
@@ -960,7 +960,7 @@ impl Default for DebugConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct CharacterWidthConfig {
     #[serde(default = "default_symbol_fullwidth_map")]
     pub symbol_fullwidth: HashMap<String, bool>,
@@ -968,13 +968,13 @@ pub struct CharacterWidthConfig {
     pub groups: CharacterWidthGroups,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct UserDictionaryEntry {
     pub reading: String,
     pub word: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
 pub struct UserDictionaryConfig {
     #[serde(default)]
     pub entries: Vec<UserDictionaryEntry>,
@@ -1037,7 +1037,7 @@ impl Default for ShortcutConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct AppConfig {
     pub version: String,
     #[serde(default)]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "sync-version": "node ../scripts/sync-version.mjs",
     "prebuild": "npm run sync-version",
     "dev": "vite",
+    "test": "node --test tests/*.test.mjs",
     "typecheck": "tsc --noEmit",
     "build": "tsc && vite build",
     "pretauri": "npm run sync-version",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ windows-registry = "0.2"
 version = "0.58.0"
 features = [
     "Win32_Foundation",
+    "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_System_Registry",
     "Win32_System_Diagnostics_ToolHelp",

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -3,8 +3,16 @@ mod server_process;
 mod updater;
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use shared::{AppConfig, AppConfigLoadResult, ConfigError, ConfigRecovery, RomajiRule};
 use std::{path::PathBuf, sync::Mutex, time::Duration};
+use windows::{
+    core::w,
+    Win32::{
+        Foundation::{CloseHandle, HANDLE, WAIT_ABANDONED, WAIT_OBJECT_0},
+        System::Threading::{CreateMutexW, ReleaseMutex, WaitForSingleObject, INFINITE},
+    },
+};
 
 use anyhow::Context as _;
 
@@ -12,6 +20,8 @@ use anyhow::Context as _;
 pub struct AppState {
     settings: Mutex<AppConfig>,
     ipc: Mutex<Option<ipc::IPCService>>,
+    config_update_lock: Mutex<()>,
+    server_config_dirty: Mutex<bool>,
     startup_notice: Mutex<Option<ConfigStartupNotice>>,
 }
 
@@ -51,6 +61,8 @@ impl AppState {
         AppState {
             settings: Mutex::new(settings),
             ipc: Mutex::new(ipc),
+            config_update_lock: Mutex::new(()),
+            server_config_dirty: Mutex::new(false),
             startup_notice: Mutex::new(startup_notice),
         }
     }
@@ -67,7 +79,36 @@ struct ConfigStartupNotice {
 struct UpdateConfigResponse {
     saved: bool,
     server_applied: bool,
+    changed: bool,
+    config: AppConfig,
     message: Option<String>,
+}
+
+struct CrossProcessConfigGuard(HANDLE);
+
+impl CrossProcessConfigGuard {
+    fn acquire() -> Result<Self, String> {
+        let handle = unsafe { CreateMutexW(None, false, w!("Local\\AzookeyWindowsConfigUpdate")) }
+            .map_err(|error| format!("failed to create config update mutex: {error}"))?;
+
+        let wait = unsafe { WaitForSingleObject(handle, INFINITE) };
+        if wait == WAIT_OBJECT_0 || wait == WAIT_ABANDONED {
+            Ok(Self(handle))
+        } else {
+            let _ = unsafe { CloseHandle(handle) };
+            Err(format!(
+                "failed to acquire config update mutex: wait={}",
+                wait.0
+            ))
+        }
+    }
+}
+
+impl Drop for CrossProcessConfigGuard {
+    fn drop(&mut self) {
+        let _ = unsafe { ReleaseMutex(self.0) };
+        let _ = unsafe { CloseHandle(self.0) };
+    }
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -122,8 +163,21 @@ fn greet(name: &str) -> String {
 
 #[tauri::command]
 fn get_config(state: tauri::State<AppState>) -> AppConfig {
-    let config = state.settings.lock().unwrap();
-    config.clone()
+    get_config_impl(&state)
+}
+
+fn get_config_impl(state: &AppState) -> AppConfig {
+    let _update_guard = state.config_update_lock.lock().unwrap();
+    match AppConfig::read() {
+        Ok(config) => {
+            *state.settings.lock().unwrap() = config.clone();
+            config
+        }
+        Err(error) => {
+            eprintln!("Failed to refresh settings from disk: {error}");
+            state.settings.lock().unwrap().clone()
+        }
+    }
 }
 
 #[tauri::command]
@@ -134,19 +188,89 @@ fn take_config_startup_notice(state: tauri::State<AppState>) -> Option<ConfigSta
 #[tauri::command]
 fn update_config(
     state: tauri::State<AppState>,
+    base_config: AppConfig,
     new_config: AppConfig,
 ) -> Result<UpdateConfigResponse, String> {
-    update_config_impl(&state, new_config)
+    update_config_impl(&state, base_config, new_config)
+}
+
+fn apply_config_delta(current: &mut Value, base: &Value, updated: &Value) {
+    if base == updated {
+        return;
+    }
+
+    let (Some(current_object), Some(base_object), Some(updated_object)) = (
+        current.as_object_mut(),
+        base.as_object(),
+        updated.as_object(),
+    ) else {
+        *current = updated.clone();
+        return;
+    };
+
+    for (key, updated_value) in updated_object {
+        match base_object.get(key) {
+            Some(base_value) if base_value == updated_value => {}
+            Some(base_value) => {
+                if let Some(current_value) = current_object.get_mut(key) {
+                    apply_config_delta(current_value, base_value, updated_value);
+                } else {
+                    current_object.insert(key.clone(), updated_value.clone());
+                }
+            }
+            None => {
+                current_object.insert(key.clone(), updated_value.clone());
+            }
+        }
+    }
+
+    for key in base_object.keys() {
+        if !updated_object.contains_key(key) {
+            current_object.remove(key);
+        }
+    }
+}
+
+fn merge_config_update(
+    current_config: AppConfig,
+    base_config: AppConfig,
+    new_config: AppConfig,
+) -> Result<AppConfig, String> {
+    let mut current = serde_json::to_value(current_config).map_err(|error| error.to_string())?;
+    let base = serde_json::to_value(base_config).map_err(|error| error.to_string())?;
+    let updated = serde_json::to_value(new_config).map_err(|error| error.to_string())?;
+    apply_config_delta(&mut current, &base, &updated);
+    serde_json::from_value(current).map_err(|error| error.to_string())
 }
 
 fn update_config_impl(
     state: &AppState,
+    base_config: AppConfig,
     new_config: AppConfig,
 ) -> Result<UpdateConfigResponse, String> {
-    {
-        let mut config = state.settings.lock().unwrap();
+    let _update_guard = state.config_update_lock.lock().unwrap();
+    let _cross_process_guard = CrossProcessConfigGuard::acquire()?;
+    let current_config = AppConfig::read().unwrap_or_else(|error| {
+        eprintln!("Failed to read latest settings before update: {error}");
+        state.settings.lock().unwrap().clone()
+    });
+    let new_config = merge_config_update(current_config.clone(), base_config, new_config)?;
+    let changed = current_config != new_config;
+    if changed {
         new_config.write().map_err(|error| error.to_string())?;
-        *config = new_config;
+    }
+    *state.settings.lock().unwrap() = new_config.clone();
+
+    if changed {
+        *state.server_config_dirty.lock().unwrap() = true;
+    } else if !*state.server_config_dirty.lock().unwrap() {
+        return Ok(UpdateConfigResponse {
+            saved: true,
+            server_applied: true,
+            changed: false,
+            config: new_config,
+            message: None,
+        });
     }
 
     if let Some(ipc) = state.ipc.lock().unwrap().as_mut() {
@@ -155,6 +279,8 @@ fn update_config_impl(
             return Ok(UpdateConfigResponse {
                 saved: true,
                 server_applied: false,
+                changed,
+                config: new_config,
                 message: Some(error.to_string()),
             });
         }
@@ -162,13 +288,18 @@ fn update_config_impl(
         return Ok(UpdateConfigResponse {
             saved: true,
             server_applied: false,
+            changed,
+            config: new_config,
             message: Some("IPC service is not initialized".to_string()),
         });
     }
 
+    *state.server_config_dirty.lock().unwrap() = false;
     Ok(UpdateConfigResponse {
         saved: true,
         server_applied: true,
+        changed,
+        config: new_config,
         message: None,
     })
 }
@@ -221,13 +352,20 @@ fn restart_server(state: tauri::State<AppState>) -> Result<(), String> {
 }
 
 fn restart_server_impl(state: &AppState) -> Result<(), anyhow::Error> {
-    let config = state.settings.lock().unwrap().clone();
+    let _update_guard = state.config_update_lock.lock().unwrap();
+    let _cross_process_guard = CrossProcessConfigGuard::acquire().map_err(anyhow::Error::msg)?;
+    let config = AppConfig::read().unwrap_or_else(|error| {
+        eprintln!("Failed to refresh settings before server restart: {error}");
+        state.settings.lock().unwrap().clone()
+    });
+    *state.settings.lock().unwrap() = config.clone();
 
     server_process::restart_server(&config)?;
 
     let ipc = ipc::IPCService::new_with_timeout(Duration::from_secs(10))
         .context("Server restarted, but IPC reconnect failed")?;
     *state.ipc.lock().unwrap() = Some(ipc);
+    *state.server_config_dirty.lock().unwrap() = false;
 
     Ok(())
 }
@@ -422,6 +560,8 @@ mod tests {
         AppState {
             settings: Mutex::new(AppConfig::default()),
             ipc: Mutex::new(None),
+            config_update_lock: Mutex::new(()),
+            server_config_dirty: Mutex::new(false),
             startup_notice: Mutex::new(None),
         }
     }
@@ -434,25 +574,82 @@ mod tests {
         let mut config = AppConfig::default();
         config.zenzai.enable = true;
 
-        let result = update_config_impl(&state, config).unwrap();
+        let result = update_config_impl(&state, AppConfig::default(), config).unwrap();
 
         assert!(result.saved);
         assert!(!result.server_applied);
+        assert!(result.changed);
         assert!(result.message.is_some());
         assert!(temp.path().join("Azookey").join("settings.json").exists());
         assert!(state.settings.lock().unwrap().zenzai.enable);
     }
 
     #[test]
-    fn update_config_returns_error_when_save_fails() {
+    fn update_config_skips_disk_and_server_for_unchanged_settings() {
         let _appdata = AppDataGuard::unset();
         let state = test_state();
 
-        let error = update_config_impl(&state, AppConfig::default())
+        let config = AppConfig::default();
+        let result = update_config_impl(&state, config.clone(), config).unwrap();
+
+        assert!(result.saved);
+        assert!(result.server_applied);
+        assert!(!result.changed);
+        assert!(result.message.is_none());
+    }
+
+    #[test]
+    fn update_config_returns_error_when_save_fails() {
+        let _appdata = AppDataGuard::unset();
+        let state = test_state();
+        let mut config = AppConfig::default();
+        config.zenzai.enable = true;
+
+        let error = update_config_impl(&state, AppConfig::default(), config)
             .expect_err("save failure should be returned to the UI");
 
         assert!(error.contains("APPDATA"));
         assert!(!state.settings.lock().unwrap().zenzai.enable);
+    }
+
+    #[test]
+    fn unchanged_settings_remain_pending_after_server_apply_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let _appdata = AppDataGuard::set(temp.path());
+        let state = test_state();
+        let mut config = AppConfig::default();
+        config.zenzai.profile = "profile".to_string();
+
+        let first = update_config_impl(&state, AppConfig::default(), config.clone()).unwrap();
+        let retry = update_config_impl(&state, config.clone(), config).unwrap();
+
+        assert!(first.changed);
+        assert!(!first.server_applied);
+        assert!(!retry.changed);
+        assert!(!retry.server_applied);
+        assert!(*state.server_config_dirty.lock().unwrap());
+    }
+
+    #[test]
+    fn stale_full_config_update_preserves_newer_unrelated_fields() {
+        let temp = tempfile::tempdir().unwrap();
+        let _appdata = AppDataGuard::set(temp.path());
+        let state = test_state();
+        let base = AppConfig::default();
+        let mut current = base.clone();
+        current.zenzai.profile = "newer profile".to_string();
+        current.write().unwrap();
+        let mut stale_update = base.clone();
+        stale_update.shortcuts.eisu_toggle = true;
+
+        let result = update_config_impl(&state, base, stale_update).unwrap();
+
+        assert!(result.changed);
+        assert_eq!(result.config.zenzai.profile, "newer profile");
+        assert!(result.config.shortcuts.eisu_toggle);
+        let persisted = AppConfig::read().unwrap();
+        assert_eq!(persisted.zenzai.profile, "newer profile");
+        assert!(persisted.shortcuts.eisu_toggle);
     }
 
     #[test]

--- a/frontend/src/lib/config-save-controller.d.ts
+++ b/frontend/src/lib/config-save-controller.d.ts
@@ -1,0 +1,20 @@
+export type ConfigSaveState = "dirty" | "saving" | "saved" | "error";
+
+export declare const createSerialTaskQueue: () => <T>(
+    task: () => T | Promise<T>,
+) => Promise<T>;
+
+export declare const createDebouncedSaver: <T, R>({
+    save,
+    onStateChange,
+    delayMs,
+}: {
+    save: (value: T) => R | Promise<R>;
+    onStateChange?: (state: ConfigSaveState) => void;
+    delayMs?: number;
+}) => {
+    schedule: (value: T) => void;
+    flush: () => Promise<R | undefined>;
+    resume: () => void;
+    dispose: () => Promise<R | undefined>;
+};

--- a/frontend/src/lib/config-save-controller.js
+++ b/frontend/src/lib/config-save-controller.js
@@ -1,0 +1,107 @@
+export const createSerialTaskQueue = () => {
+    let tail = Promise.resolve();
+
+    return (task) => {
+        const result = tail.then(task, task);
+        tail = result.then(
+            () => undefined,
+            () => undefined,
+        );
+        return result;
+    };
+};
+
+export const createDebouncedSaver = ({
+    save,
+    onStateChange = () => {},
+    delayMs = 500,
+}) => {
+    let timer = null;
+    let pending = null;
+    let revision = 0;
+    let disposed = false;
+
+    const clearTimer = () => {
+        if (timer !== null) {
+            clearTimeout(timer);
+            timer = null;
+        }
+    };
+
+    const runSave = ({ value, revision: requestRevision }, notify) => {
+        if (notify) {
+            onStateChange("saving");
+        }
+
+        let saveResult;
+        try {
+            saveResult = save(value);
+        } catch (error) {
+            saveResult = Promise.reject(error);
+        }
+
+        return Promise.resolve(saveResult)
+            .then(
+                (result) => {
+                    if (
+                        notify &&
+                        !disposed &&
+                        requestRevision === revision
+                    ) {
+                        onStateChange(result === null ? "error" : "saved");
+                    }
+                    return result;
+                },
+                (error) => {
+                    if (
+                        notify &&
+                        !disposed &&
+                        requestRevision === revision
+                    ) {
+                        onStateChange("error");
+                    }
+                    throw error;
+                },
+            );
+    };
+
+    const flush = () => {
+        clearTimer();
+        if (pending === null) {
+            return Promise.resolve(undefined);
+        }
+
+        const request = pending;
+        pending = null;
+        return runSave(request, !disposed);
+    };
+
+    return {
+        schedule(value) {
+            disposed = false;
+            revision += 1;
+            pending = { value, revision };
+            clearTimer();
+            onStateChange("dirty");
+            timer = setTimeout(() => {
+                timer = null;
+                void flush().catch(() => undefined);
+            }, delayMs);
+        },
+        flush,
+        resume() {
+            disposed = false;
+        },
+        dispose() {
+            clearTimer();
+            disposed = true;
+            if (pending === null) {
+                return Promise.resolve(undefined);
+            }
+
+            const request = pending;
+            pending = null;
+            return runSave(request, false);
+        },
+    };
+};

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
+import { createSerialTaskQueue } from "@/lib/config-save-controller.js";
 
 type ConfigStartupNotice = {
     kind: string;
@@ -10,6 +11,8 @@ type ConfigStartupNotice = {
 type UpdateConfigResponse = {
     saved: boolean;
     server_applied: boolean;
+    changed: boolean;
+    config: any;
     message?: string | null;
 };
 
@@ -25,6 +28,10 @@ type UpdateInstallResult = {
 
 const SERVER_APPLY_WARNING =
     "設定を保存しましたが、IME への反映に失敗しました。再起動後に反映されます。";
+const enqueueConfigUpdate = createSerialTaskQueue();
+
+export const getConfigAfterPendingUpdates = async () =>
+    enqueueConfigUpdate(() => invoke<any>("get_config"));
 
 export const showConfigStartupNoticeOnce = async () => {
     try {
@@ -73,24 +80,27 @@ export const showUpdateInstallResultOnce = async () => {
 export const saveConfigWithToast = async (
     updater: (config: any) => void,
     failureMessage = "設定の更新に失敗しました",
-) => {
-    try {
-        const data = await invoke<any>("get_config");
-        updater(data);
-        const result = await invoke<UpdateConfigResponse>("update_config", {
-            newConfig: data,
-        });
-
-        if (result.saved && !result.server_applied) {
-            toast(SERVER_APPLY_WARNING, {
-                description: result.message ?? undefined,
-                duration: 10000,
+) =>
+    enqueueConfigUpdate(async () => {
+        try {
+            const baseConfig = await invoke<any>("get_config");
+            const data = structuredClone(baseConfig);
+            updater(data);
+            const result = await invoke<UpdateConfigResponse>("update_config", {
+                baseConfig,
+                newConfig: data,
             });
-        }
 
-        return data;
-    } catch (_error) {
-        toast(failureMessage);
-        return null;
-    }
-};
+            if (result.saved && !result.server_applied) {
+                toast(SERVER_APPLY_WARNING, {
+                    description: result.message ?? undefined,
+                    duration: 10000,
+                });
+            }
+
+            return result.config;
+        } catch (_error) {
+            toast(failureMessage);
+            return null;
+        }
+    });

--- a/frontend/src/pages/zenzai.tsx
+++ b/frontend/src/pages/zenzai.tsx
@@ -8,7 +8,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select"
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner"
 import { invoke } from '@tauri-apps/api/core';
 import {
@@ -17,7 +17,23 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { saveConfigWithToast } from "@/lib/config";
+import {
+    getConfigAfterPendingUpdates,
+    saveConfigWithToast,
+} from "@/lib/config";
+import {
+    createDebouncedSaver,
+    type ConfigSaveState,
+} from "@/lib/config-save-controller.js";
+
+const PROFILE_SAVE_DELAY_MS = 500;
+
+const PROFILE_SAVE_LABELS: Record<ConfigSaveState, string> = {
+    dirty: "未保存の変更があります",
+    saving: "保存中…",
+    saved: "保存済み",
+    error: "保存できませんでした。入力内容は画面に保持されています。",
+};
 
 const ToolTipSelectItem = ({
     name,
@@ -58,17 +74,35 @@ export const Zenzai = () => {
         cuda: false,
         vulkan: false,
     });
+    const [profileSaveState, setProfileSaveState] =
+        useState<ConfigSaveState>("saved");
+    const profileEdited = useRef(false);
+    const profileSaver = useMemo(
+        () =>
+            createDebouncedSaver<string, any>({
+                delayMs: PROFILE_SAVE_DELAY_MS,
+                onStateChange: setProfileSaveState,
+                save: (profile) =>
+                    saveConfigWithToast((config) => {
+                        config.zenzai.profile = profile;
+                    }),
+            }),
+        [],
+    );
 
     // Load config on component mount
     useEffect(() => {
-        invoke<any>("get_config")
+        profileSaver.resume();
+        getConfigAfterPendingUpdates()
             .then((data) => {
                 const zenzai = data.zenzai;
-                setValue({
+                setValue((previous) => ({
                     enable: zenzai.enable,
-                    profile: zenzai.profile,
+                    profile: profileEdited.current
+                        ? previous.profile
+                        : zenzai.profile,
                     backend: zenzai.backend,
-                });
+                }));
             })
             .catch(() => {
                 // Keep default values if config fetch fails
@@ -81,7 +115,11 @@ export const Zenzai = () => {
                 vulkan: capability["vulkan"],
             });
         })
-    }, []);
+
+        return () => {
+            void profileSaver.dispose();
+        };
+    }, [profileSaver]);
 
     const updateConfig = (updater: (config: any) => void) =>
         saveConfigWithToast(updater);
@@ -98,11 +136,9 @@ export const Zenzai = () => {
 
     const handleProfileChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
         const newProfile = event.target.value;
+        profileEdited.current = true;
         setValue((prev) => ({ ...prev, profile: newProfile }));
-        
-        updateConfig((data) => {
-            data.zenzai.profile = newProfile;
-        });
+        profileSaver.schedule(newProfile);
     };
 
     const handleBackendChange = async (backend: string) => {
@@ -151,7 +187,26 @@ export const Zenzai = () => {
                             </p>
                         </div>
                     </div>
-                    <Textarea placeholder="例）山田太郎、数学科の学生。" value={value.profile} disabled={!value.enable} onChange={handleProfileChange} />
+                    <Textarea
+                        placeholder="例）山田太郎、数学科の学生。"
+                        value={value.profile}
+                        disabled={!value.enable}
+                        aria-invalid={profileSaveState === "error"}
+                        onChange={handleProfileChange}
+                        onBlur={() => {
+                            void profileSaver.flush();
+                        }}
+                    />
+                    <p
+                        className={
+                            profileSaveState === "error"
+                                ? "text-xs text-destructive"
+                                : "text-xs text-muted-foreground"
+                        }
+                        aria-live="polite"
+                    >
+                        {PROFILE_SAVE_LABELS[profileSaveState]}
+                    </p>
                 </div>
                 <div className="flex items-center space-x-4 rounded-md border p-4">
                     <Cpu />

--- a/frontend/tests/config-save-controller.test.mjs
+++ b/frontend/tests/config-save-controller.test.mjs
@@ -1,0 +1,134 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+    createDebouncedSaver,
+    createSerialTaskQueue,
+} from "../src/lib/config-save-controller.js";
+
+test("serialized updates preserve changes from different settings", async () => {
+    const enqueue = createSerialTaskQueue();
+    let config = { profile: "", otherSetting: false };
+    let loadCount = 0;
+    let releaseFirst;
+    const firstGate = new Promise((resolve) => {
+        releaseFirst = resolve;
+    });
+
+    const update = (mutate, gate = Promise.resolve()) =>
+        enqueue(async () => {
+            loadCount += 1;
+            const next = structuredClone(config);
+            mutate(next);
+            await gate;
+            config = next;
+        });
+
+    const first = update((next) => {
+        next.profile = "latest profile";
+    }, firstGate);
+    const second = update((next) => {
+        next.otherSetting = true;
+    });
+
+    await Promise.resolve();
+    assert.equal(loadCount, 1, "the second read must wait for the first write");
+
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    assert.deepEqual(config, {
+        profile: "latest profile",
+        otherSetting: true,
+    });
+    assert.equal(loadCount, 2);
+});
+
+test("a rejected serialized task does not block later updates", async () => {
+    const enqueue = createSerialTaskQueue();
+
+    await assert.rejects(
+        enqueue(async () => {
+            throw new Error("expected failure");
+        }),
+        /expected failure/,
+    );
+
+    assert.equal(await enqueue(async () => "continued"), "continued");
+});
+
+test("rapid profile edits are saved once with the latest value", async () => {
+    const saved = [];
+    const states = [];
+    const saver = createDebouncedSaver({
+        save: async (value) => {
+            saved.push(value);
+            return value;
+        },
+        onStateChange: (state) => states.push(state),
+        delayMs: 60_000,
+    });
+
+    saver.schedule("p");
+    saver.schedule("pr");
+    saver.schedule("profile");
+    await saver.flush();
+
+    assert.deepEqual(saved, ["profile"]);
+    assert.deepEqual(states.slice(-2), ["saving", "saved"]);
+});
+
+test("an older failed request cannot overwrite a newer completion state", async () => {
+    const completions = new Map();
+    const states = [];
+    const saver = createDebouncedSaver({
+        save: (value) =>
+            new Promise((resolve) => {
+                completions.set(value, resolve);
+            }),
+        onStateChange: (state) => states.push(state),
+        delayMs: 60_000,
+    });
+
+    saver.schedule("old");
+    const oldRequest = saver.flush();
+    await Promise.resolve();
+
+    saver.schedule("new");
+    const newRequest = saver.flush();
+    await Promise.resolve();
+
+    completions.get("new")("new");
+    await newRequest;
+    completions.get("old")(null);
+    await oldRequest;
+
+    assert.equal(states.at(-1), "saved");
+    assert.deepEqual(
+        states.filter((state) => state === "error"),
+        [],
+    );
+});
+
+test("dispose synchronously queues the pending save before a remount load", async () => {
+    const enqueue = createSerialTaskQueue();
+    let profile = "old";
+    const states = [];
+    const saver = createDebouncedSaver({
+        save: (value) =>
+            enqueue(async () => {
+                profile = value;
+                return value;
+            }),
+        onStateChange: (state) => states.push(state),
+        delayMs: 60_000,
+    });
+
+    saver.schedule("new");
+    const unmountSave = saver.dispose();
+    const remountLoad = enqueue(async () => profile);
+
+    await unmountSave;
+    assert.equal(await remountLoad, "new");
+    assert.deepEqual(states, ["dirty"]);
+});


### PR DESCRIPTION
## Summary
- 設定の read-modify-write 全体を直列化し、複数設定画面からの更新も 3-way merge で保全します。
- Zenzai プロファイル保存を 500ms debounce 化し、未保存・保存中・保存済み・失敗状態を表示します。
- 実変更がない場合のディスク書き込みと IME サーバー再初期化を省略します。

## Background
- Issue: #137
- Issue close: 対象リリース公開・成果物確認後
- 高速入力や並行する設定更新で、古い request が新しい設定を上書きする競合と、プロファイル入力のたびに converter が再構築される問題を解消します。

## Changes
- frontend: 設定更新キュー、debounced saver、失敗時も保持される保存状態 UI と回帰テストを追加
- native settings: process 内・process 間の更新を直列化し、base/current/new の差分 merge と atomic save を実装
- server apply: no-op 時の再適用省略と、失敗後の dirty retry、server restart との排他を実装
- CI: frontend 設定保存テストを GitHub Actions に追加

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/30076964464
  - static/frontend, Windows Swift/Rust all tests, installer build: success
  - `azookey-setup.exe`: `SHA256SUMS.txt` verification OK
- [x] Windows 実機確認
  - Windows 11 build VM: `cargo test -p frontend config` 5 passed
  - Windows 11 install VM: silent install exit code 0、DLL/Uninstall entry/WebView2/配置を確認
  - Zenzai UI: 連続入力後に「保存済み」、disk 上の `enable=True` と `profile=Issue137 latest profile` を確認
  - logs: `.local/logs/vm-client-test-20260724-164442.log`, `.local/logs/win11-install-20260724-172324.log`
  - screenshot: `.local/vm-debug/issue137-profile-saved-later.png`
- [x] ローカル確認
  - `npm test`: 5 passed
  - `npm run typecheck`: passed
  - `npm run build`: passed
  - `cargo test -p shared`: 16 passed
  - Windows target `cargo check -p frontend --tests`: passed
  - Windows target clippy (`-D warnings`): passed

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した