### PR TITLE
chore(release): prepare v0.1.0-batao.12

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.1.0-batao.11",
+  "version": "0.1.0-batao.12",
   "installerGeneration": 2
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0-batao.11",
+  "version": "0.1.0-batao.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0-batao.11",
+      "version": "0.1.0-batao.12",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-dialog": "^1.1.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0-batao.11",
+  "version": "0.1.0-batao.12",
   "type": "module",
   "scripts": {
     "sync-version": "node ../scripts/sync-version.mjs",

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Azookey",
-  "version": "0.1.0-batao.11",
+  "version": "0.1.0-batao.12",
   "identifier": "com.azookey.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/installer/AppVersion.iss
+++ b/installer/AppVersion.iss
@@ -1,3 +1,3 @@
 ; Generated from app-version.json by scripts/sync-version.mjs --sync-release.
-#define MyReleaseVersion "0.1.0-batao.11"
+#define MyReleaseVersion "0.1.0-batao.12"
 #define MyInstallerGeneration 2


### PR DESCRIPTION
## Summary
- app-version.json を 0.1.0-batao.12 に更新
- frontend、Tauri、installer の版数を同期

## Verification
- git diff --check
- node scripts/sync-version.mjs --check-release
- cd frontend && node node_modules/typescript/bin/tsc

## Checklist
- [x] 版数同期対象の5ファイルを確認
- [x] ローカル検証成功