### PR TITLE
fix(ui): make UIAccess token acquisition session-aware

### DIFF
--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -18,8 +18,10 @@ serde_json = "1.0"
 version = "0.58.0"
 features = [
     "Win32_Foundation",
+    "Win32_Security",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Environment",
+    "Win32_System_Threading",
     "Win32_Graphics_Gdi",
     "Win32_UI_HiDpi",
 ]

--- a/crates/ui/src/uiaccess.rs
+++ b/crates/ui/src/uiaccess.rs
@@ -1,27 +1,26 @@
 // obtain useraccess privileges from system applications
 // cf: https://github.com/killtimer0/uiaccess/
 
-use std::{ffi::c_void, ptr::addr_of_mut};
+use std::{error::Error, ffi::c_void, fmt, ptr::addr_of_mut, slice};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use windows::{
-    core::PWSTR,
+    core::{Owned, HRESULT, PWSTR},
     Win32::{
-        Foundation::{CloseHandle, BOOL, HANDLE, INVALID_HANDLE_VALUE},
+        Foundation::{BOOL, ERROR_INSUFFICIENT_BUFFER, ERROR_NO_MORE_FILES, HANDLE, LUID},
         Security::{
-            DuplicateTokenEx, GetTokenInformation, LookupPrivilegeValueW, PrivilegeCheck,
+            DuplicateTokenEx, GetTokenInformation, LookupPrivilegeValueW, RevertToSelf,
             SecurityAnonymous, SecurityImpersonation, SetTokenInformation, TokenImpersonation,
-            TokenPrimary, TokenSessionId, TokenUIAccess, PRIVILEGE_SET, SE_TCB_NAME,
-            TOKEN_ACCESS_MASK, TOKEN_ADJUST_DEFAULT, TOKEN_ASSIGN_PRIMARY, TOKEN_DUPLICATE,
-            TOKEN_IMPERSONATE, TOKEN_QUERY,
+            TokenPrimary, TokenPrivileges, TokenSessionId, TokenUIAccess, LUID_AND_ATTRIBUTES,
+            SE_PRIVILEGE_ENABLED, SE_TCB_NAME, TOKEN_ACCESS_MASK, TOKEN_ADJUST_DEFAULT,
+            TOKEN_ASSIGN_PRIMARY, TOKEN_DUPLICATE, TOKEN_IMPERSONATE, TOKEN_QUERY,
         },
         System::{
             Diagnostics::ToolHelp::{
-                CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32,
+                CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
                 TH32CS_SNAPPROCESS,
             },
             Environment::GetCommandLineW,
-            SystemServices::PRIVILEGE_SET_ALL_NECESSARY,
             Threading::{
                 CreateProcessAsUserW, ExitProcess, GetCurrentProcess, GetStartupInfoW, OpenProcess,
                 OpenProcessToken, SetThreadToken, PROCESS_CREATION_FLAGS, PROCESS_INFORMATION,
@@ -31,182 +30,319 @@ use windows::{
     },
 };
 
-/// get token from current process
-fn open_current_process_token() -> Result<HANDLE> {
-    let mut h_token = HANDLE::default();
-    unsafe {
-        if let Ok(()) = OpenProcessToken(
-            GetCurrentProcess(),
-            TOKEN_DUPLICATE | TOKEN_QUERY,
-            &mut h_token,
-        ) {
-            Ok(h_token)
-        } else {
-            anyhow::bail!("OpenProcessToken failed");
-        }
-    }
-}
-
-/// check for ui access
-pub fn check_for_ui_access() -> Result<bool> {
-    let mut token_ui_access: BOOL = false.into();
-    let mut token_len: u32 = 0;
-
-    unsafe {
-        let h_token = open_current_process_token()?;
-        let success = GetTokenInformation(
-            h_token,
-            TokenUIAccess,
-            Some(&mut token_ui_access as *mut _ as *mut _),
-            std::mem::size_of::<BOOL>() as u32,
-            &mut token_len,
-        );
-        let _ = CloseHandle(h_token);
-        if let Ok(()) = success {
-            Ok(token_ui_access.as_bool())
-        } else {
-            anyhow::bail!("GetTokenInformation failed {success:?}");
-        }
-    }
-}
-
-pub fn duplicate_winlogon_token(
+#[derive(Debug)]
+struct WinlogonTokenNotFound {
     session_id: u32,
-    desired_access: TOKEN_ACCESS_MASK,
-    h_token: &mut HANDLE,
-) -> Result<()> {
-    let mut privilege_set = PRIVILEGE_SET {
-        PrivilegeCount: 1,
-        Control: PRIVILEGE_SET_ALL_NECESSARY,
-        ..Default::default()
-    };
-
-    unsafe {
-        LookupPrivilegeValueW(None, SE_TCB_NAME, &mut privilege_set.Privilege[0].Luid)?;
-
-        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)?;
-        anyhow::ensure!(
-            snapshot != INVALID_HANDLE_VALUE,
-            "CreateToolhelp32Snapshot failed"
-        );
-
-        let mut process_entry = PROCESSENTRY32 {
-            dwSize: std::mem::size_of::<PROCESSENTRY32>() as u32,
-            ..Default::default()
-        };
-
-        Process32First(snapshot, &mut process_entry)?;
-        while let Ok(()) = Process32Next(snapshot, &mut process_entry) {
-            // check if the process is winlogon
-            let exe_string = process_entry
-                .szExeFile
-                .iter()
-                .map(|&c| c as u8)
-                .collect::<Vec<_>>();
-            let exe_string = String::from_utf8(exe_string)?;
-
-            if !exe_string.to_lowercase().contains("winlogon") {
-                continue;
-            }
-
-            let process = OpenProcess(
-                PROCESS_QUERY_LIMITED_INFORMATION,
-                false,
-                process_entry.th32ProcessID,
-            )?;
-
-            let mut token = HANDLE::default();
-            OpenProcessToken(process, TOKEN_QUERY | TOKEN_DUPLICATE, &mut token)?;
-
-            let mut privilege_result = false.into();
-            PrivilegeCheck(token, &mut privilege_set as *mut _, &mut privilege_result)?;
-
-            let mut token_session_id: u32 = 0;
-            let mut token_info_length: u32 = 0;
-
-            GetTokenInformation(
-                token,
-                TokenSessionId,
-                Some(addr_of_mut!(token_session_id) as *mut c_void),
-                std::mem::size_of::<u32>() as u32,
-                &mut token_info_length,
-            )?;
-
-            anyhow::ensure!(
-                token_session_id == session_id,
-                "TokenSessionId does not match the session_id"
-            );
-
-            DuplicateTokenEx(
-                token,
-                desired_access,
-                None,
-                SecurityImpersonation,
-                TokenImpersonation,
-                h_token,
-            )?;
-        }
-    }
-
-    Ok(())
 }
 
-pub fn create_uiaccess_token(token_handle: &mut HANDLE) -> Result<()> {
-    let mut token_self = HANDLE::default();
+impl fmt::Display for WinlogonTokenNotFound {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "no winlogon token with SeTcbPrivilege found for session {}",
+            self.session_id
+        )
+    }
+}
 
+impl Error for WinlogonTokenNotFound {}
+
+struct ThreadImpersonation {
+    active: bool,
+}
+
+impl ThreadImpersonation {
+    fn start(token: HANDLE) -> Result<Self> {
+        unsafe {
+            SetThreadToken(None, token).context("SetThreadToken failed")?;
+        }
+        Ok(Self { active: true })
+    }
+
+    fn revert(mut self) -> Result<()> {
+        unsafe {
+            RevertToSelf().context("RevertToSelf failed")?;
+        }
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for ThreadImpersonation {
+    fn drop(&mut self) {
+        if self.active {
+            if let Err(error) = unsafe { RevertToSelf() } {
+                eprintln!("Warning: Failed to revert UIAccess token impersonation: {error:?}");
+            }
+        }
+    }
+}
+
+fn open_current_process_token(desired_access: TOKEN_ACCESS_MASK) -> Result<Owned<HANDLE>> {
+    let mut token = Owned::<HANDLE>::default();
     unsafe {
-        OpenProcessToken(
-            GetCurrentProcess(),
-            TOKEN_QUERY | TOKEN_DUPLICATE,
-            &mut token_self,
-        )?;
+        OpenProcessToken(GetCurrentProcess(), desired_access, &mut *token)
+            .context("OpenProcessToken for current process failed")?;
+    }
+    Ok(token)
+}
 
-        let mut session_id = 0;
-        let mut token_info_length = 0;
-
+fn token_session_id(token: HANDLE) -> Result<u32> {
+    let mut session_id = 0;
+    let mut token_info_length = 0;
+    unsafe {
         GetTokenInformation(
-            token_self,
+            token,
             TokenSessionId,
             Some(addr_of_mut!(session_id) as *mut c_void),
             std::mem::size_of::<u32>() as u32,
             &mut token_info_length,
-        )?;
+        )
+        .context("GetTokenInformation(TokenSessionId) failed")?;
+    }
+    Ok(session_id)
+}
 
-        let mut system_token_handle = HANDLE::default();
-        duplicate_winlogon_token(session_id, TOKEN_IMPERSONATE, &mut system_token_handle)?;
+/// check for ui access
+pub fn check_for_ui_access() -> Result<bool> {
+    let token = open_current_process_token(TOKEN_QUERY)?;
+    let mut token_ui_access: BOOL = false.into();
+    let mut token_len = 0;
 
-        SetThreadToken(None, system_token_handle)?;
+    unsafe {
+        GetTokenInformation(
+            *token,
+            TokenUIAccess,
+            Some(&mut token_ui_access as *mut _ as *mut _),
+            std::mem::size_of::<BOOL>() as u32,
+            &mut token_len,
+        )
+        .context("GetTokenInformation(TokenUIAccess) failed")?;
+    }
+
+    Ok(token_ui_access.as_bool())
+}
+
+fn is_winlogon_executable(executable_name: &[u16]) -> bool {
+    let name_length = executable_name
+        .iter()
+        .position(|character| *character == 0)
+        .unwrap_or(executable_name.len());
+    String::from_utf16_lossy(&executable_name[..name_length]).eq_ignore_ascii_case("winlogon.exe")
+}
+
+fn winlogon_process_ids() -> Result<Vec<u32>> {
+    let snapshot = unsafe {
+        Owned::new(
+            CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+                .context("CreateToolhelp32Snapshot failed")?,
+        )
+    };
+    let mut process_entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+    let mut process_ids = Vec::new();
+
+    unsafe {
+        Process32FirstW(*snapshot, &mut process_entry).context("Process32FirstW failed")?;
+        loop {
+            if is_winlogon_executable(&process_entry.szExeFile) {
+                process_ids.push(process_entry.th32ProcessID);
+            }
+            match Process32NextW(*snapshot, &mut process_entry) {
+                Ok(()) => {}
+                Err(error) if error.code() == HRESULT::from_win32(ERROR_NO_MORE_FILES.0) => {
+                    break;
+                }
+                Err(error) => return Err(error).context("Process32NextW failed"),
+            }
+        }
+    }
+
+    Ok(process_ids)
+}
+
+fn select_token_for_session<I, T, F>(
+    process_ids: I,
+    requested_session_id: u32,
+    mut inspect_token: F,
+) -> Option<T>
+where
+    I: IntoIterator<Item = u32>,
+    F: FnMut(u32) -> Option<(u32, T)>,
+{
+    process_ids.into_iter().find_map(|process_id| {
+        let (token_session_id, token) = inspect_token(process_id)?;
+        (token_session_id == requested_session_id).then_some(token)
+    })
+}
+
+fn token_has_enabled_privilege(token: HANDLE, privilege_luid: LUID) -> Result<bool> {
+    let mut token_info_length = 0;
+    let size_result =
+        unsafe { GetTokenInformation(token, TokenPrivileges, None, 0, &mut token_info_length) };
+    match size_result {
+        Err(error) if error.code() == HRESULT::from_win32(ERROR_INSUFFICIENT_BUFFER.0) => {}
+        Err(error) => {
+            return Err(error).context("GetTokenInformation(TokenPrivileges) size failed")
+        }
+        Ok(()) => anyhow::bail!("GetTokenInformation(TokenPrivileges) returned no size"),
+    }
+
+    let word_size = std::mem::size_of::<usize>();
+    let word_count = (token_info_length as usize).div_ceil(word_size);
+    let mut token_info = vec![0_usize; word_count];
+    unsafe {
+        GetTokenInformation(
+            token,
+            TokenPrivileges,
+            Some(token_info.as_mut_ptr().cast()),
+            token_info_length,
+            &mut token_info_length,
+        )
+        .context("GetTokenInformation(TokenPrivileges) failed")?;
+    }
+
+    anyhow::ensure!(
+        token_info_length as usize >= std::mem::size_of::<u32>(),
+        "TokenPrivileges response is shorter than its header"
+    );
+    let privilege_count = unsafe { *token_info.as_ptr().cast::<u32>() as usize };
+    let privileges_offset = std::mem::size_of::<u32>();
+    let privileges_size = privilege_count
+        .checked_mul(std::mem::size_of::<LUID_AND_ATTRIBUTES>())
+        .and_then(|size| privileges_offset.checked_add(size))
+        .context("TokenPrivileges response size overflow")?;
+    anyhow::ensure!(
+        privileges_size <= token_info_length as usize,
+        "TokenPrivileges response is shorter than its privilege array"
+    );
+    let privileges = unsafe {
+        slice::from_raw_parts(
+            token_info
+                .as_ptr()
+                .cast::<u8>()
+                .add(privileges_offset)
+                .cast::<LUID_AND_ATTRIBUTES>(),
+            privilege_count,
+        )
+    };
+
+    Ok(privileges.iter().any(|privilege| {
+        privilege.Luid == privilege_luid && privilege.Attributes.contains(SE_PRIVILEGE_ENABLED)
+    }))
+}
+
+fn open_winlogon_token(
+    process_id: u32,
+    tcb_privilege_luid: LUID,
+) -> Result<Option<(u32, Owned<HANDLE>)>> {
+    let process = unsafe {
+        Owned::new(
+            OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_id)
+                .with_context(|| format!("OpenProcess({process_id}) failed"))?,
+        )
+    };
+    let mut token = Owned::<HANDLE>::default();
+    unsafe {
+        OpenProcessToken(*process, TOKEN_QUERY | TOKEN_DUPLICATE, &mut *token)
+            .with_context(|| format!("OpenProcessToken({process_id}) failed"))?;
+    }
+    if !token_has_enabled_privilege(*token, tcb_privilege_luid)
+        .with_context(|| format!("SeTcbPrivilege query for process {process_id} failed"))?
+    {
+        return Ok(None);
+    }
+
+    Ok(Some((token_session_id(*token)?, token)))
+}
+
+fn duplicate_winlogon_token(
+    session_id: u32,
+    desired_access: TOKEN_ACCESS_MASK,
+) -> Result<Owned<HANDLE>> {
+    let mut tcb_privilege_luid = LUID::default();
+    unsafe {
+        LookupPrivilegeValueW(None, SE_TCB_NAME, &mut tcb_privilege_luid)
+            .context("LookupPrivilegeValueW(SeTcbPrivilege) failed")?;
+    }
+
+    let token = select_token_for_session(winlogon_process_ids()?, session_id, |process_id| {
+        match open_winlogon_token(process_id, tcb_privilege_luid) {
+            Ok(token) => token,
+            Err(error) => {
+                eprintln!(
+                    "Warning: Skipping winlogon process {process_id} while acquiring UIAccess: {error:#}"
+                );
+                None
+            }
+        }
+    })
+    .ok_or(WinlogonTokenNotFound { session_id })?;
+
+    let mut duplicated_token = Owned::<HANDLE>::default();
+    unsafe {
         DuplicateTokenEx(
-            token_self,
+            *token,
+            desired_access,
+            None,
+            SecurityImpersonation,
+            TokenImpersonation,
+            &mut *duplicated_token,
+        )
+        .context("DuplicateTokenEx for winlogon token failed")?;
+    }
+    Ok(duplicated_token)
+}
+
+fn create_uiaccess_token() -> Result<Owned<HANDLE>> {
+    let token_self = open_current_process_token(TOKEN_QUERY | TOKEN_DUPLICATE)?;
+    let session_id = token_session_id(*token_self)?;
+    let system_token = duplicate_winlogon_token(session_id, TOKEN_IMPERSONATE)?;
+    let impersonation = ThreadImpersonation::start(*system_token)?;
+
+    let mut uiaccess_token = Owned::<HANDLE>::default();
+    unsafe {
+        DuplicateTokenEx(
+            *token_self,
             TOKEN_QUERY | TOKEN_DUPLICATE | TOKEN_ASSIGN_PRIMARY | TOKEN_ADJUST_DEFAULT,
             None,
             SecurityAnonymous,
             TokenPrimary,
-            token_handle,
-        )?;
-
-        let ui_access: BOOL = true.into();
-
+            &mut *uiaccess_token,
+        )
+        .context("DuplicateTokenEx for UIAccess token failed")?;
+    }
+    let ui_access: BOOL = true.into();
+    unsafe {
         SetTokenInformation(
-            *token_handle,
+            *uiaccess_token,
             TokenUIAccess,
             &ui_access as *const _ as *mut _,
             std::mem::size_of::<BOOL>() as u32,
-        )?;
+        )
+        .context("SetTokenInformation(TokenUIAccess) failed")?;
     }
+    impersonation.revert()?;
 
-    Ok(())
+    Ok(uiaccess_token)
 }
 
 pub fn prepare_uiaccess_token() -> Result<()> {
-    let ui_access = check_for_ui_access()?;
-    if ui_access {
+    if check_for_ui_access()? {
         println!("UIAccess is already enabled");
         return Ok(());
     }
 
-    let mut token_handle = HANDLE::default();
-    create_uiaccess_token(&mut token_handle)?;
+    let token = match create_uiaccess_token() {
+        Ok(token) => token,
+        Err(error) if error.downcast_ref::<WinlogonTokenNotFound>().is_some() => {
+            eprintln!("Warning: {error:#}; continuing candidate UI startup without UIAccess");
+            return Ok(());
+        }
+        Err(error) => return Err(error),
+    };
 
     let mut startup_info = STARTUPINFOW::default();
     let mut process_info = PROCESS_INFORMATION::default();
@@ -214,7 +350,7 @@ pub fn prepare_uiaccess_token() -> Result<()> {
     unsafe {
         GetStartupInfoW(&mut startup_info);
         CreateProcessAsUserW(
-            token_handle,
+            *token,
             None,
             PWSTR(GetCommandLineW().as_ptr() as *mut u16),
             None,
@@ -225,11 +361,62 @@ pub fn prepare_uiaccess_token() -> Result<()> {
             None,
             &startup_info,
             &mut process_info,
-        )?;
+        )
+        .context("CreateProcessAsUserW for UIAccess process failed")?;
 
+        let process_handle = Owned::new(process_info.hProcess);
+        let thread_handle = Owned::new(process_info.hThread);
         println!("Process created with UIAccess token");
-        CloseHandle(process_info.hProcess)?;
-        CloseHandle(process_info.hThread)?;
+        drop(process_handle);
+        drop(thread_handle);
+        drop(token);
         ExitProcess(0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_winlogon_executable, select_token_for_session};
+
+    #[test]
+    fn winlogon_name_match_is_exact_and_case_insensitive() {
+        let mut name = "WinLogon.ExE".encode_utf16().collect::<Vec<_>>();
+        name.extend([0, 0]);
+        assert!(is_winlogon_executable(&name));
+
+        let similar_name = "not-winlogon.exe".encode_utf16().collect::<Vec<_>>();
+        assert!(!is_winlogon_executable(&similar_name));
+    }
+
+    #[test]
+    fn token_selection_skips_an_earlier_winlogon_from_another_session() {
+        let candidates = [(101, 1), (202, 7), (303, 7)];
+        let mut inspected_processes = Vec::new();
+
+        let selected = select_token_for_session(
+            candidates.map(|(process_id, _)| process_id),
+            7,
+            |process_id| {
+                inspected_processes.push(process_id);
+                candidates
+                    .iter()
+                    .find(|(candidate_id, _)| *candidate_id == process_id)
+                    .map(|(_, session_id)| (*session_id, process_id))
+            },
+        );
+
+        assert_eq!(selected, Some(202));
+        assert_eq!(inspected_processes, vec![101, 202]);
+    }
+
+    #[test]
+    fn token_selection_returns_none_when_no_current_session_token_is_available() {
+        let selected = select_token_for_session([101, 202], 7, |process_id| match process_id {
+            101 => None,
+            202 => Some((1, process_id)),
+            _ => unreachable!(),
+        });
+
+        assert_eq!(selected, None);
     }
 }


### PR DESCRIPTION
## Summary
- UIAccess token 取得時に、別セッションの `winlogon.exe` をエラーにせずスキップし、現在のセッションに対応する token を選択します。
- snapshot・process・token・起動した process/thread の Win32 handle を RAII で管理し、成功・失敗の全経路で解放します。
- 利用可能な同一セッション token がない場合は、candidate UI を UIAccess なしで継続して起動します。

## Background
- Issue: #142
- Issue close: 対象リリース公開・成果物確認後
- 従来の探索は最初に見つかった別セッションの `winlogon.exe` で session mismatch を返し、RDP やユーザー切り替え後に UIAccess token を取得できない可能性がありました。また Win32 handle と thread impersonation の cleanup が一部の error path で保証されていませんでした。

## Changes
- UIAccess session selection: `Process32FirstW` の先頭 entry から `winlogon.exe` を完全一致・case-insensitive で列挙し、利用不能・別セッションの候補をスキップして同一セッションを探索
- Token validation: primary token に対する `PrivilegeCheck` を廃止し、`TokenPrivileges` から enabled `SeTcbPrivilege` を確認
- Resource management: `Owned<HANDLE>` で snapshot・process・token・child process/thread を所有し、thread impersonation guard で `RevertToSelf` を保証
- Least privilege / fallback: 用途ごとに token/process access mask を縮小し、同一セッションの token が見つからない場合だけ警告付きで非 UIAccess 起動へ fallback
- Tests: 別セッションの候補が先にある場合の選択、利用可能な同一セッション token がない場合、`winlogon.exe` 名の完全一致を回帰 test に追加

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/31309389112
  - Static checks / frontend tests、Windows Swift / Rust tests、installer build・metadata 検証・artifact upload が成功
  - Silent installer smoke job は tag / manual dispatch 専用条件のため PR push では skip。ローカル Windows VM の silent install と startup smoke は下記で確認
- [x] Windows VM 確認
  - `.local/vm_build_master.sh fix/142-uiaccess-multi-session`: Rust release build、Vite、Inno Setup compilation 成功
  - build: `0.1.0-batao.11.dev.20260809055323.geebaf86c` / `channel=validation` / `revision=eebaf86c66b95e64d1753209cef5eb1c1a9df0d4` / `installerGeneration=2`
  - `.local/vm_stage_for_manual_test.sh <installer>`: silent install、startup smoke、UI/server process 確認に成功
  - token probe: candidate UI と `winlogon.exe` が同じ `SessionId=1` で、candidate UI の `TokenUIAccess=1` を確認
  - Notepad: azooKey の変換候補表示と `aiueo` 入力時の応答を確認
  - 実際の RDP 切断・再接続は未実施。別セッション候補が先に列挙されるケースは回帰 test で確認
- [x] ローカル確認
  - `PROTOC=/tmp/azookey-issue142-protoc-35.1/bin/protoc cargo check -p ui --tests --target x86_64-pc-windows-msvc`: 成功
  - `PROTOC=/tmp/azookey-issue142-protoc-35.1/bin/protoc cargo clippy -p ui --tests --target x86_64-pc-windows-msvc -- -D warnings`: 成功
  - `cargo fmt --all --check`、`git diff --check`、`node scripts/sync-version.mjs --check-release`: 成功
  - focused VM cargo test は helper が Swift native library 生成前に Rust test を link するため未実行。追加 test の Windows target compile は上記 `cargo check --tests` で確認
- [x] Read-only review
  - P0 / P1 / P2 指摘なし
  - UIAccess 処理は candidate UI 起動時に一度だけ実行され、IME key input hot path への変更なし

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
