### PR TITLE
perf(server): bound composition resource usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,6 @@
 
 # 設定
 
-## 設定ファイルの互換性とダウングレード
-
-設定は `%APPDATA%\Azookey\settings.json` に保存され、`version` を Semantic Versioning として比較します。現在のアプリより古い version の設定だけを migration します。
-
-新しい version の設定ファイルを古いアプリで検出した場合、未知の設定項目を失わないように元ファイルを変更せず、既定値で起動します。この状態では設定画面に通知を表示し、古いアプリからの設定保存を拒否します。新しいアプリを試した後にダウングレードした場合は、設定を変更せずに新しいアプリへ戻してください。古いアプリ用の設定を作り直す場合は、先に `settings.json` を手動でバックアップしてから削除し、古いアプリを起動します。
-
-JSON または `version` が不正な設定は破損設定として扱い、元ファイルを `settings.json.broken-*` に退避してから既定値を生成します。
-
 ## 全般設定
 
 ### 基本設定
@@ -43,19 +35,9 @@ JSON または `version` が不正な設定は破損設定として扱い、元�
 ### キー設定
 - ローマ字テーブル:
   - 設定画面から Google IME 型の行テーブル（入力 / 出力 / 次の入力）を編集できます。
-  - `次の入力` により、`tt -> っ + t` のような継続入力ルールを設定できます。
-  - モーダルの「テーブルを初期化」はドラフトのみ更新し、`保存` で初めて反映されます。
 
 ### 半角全角設定
 日本語入力時の文字幅はカテゴリごとに `半角 / 全角` を設定できます。
-
-### 変換の優先順位
-記号・句読点の変換は次の優先順位で適用されます。
-
-1. ローマ字テーブル（Google IME 型、`next_input` 対応）
-2. 基本設定（句読点 / 記号）と半角全角設定（カテゴリ設定）のフォールバック
-
-`z/` のような複合入力はローマ字テーブルを優先し、テーブル文脈に当たらない単体記号入力のみフォールバック設定を適用します。
 
 ### 句読点確定
 基本設定の「句読点確定」を有効にすると、変換中に対象記号を入力した時点で現在の変換結果を確定し、続けて対象記号を入力します。対象は句読点、`！`、`？` から個別に選択できます。
@@ -71,9 +53,6 @@ JSON または `version` が不正な設定は破損設定として扱い、元�
 - `半角/全角`: 入力モード切り替え（英数/ひらがな）
 - `VK_IME_ON` (`0x16`): ひらがな入力へ切替
 - `VK_IME_OFF` (`0x1A`): 英数入力へ切替
-- 言語バーの `あ/A` アイコン:
-  - 左クリックで入力モードを切り替えます。
-  - 右クリックで設定画面を開けます。
 
 英語キーボードでは以下のショートカットも設定可能です。
 - `Ctrl + Space`: 入力モード切替（英数/ひらがなかな）
@@ -136,8 +115,6 @@ cargo make build [--debug/--release]
 `--debug`オプションを付けるとデバッグビルド、`--release`オプションを付けるとリリースビルドになります。必ずどちらかを指定してください。
 
 `build`フォルダーが作成され、ビルドされた実行ファイルが格納されます。
-
-通常の branch、PR、`master`、VM、ローカル build で作る installer は検証版として、直近の release を基準に `0.1.0-batao.11.dev.<build-number>.g<short-sha>` のような一意の版数を自動生成します。直近の release が stable 版なら、次 patch の prerelease（例: `1.0.1-dev.<build-number>.g<short-sha>`）を使います。正式版は `app-version.json` と一致する `v<version>` tag の CI だけが build channel を明示して生成します。実際の build channel、commit、installer generation は `build/build-info.json` に出力され、installer にも同梱されます。正式リリース版数を変更するときは `app-version.json` を編集後、`node scripts/sync-version.mjs --sync-release` で追従ファイルを同期します。
 
 配布用インストーラーは Inno Setup で作成する `build/azookey-setup.exe` の 1 種類です。Tauri は設定アプリ `frontend.exe` のビルドにのみ使用し、Tauri/NSIS インストーラーは生成・同梱しません。`frontend.exe` を含むアプリ本体、IME DLL、サーバー、UI、ランチャー、辞書、Zenzai model、llama backend は Inno installer が `{autopf}\Azookey`（通常は `C:\Program Files\Azookey`）に配置します。設定・学習・ログ・`EngineRuntime` は `%APPDATA%\Azookey`、候補 UI の WebView2 data は `%LOCALAPPDATA%\Azookey\ui-webview` に保存します。
 

--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -160,6 +160,7 @@ impl ClauseActionBackend for PreparedClauseBackend {
         &mut self,
         _offset: i32,
         _previous_candidates: &Candidates,
+        _selected_candidate_id: u64,
     ) -> Result<ClauseAdvance> {
         self.advances
             .pop_front()
@@ -1765,33 +1766,19 @@ impl TextServiceFactory {
         ));
     }
 
-    fn clear_clause_snapshots(
-        clause_snapshots: &mut Vec<ClauseSnapshot>,
-        ipc_service: &mut IPCService,
-        candidates: &Candidates,
-    ) -> Result<()> {
-        if clause_snapshots.is_empty() {
-            return Ok(());
-        }
-
-        clause_snapshots.clear();
-        ipc_service.update_composition_snapshot(ClauseSnapshotOperation::Clear, candidates)
-    }
-
-    #[inline]
-    fn clear_future_clause_snapshots(future_clause_snapshots: &mut Vec<FutureClauseSnapshot>) {
-        future_clause_snapshots.clear();
-    }
-
-    #[inline]
     fn clear_clause_caches(
         clause_snapshots: &mut Vec<ClauseSnapshot>,
         future_clause_snapshots: &mut Vec<FutureClauseSnapshot>,
         ipc_service: &mut IPCService,
         candidates: &Candidates,
     ) -> Result<()> {
-        Self::clear_future_clause_snapshots(future_clause_snapshots);
-        Self::clear_clause_snapshots(clause_snapshots, ipc_service, candidates)
+        future_clause_snapshots.clear();
+        if clause_snapshots.is_empty() {
+            return Ok(());
+        }
+
+        clause_snapshots.clear();
+        ipc_service.update_composition_snapshot(ClauseSnapshotOperation::Clear, candidates, 0)
     }
 
     #[cfg(test)]

--- a/crates/client/src/engine/composition/clause_state.rs
+++ b/crates/client/src/engine/composition/clause_state.rs
@@ -123,8 +123,13 @@ pub(crate) trait ClauseActionBackend {
         &mut self,
         offset: i32,
         previous_candidates: &Candidates,
+        selected_candidate_id: u64,
     ) -> Result<ClauseAdvance> {
-        self.update_composition_snapshot(ClauseSnapshotOperation::Push, previous_candidates)?;
+        self.update_composition_snapshot(
+            ClauseSnapshotOperation::Push,
+            previous_candidates,
+            selected_candidate_id,
+        )?;
         let shrunk = self.shrink_text_with_context(offset, previous_candidates)?;
         let navigation = self.move_cursor(0)?;
         Ok(ClauseAdvance {
@@ -138,6 +143,7 @@ pub(crate) trait ClauseActionBackend {
         &mut self,
         initial_offset: i32,
         previous_candidates: &Candidates,
+        initial_selected_candidate_id: u64,
         leave_at_last: bool,
     ) -> Result<(Vec<ClauseAdvance>, bool)> {
         let mut offset = initial_offset;
@@ -146,6 +152,7 @@ pub(crate) trait ClauseActionBackend {
         let mut last_signature = None;
         let mut snapshot_count = 0;
         let mut completed = false;
+        let mut selected_candidate_id = initial_selected_candidate_id;
         let max_steps = previous
             .hiragana
             .chars()
@@ -153,7 +160,7 @@ pub(crate) trait ClauseActionBackend {
             .clamp(1, shared::MAX_PREPARED_CLAUSE_ADVANCES);
 
         for _ in 0..max_steps {
-            let advance = self.advance_clause(offset, &previous)?;
+            let advance = self.advance_clause(offset, &previous, selected_candidate_id)?;
             snapshot_count += 1;
             let Some(selected) = TextServiceFactory::select_candidate(&advance.navigation, 0)
             else {
@@ -171,6 +178,7 @@ pub(crate) trait ClauseActionBackend {
             advances.push(advance.clone());
             last_signature = Some(signature);
             offset = selected.corresponding_count;
+            selected_candidate_id = selected.candidate_id;
             previous = advance.navigation;
             if is_last {
                 completed = true;
@@ -184,7 +192,7 @@ pub(crate) trait ClauseActionBackend {
             0
         };
         for _ in retained_snapshot_count..snapshot_count {
-            self.update_composition_snapshot(ClauseSnapshotOperation::Pop, &previous)?;
+            self.update_composition_snapshot(ClauseSnapshotOperation::Pop, &previous, 0)?;
         }
         Ok((advances, completed))
     }
@@ -209,6 +217,7 @@ pub(crate) trait ClauseActionBackend {
         &mut self,
         _operation: ClauseSnapshotOperation,
         _previous_candidates: &Candidates,
+        _selected_candidate_id: u64,
     ) -> Result<()> {
         Ok(())
     }
@@ -245,17 +254,25 @@ impl ClauseActionBackend for IPCService {
         &mut self,
         offset: i32,
         previous_candidates: &Candidates,
+        selected_candidate_id: u64,
     ) -> Result<ClauseAdvance> {
-        IPCService::advance_clause(self, offset, previous_candidates)
+        IPCService::advance_clause(self, offset, previous_candidates, selected_candidate_id)
     }
 
     fn prepare_future_clauses(
         &mut self,
         initial_offset: i32,
         previous_candidates: &Candidates,
+        initial_selected_candidate_id: u64,
         leave_at_last: bool,
     ) -> Result<(Vec<ClauseAdvance>, bool)> {
-        IPCService::prepare_future_clauses(self, initial_offset, previous_candidates, leave_at_last)
+        IPCService::prepare_future_clauses(
+            self,
+            initial_offset,
+            previous_candidates,
+            initial_selected_candidate_id,
+            leave_at_last,
+        )
     }
 
     fn move_cursor_with_context(
@@ -278,8 +295,14 @@ impl ClauseActionBackend for IPCService {
         &mut self,
         operation: ClauseSnapshotOperation,
         previous_candidates: &Candidates,
+        selected_candidate_id: u64,
     ) -> Result<()> {
-        IPCService::update_composition_snapshot(self, operation, previous_candidates)
+        IPCService::update_composition_snapshot(
+            self,
+            operation,
+            previous_candidates,
+            selected_candidate_id,
+        )
     }
 }
 
@@ -657,6 +680,7 @@ impl ClauseState {
             let (prepared, _) = backend.prepare_future_clauses(
                 selected.corresponding_count,
                 state.candidates,
+                selected.candidate_id,
                 false,
             )?;
             TextServiceFactory::rebuild_future_clause_snapshots_from_prepared(state, prepared)?;
@@ -714,9 +738,16 @@ impl ClauseState {
         direction: i32,
     ) -> Result<ClauseActionEffect> {
         if direction == TextServiceFactory::MOVE_CLAUSE_TO_LAST {
+            let selected_candidate_id = state
+                .candidates
+                .candidate_ids
+                .get((*state.selection_index).max(0) as usize)
+                .copied()
+                .unwrap_or(0);
             let (prepared, completed) = backend.prepare_future_clauses(
                 *state.corresponding_count,
                 state.candidates,
+                selected_candidate_id,
                 true,
             )?;
             if !completed {
@@ -825,8 +856,16 @@ impl ClauseState {
 
             state.clause_snapshots.push(snapshot.clone());
 
-            let advance =
-                backend.advance_clause(current_corresponding_count, &previous_candidates)?;
+            let selected_candidate_id = previous_candidates
+                .candidate_ids
+                .get((*state.selection_index).max(0) as usize)
+                .copied()
+                .unwrap_or(0);
+            let advance = backend.advance_clause(
+                current_corresponding_count,
+                &previous_candidates,
+                selected_candidate_id,
+            )?;
             let navigation_candidates = advance.navigation;
             let raw_input_identity = advance.raw_input;
             *state.candidates = advance.shrunk;
@@ -881,6 +920,7 @@ impl ClauseState {
                             backend.update_composition_snapshot(
                                 ClauseSnapshotOperation::Pop,
                                 &rollback_candidates,
+                                0,
                             )?;
                             state.future_clause_snapshots.push(restored_future);
                             let restored = state.clause_snapshots.pop().unwrap_or(snapshot);
@@ -987,6 +1027,7 @@ impl ClauseState {
                     backend.update_composition_snapshot(
                         ClauseSnapshotOperation::Pop,
                         &previous_candidates,
+                        0,
                     )?;
                     if let Some(restored) = state.clause_snapshots.pop() {
                         Self::restore_current_clause_snapshot(state, restored);
@@ -1048,9 +1089,15 @@ impl ClauseState {
                     state.candidates,
                 );
                 let previous_candidates = state.candidates.clone();
+                let selected_candidate_id = previous_candidates
+                    .candidate_ids
+                    .get((*state.selection_index).max(0) as usize)
+                    .copied()
+                    .unwrap_or(0);
                 backend.update_composition_snapshot(
                     ClauseSnapshotOperation::Pop,
                     &previous_candidates,
+                    selected_candidate_id,
                 )?;
 
                 Self::restore_current_clause_snapshot(state, restored);

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -1609,6 +1609,8 @@ struct NonProgressEnsureBackend {
 
 struct BatchedClauseAdvanceBackend {
     advance_calls: usize,
+    selected_candidate_id: u64,
+    popped_candidate_id: u64,
 }
 
 impl ClauseActionBackend for BatchedClauseAdvanceBackend {
@@ -1624,15 +1626,30 @@ impl ClauseActionBackend for BatchedClauseAdvanceBackend {
         &mut self,
         offset: i32,
         _previous_candidates: &Candidates,
+        selected_candidate_id: u64,
     ) -> anyhow::Result<ClauseAdvance> {
         self.advance_calls += 1;
+        self.selected_candidate_id = selected_candidate_id;
         assert_eq!(offset, 7);
-        let next = candidates(&["統一"], &[""], "とういつ", &[6]);
+        let mut next = candidates(&["統一"], &[""], "とういつ", &[6]);
+        next.candidate_ids = vec![84];
         Ok(ClauseAdvance {
             shrunk: next.clone(),
             navigation: next,
             raw_input: ClauseAdvanceRawInput::Unverified,
         })
+    }
+
+    fn update_composition_snapshot(
+        &mut self,
+        operation: ClauseSnapshotOperation,
+        _previous_candidates: &Candidates,
+        selected_candidate_id: u64,
+    ) -> anyhow::Result<()> {
+        if operation == ClauseSnapshotOperation::Pop {
+            self.popped_candidate_id = selected_candidate_id;
+        }
+        Ok(())
     }
 }
 
@@ -1646,6 +1663,7 @@ fn move_clause_right_uses_one_batched_backend_operation() {
     let mut corresponding_count = 7;
     let mut selection_index = 0;
     let mut current_candidates = candidates(&["いい加減"], &["統一"], "いいかげんとういつ", &[7]);
+    current_candidates.candidate_ids = vec![41];
     let mut clause_snapshots = Vec::new();
     let mut future_clause_snapshots = Vec::new();
     let mut current_clause_is_split_derived = true;
@@ -1654,7 +1672,11 @@ fn move_clause_right_uses_one_batched_backend_operation() {
     let mut current_clause_split_group_id = None;
     let mut current_clause_consumed_prefix_restore = None;
     let mut next_split_group_id = 1;
-    let mut backend = BatchedClauseAdvanceBackend { advance_calls: 0 };
+    let mut backend = BatchedClauseAdvanceBackend {
+        advance_calls: 0,
+        selected_candidate_id: 0,
+        popped_candidate_id: 0,
+    };
 
     let mut state = ClauseActionStateMut {
         preview: &mut preview,
@@ -1684,8 +1706,14 @@ fn move_clause_right_uses_one_batched_backend_operation() {
 
     assert!(effect.applied);
     assert_eq!(backend.advance_calls, 1);
-    assert_eq!(preview, "いい加減統一");
-    assert_eq!(suffix, "");
+    assert_eq!(backend.selected_candidate_id, 41);
+    assert_eq!(state.preview.as_str(), "いい加減統一");
+    assert_eq!(state.suffix.as_str(), "");
+
+    let effect = TextServiceFactory::apply_move_clause(&mut state, &mut backend, -1)
+        .expect("left move should preserve the selected future candidate");
+    assert!(effect.applied);
+    assert_eq!(backend.popped_candidate_id, 84);
 }
 
 struct MoveToLastPreparationBackend {
@@ -1706,6 +1734,7 @@ impl ClauseActionBackend for MoveToLastPreparationBackend {
         &mut self,
         _offset: i32,
         _previous_candidates: &Candidates,
+        _selected_candidate_id: u64,
     ) -> anyhow::Result<ClauseAdvance> {
         self.direct_advance_calls += 1;
         panic!("move-to-last must not replay a direct clause advance")
@@ -1715,6 +1744,7 @@ impl ClauseActionBackend for MoveToLastPreparationBackend {
         &mut self,
         initial_offset: i32,
         _previous_candidates: &Candidates,
+        _initial_selected_candidate_id: u64,
         leave_at_last: bool,
     ) -> anyhow::Result<(Vec<ClauseAdvance>, bool)> {
         self.prepare_calls += 1;
@@ -1832,6 +1862,7 @@ impl ClauseActionBackend for IncompleteMoveToLastBackend {
         &mut self,
         offset: i32,
         _previous_candidates: &Candidates,
+        _selected_candidate_id: u64,
     ) -> anyhow::Result<ClauseAdvance> {
         self.direct_advance_calls += 1;
         assert_eq!(offset, 1);
@@ -1846,6 +1877,7 @@ impl ClauseActionBackend for IncompleteMoveToLastBackend {
         &mut self,
         initial_offset: i32,
         _previous_candidates: &Candidates,
+        _initial_selected_candidate_id: u64,
         leave_at_last: bool,
     ) -> anyhow::Result<(Vec<ClauseAdvance>, bool)> {
         self.prepare_calls += 1;
@@ -1941,6 +1973,7 @@ impl ClauseActionBackend for NonProgressEnsureBackend {
         &mut self,
         initial_offset: i32,
         _previous_candidates: &Candidates,
+        _initial_selected_candidate_id: u64,
         leave_at_last: bool,
     ) -> anyhow::Result<(Vec<ClauseAdvance>, bool)> {
         self.prepare_calls += 1;
@@ -1977,6 +2010,7 @@ impl ClauseActionBackend for BoundedPrepareBackend {
         &mut self,
         operation: ClauseSnapshotOperation,
         _previous_candidates: &Candidates,
+        _selected_candidate_id: u64,
     ) -> anyhow::Result<()> {
         match operation {
             ClauseSnapshotOperation::Push => self.pushes += 1,
@@ -1993,7 +2027,7 @@ fn prepare_future_clauses_bounds_suffix_clone_work() {
     let mut backend = BoundedPrepareBackend::default();
 
     let (prepared, completed) = backend
-        .prepare_future_clauses(1, &previous, false)
+        .prepare_future_clauses(1, &previous, 0, false)
         .expect("bounded preparation should succeed");
 
     assert_eq!(prepared.len(), shared::MAX_PREPARED_CLAUSE_ADVANCES);
@@ -2741,6 +2775,7 @@ impl ClauseActionBackend for InitialSplitSingleNBoundaryBackend {
         &mut self,
         operation: ClauseSnapshotOperation,
         _previous_candidates: &Candidates,
+        _selected_candidate_id: u64,
     ) -> anyhow::Result<()> {
         match operation {
             ClauseSnapshotOperation::Push => {

--- a/crates/client/src/engine/composition/tests/snapshot_restore.rs
+++ b/crates/client/src/engine/composition/tests/snapshot_restore.rs
@@ -153,6 +153,7 @@ impl ClauseActionBackend for RichNavigationAfterShrinkBackend {
         &mut self,
         _offset: i32,
         _previous_candidates: &Candidates,
+        _selected_candidate_id: u64,
     ) -> anyhow::Result<ClauseAdvance> {
         Ok(ClauseAdvance {
             shrunk: self.shrink_candidates.clone(),
@@ -190,6 +191,7 @@ impl ClauseActionBackend for DesynchronizedFutureRestoreBackend {
         &mut self,
         _offset: i32,
         _previous_candidates: &Candidates,
+        _selected_candidate_id: u64,
     ) -> anyhow::Result<ClauseAdvance> {
         self.snapshot_depth += 1;
         Ok(ClauseAdvance {
@@ -203,6 +205,7 @@ impl ClauseActionBackend for DesynchronizedFutureRestoreBackend {
         &mut self,
         operation: ClauseSnapshotOperation,
         _previous_candidates: &Candidates,
+        _selected_candidate_id: u64,
     ) -> anyhow::Result<()> {
         if operation == ClauseSnapshotOperation::Pop {
             assert!(self.snapshot_depth > 0, "server snapshot stack underflow");

--- a/crates/client/src/engine/composition/tests/stateful_harness.rs
+++ b/crates/client/src/engine/composition/tests/stateful_harness.rs
@@ -1545,6 +1545,7 @@ impl ClauseActionBackend for ScenarioBackend {
         &mut self,
         operation: ClauseSnapshotOperation,
         _previous_candidates: &Candidates,
+        _selected_candidate_id: u64,
     ) -> anyhow::Result<()> {
         match operation {
             ClauseSnapshotOperation::Clear => {

--- a/crates/client/src/engine/ipc_service.rs
+++ b/crates/client/src/engine/ipc_service.rs
@@ -1162,10 +1162,14 @@ impl IPCService {
     fn send_advance_clause(
         &mut self,
         offset: i32,
+        selected_candidate_id: u64,
         request_id: u64,
     ) -> anyhow::Result<super::composition::ClauseAdvance> {
-        let mut request =
-            tonic::Request::new(shared::proto::AdvanceClauseRequest { offset, request_id });
+        let mut request = tonic::Request::new(shared::proto::AdvanceClauseRequest {
+            offset,
+            request_id,
+            selected_candidate_id,
+        });
         request.set_timeout(INPUT_RPC_DEADLINE);
         let response = Self::block_on_server_rpc(
             self.runtime.as_ref(),
@@ -1194,6 +1198,7 @@ impl IPCService {
     fn send_prepare_future_clauses(
         &mut self,
         initial_offset: i32,
+        initial_selected_candidate_id: u64,
         request_id: u64,
         leave_at_last: bool,
     ) -> anyhow::Result<(Vec<super::composition::ClauseAdvance>, bool)> {
@@ -1201,6 +1206,7 @@ impl IPCService {
             initial_offset,
             request_id,
             leave_at_last,
+            initial_selected_candidate_id,
         });
         request.set_timeout(INPUT_RPC_DEADLINE);
         let response = Self::block_on_server_rpc(
@@ -1310,11 +1316,13 @@ impl IPCService {
     fn send_update_composition_snapshot(
         &mut self,
         operation: ClauseSnapshotOperation,
+        selected_candidate_id: u64,
         request_id: u64,
     ) -> anyhow::Result<()> {
         let mut request = tonic::Request::new(shared::proto::UpdateCompositionSnapshotRequest {
             operation: operation.proto_value(),
             request_id,
+            selected_candidate_id,
         });
         request.set_timeout(INPUT_RPC_DEADLINE);
         let response = Self::block_on_server_rpc(
@@ -1924,6 +1932,7 @@ impl IPCService {
         &mut self,
         offset: i32,
         previous_candidates: &Candidates,
+        selected_candidate_id: u64,
     ) -> anyhow::Result<super::composition::ClauseAdvance> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
@@ -1934,7 +1943,8 @@ impl IPCService {
             Some(previous_candidates),
             None,
             |this| {
-                let advance = this.send_advance_clause(offset, request_id)?;
+                let advance =
+                    this.send_advance_clause(offset, selected_candidate_id, request_id)?;
                 let navigation = advance.navigation.clone();
                 completed_advance = Some(advance);
                 Ok(navigation)
@@ -1970,39 +1980,50 @@ impl IPCService {
         &mut self,
         initial_offset: i32,
         previous_candidates: &Candidates,
+        initial_selected_candidate_id: u64,
         leave_at_last: bool,
     ) -> anyhow::Result<(Vec<super::composition::ClauseAdvance>, bool)> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
         let result = if leave_at_last {
-            self.send_prepare_future_clauses(initial_offset, request_id, true)
-                .map_err(|error| {
-                    if Self::should_reconnect_rpc_error(&error) {
-                        Self::mark_server_recovery_required(
-                            &self.recovery,
-                            "prepare_future_clauses_to_last_failed",
-                        );
-                        preserve_recovery_error(error)
-                    } else {
-                        error
-                    }
-                })
-                .and_then(|prepared| {
-                    if self.take_server_reset_recovered() {
-                        Self::mark_server_recovery_required(
-                            &self.recovery,
-                            "prepare_future_clauses_to_last_session_change",
-                        );
-                        Err(preserve_recovery_error(anyhow::anyhow!(
-                            "prepare_future_clauses_to_last reached a different server session"
-                        )))
-                    } else {
-                        Ok(prepared)
-                    }
-                })
+            self.send_prepare_future_clauses(
+                initial_offset,
+                initial_selected_candidate_id,
+                request_id,
+                true,
+            )
+            .map_err(|error| {
+                if Self::should_reconnect_rpc_error(&error) {
+                    Self::mark_server_recovery_required(
+                        &self.recovery,
+                        "prepare_future_clauses_to_last_failed",
+                    );
+                    preserve_recovery_error(error)
+                } else {
+                    error
+                }
+            })
+            .and_then(|prepared| {
+                if self.take_server_reset_recovered() {
+                    Self::mark_server_recovery_required(
+                        &self.recovery,
+                        "prepare_future_clauses_to_last_session_change",
+                    );
+                    Err(preserve_recovery_error(anyhow::anyhow!(
+                        "prepare_future_clauses_to_last reached a different server session"
+                    )))
+                } else {
+                    Ok(prepared)
+                }
+            })
         } else {
             self.run_rpc_with_reconnect("prepare_future_clauses", |this| {
-                this.send_prepare_future_clauses(initial_offset, request_id, false)
+                this.send_prepare_future_clauses(
+                    initial_offset,
+                    initial_selected_candidate_id,
+                    request_id,
+                    false,
+                )
             })
             .map_err(|error| {
                 if Self::should_reconnect_rpc_error(&error) {
@@ -2170,10 +2191,12 @@ impl IPCService {
         &mut self,
         operation: ClauseSnapshotOperation,
         previous_candidates: &Candidates,
+        selected_candidate_id: u64,
     ) -> anyhow::Result<()> {
         let request_id = current_or_next_request_id();
         let performance_start = client_performance_start();
-        let first_attempt = self.send_update_composition_snapshot(operation, request_id);
+        let first_attempt =
+            self.send_update_composition_snapshot(operation, selected_candidate_id, request_id);
         let result: anyhow::Result<NonIdempotentEditRecovery> =
             (|| match Self::classify_non_idempotent_edit_attempt(
                 "update_composition_snapshot",
@@ -2197,7 +2220,11 @@ impl IPCService {
                         None,
                         None,
                     ) {
-                        self.send_update_composition_snapshot(operation, request_id)?;
+                        self.send_update_composition_snapshot(
+                            operation,
+                            selected_candidate_id,
+                            request_id,
+                        )?;
                         Ok(NonIdempotentEditRecovery::RetriedAfterUnchangedRefresh)
                     } else {
                         Ok(NonIdempotentEditRecovery::RefreshedAfterReconnect)

--- a/crates/client/src/trace.rs
+++ b/crates/client/src/trace.rs
@@ -150,7 +150,21 @@ fn setup_logger() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::contain_logger_initialization;
+    use std::cell::Cell;
+
+    use super::{contain_logger_initialization, diagnostic_log_lazy};
+
+    #[test]
+    fn disabled_diagnostic_log_does_not_build_message() {
+        let called = Cell::new(false);
+
+        diagnostic_log_lazy(|| {
+            called.set(true);
+            "candidate and snapshot details".to_owned()
+        });
+
+        assert!(!called.get());
+    }
 
     #[test]
     fn logger_initialization_error_is_contained() {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -421,8 +421,9 @@ unsafe extern "C" {
         cursorOffsetPtr: *mut c_int,
     ) -> *mut c_char;
     fn ClearComposingTextSnapshots();
-    fn PushComposingTextSnapshot();
-    fn PopComposingTextSnapshot();
+    fn PushComposingTextSnapshot(selectedCandidateId: u64);
+    fn PopComposingTextSnapshot(selectedCandidateId: u64);
+    fn PinLearningCandidate(candidateId: u64) -> bool;
     fn ShrinkText(offset: c_int) -> *mut c_char;
     fn ClearText();
     fn Warmup() -> bool;
@@ -1488,9 +1489,9 @@ struct CompositionSnapshotRollback {
 }
 
 impl CompositionSnapshotRollback {
-    fn push() -> Self {
+    fn push(selected_candidate_id: u64) -> Self {
         unsafe {
-            PushComposingTextSnapshot();
+            PushComposingTextSnapshot(selected_candidate_id);
         }
         Self { armed: true }
     }
@@ -1504,7 +1505,7 @@ impl Drop for CompositionSnapshotRollback {
     fn drop(&mut self) {
         if self.armed {
             unsafe {
-                PopComposingTextSnapshot();
+                PopComposingTextSnapshot(0);
             }
         }
     }
@@ -1941,8 +1942,12 @@ impl AzookeyService for MyAzookeyService {
                     ));
                 }
                 CompositionSnapshotOperation::Clear => ClearComposingTextSnapshots(),
-                CompositionSnapshotOperation::Push => PushComposingTextSnapshot(),
-                CompositionSnapshotOperation::Pop => PopComposingTextSnapshot(),
+                CompositionSnapshotOperation::Push => {
+                    PushComposingTextSnapshot(request.selected_candidate_id)
+                }
+                CompositionSnapshotOperation::Pop => {
+                    PopComposingTextSnapshot(request.selected_candidate_id)
+                }
             }
         }
         performance_event_lazy!(
@@ -2056,7 +2061,7 @@ impl AzookeyService for MyAzookeyService {
         let handler_start = Instant::now();
         let raw_offset = validate_shrink_offset(request.offset)?;
 
-        let snapshot_rollback = CompositionSnapshotRollback::push();
+        let snapshot_rollback = CompositionSnapshotRollback::push(request.selected_candidate_id);
 
         let shrink_start = Instant::now();
         let shrunk_text =
@@ -2128,11 +2133,12 @@ impl AzookeyService for MyAzookeyService {
         let mut snapshot_count = 0usize;
         let mut last_signature = None;
         let mut completed = false;
+        let mut selected_candidate_id = request.initial_selected_candidate_id;
 
         let result = (|| -> Result<(), Box<Status>> {
             for _ in 0..shared::MAX_PREPARED_CLAUSE_ADVANCES {
                 unsafe {
-                    PushComposingTextSnapshot();
+                    PushComposingTextSnapshot(selected_candidate_id);
                 }
                 snapshot_count += 1;
 
@@ -2150,6 +2156,10 @@ impl AzookeyService for MyAzookeyService {
                 let Some(selected) = navigation_composed.suggestions.first() else {
                     break;
                 };
+                selected_candidate_id = selected.candidate_id;
+                unsafe {
+                    PinLearningCandidate(selected_candidate_id);
+                }
                 let is_last = selected.subtext.is_empty();
                 let signature = (
                     navigation_composed
@@ -2192,7 +2202,7 @@ impl AzookeyService for MyAzookeyService {
         );
         for _ in retained_snapshot_count..snapshot_count {
             unsafe {
-                PopComposingTextSnapshot();
+                PopComposingTextSnapshot(0);
             }
         }
         result.map_err(|status| *status)?;
@@ -2465,7 +2475,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     register_server_log_callbacks();
 
-    // プロセス優先度を HIGH_PRIORITY_CLASS に引き上げ（放置後のOSスケジューリング遅延を抑制）
+    // Keep IME RPC latency predictable when other applications saturate the CPU.
     unsafe {
         match SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS) {
             Ok(()) => log_event_lazy!(ServerLogLevel::Info, "process priority set to HIGH"),

--- a/crates/shared/service.proto
+++ b/crates/shared/service.proto
@@ -109,6 +109,10 @@ enum CompositionSnapshotOperation {
 message UpdateCompositionSnapshotRequest {
   CompositionSnapshotOperation operation = 1;
   uint64 request_id = 2;
+  // Candidate selected by the client when pushing or popping a clause
+  // snapshot. The server keeps only this still-referenced learning candidate
+  // when bounded candidate batches are evicted.
+  uint64 selected_candidate_id = 3;
 }
 
 message UpdateCompositionSnapshotResponse {
@@ -131,6 +135,7 @@ message ShrinkTextResponse {
 message AdvanceClauseRequest {
   int32 offset = 1;
   uint64 request_id = 2;
+  uint64 selected_candidate_id = 3;
 }
 
 message AdvanceClauseResponse {
@@ -154,6 +159,7 @@ message PrepareFutureClausesRequest {
   // prepared clause. Used by initial left-arrow navigation so the client can
   // move to the last clause without replaying one RPC per clause.
   bool leave_at_last = 3;
+  uint64 initial_selected_candidate_id = 4;
 }
 
 message PrepareFutureClausesResponse {

--- a/scripts/measure_server_resources.ps1
+++ b/scripts/measure_server_resources.ps1
@@ -1,0 +1,55 @@
+<#
+.SYNOPSIS
+Samples azookey-server CPU, memory, and priority without instrumenting the input path.
+
+.EXAMPLE
+powershell -NoProfile -File scripts/measure_server_resources.ps1 `
+    -DurationSeconds 180 > server-resources.tsv
+#>
+
+param(
+    [ValidateRange(1, 86400)]
+    [int]$DurationSeconds = 95,
+
+    [ValidateRange(100, 60000)]
+    [int]$SampleIntervalMilliseconds = 1000,
+
+    [ValidateNotNullOrEmpty()]
+    [string]$ProcessName = "azookey-server"
+)
+
+$ErrorActionPreference = "Stop"
+$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+"timestamp_utc`telapsed_ms`tpid`tcpu_seconds`tprivate_bytes`tworking_set_bytes`tpriority_class`tthread_count`thandle_count"
+
+while ($stopwatch.Elapsed.TotalSeconds -lt $DurationSeconds) {
+    $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue |
+        Sort-Object StartTime -Descending |
+        Select-Object -First 1
+
+    if ($null -ne $process) {
+        try {
+            $process.Refresh()
+            @(
+                [DateTime]::UtcNow.ToString("O")
+                [int64]$stopwatch.ElapsedMilliseconds
+                $process.Id
+                $process.TotalProcessorTime.TotalSeconds.ToString(
+                    "F6",
+                    [Globalization.CultureInfo]::InvariantCulture
+                )
+                $process.PrivateMemorySize64
+                $process.WorkingSet64
+                $process.PriorityClass
+                $process.Threads.Count
+                $process.HandleCount
+            ) -join "`t"
+        } catch [System.InvalidOperationException] {
+            # The process exited between lookup and sampling. The next sample
+            # will pick up a restarted server without terminating the probe.
+        }
+    }
+
+    Start-Sleep -Milliseconds $SampleIntervalMilliseconds
+}

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -520,6 +520,7 @@ struct LearningCandidateCache {
         let firstId: UInt64
         let candidates: [Candidate]
         var consumedOffsets: Set<Int> = []
+        var isProtected = false
     }
 
     private let maxBatchCount: Int
@@ -528,10 +529,9 @@ struct LearningCandidateCache {
     private var firstBatchIndex = 0
     private var nextCandidateId: UInt64 = 1
     private var idSpaceExhausted = false
-    private var pinnedCandidates: [UInt64: Candidate] = [:]
     private(set) var slotCount = 0
     private(set) var batchCount = 0
-    var pinnedCandidateCount: Int { pinnedCandidates.count }
+    private(set) var protectedSlotCount = 0
 
     init(
         maxBatchCount: Int = maxLearningCandidateCacheBatchCount,
@@ -549,8 +549,12 @@ struct LearningCandidateCache {
             return nil
         }
 
-        let retainedCandidates = if candidates.count > maxSlotCount {
-            Array(candidates.prefix(maxSlotCount))
+        let availableBatchSlotCount = maxSlotCount - protectedSlotCount
+        guard availableBatchSlotCount > 0 else {
+            return nil
+        }
+        let retainedCandidates = if candidates.count > availableBatchSlotCount {
+            Array(candidates.prefix(availableBatchSlotCount))
         } else {
             candidates
         }
@@ -564,7 +568,9 @@ struct LearningCandidateCache {
         while batchCount == maxBatchCount
             || slotCount > maxSlotCount - retainedCandidates.count
         {
-            evictOldestBatch()
+            guard evictOldestUnprotectedBatch() else {
+                return nil
+            }
         }
 
         let firstId = nextCandidateId
@@ -595,17 +601,20 @@ struct LearningCandidateCache {
         guard candidateId > 0 else {
             return false
         }
-        if pinnedCandidates[candidateId] != nil {
-            return true
-        }
         guard let location = candidateLocation(for: candidateId),
               !batches[location.batchIndex]!.consumedOffsets.contains(location.candidateIndex)
         else {
             return false
         }
+        if batches[location.batchIndex]!.isProtected {
+            return true
+        }
 
-        pinnedCandidates[candidateId] =
-            batches[location.batchIndex]!.candidates[location.candidateIndex]
+        // A client snapshot can later select any candidate from this batch.
+        // Protect the complete batch so every issued nonzero ID stays valid.
+        let candidateCount = batches[location.batchIndex]!.candidates.count
+        batches[location.batchIndex]!.isProtected = true
+        protectedSlotCount += candidateCount
         return true
     }
 
@@ -613,17 +622,15 @@ struct LearningCandidateCache {
         guard candidateId > 0 else {
             return nil
         }
-        let pinnedCandidate = pinnedCandidates.removeValue(forKey: candidateId)
         guard let location = candidateLocation(for: candidateId) else {
-            return pinnedCandidate
+            return nil
         }
         guard batches[location.batchIndex]!.consumedOffsets
             .insert(location.candidateIndex).inserted else {
             return nil
         }
 
-        return pinnedCandidate
-            ?? batches[location.batchIndex]!.candidates[location.candidateIndex]
+        return batches[location.batchIndex]!.candidates[location.candidateIndex]
     }
 
     mutating func removeAll() {
@@ -633,11 +640,17 @@ struct LearningCandidateCache {
         firstBatchIndex = 0
         batchCount = 0
         slotCount = 0
-        pinnedCandidates.removeAll(keepingCapacity: false)
+        protectedSlotCount = 0
     }
 
     mutating func removeAllPins() {
-        pinnedCandidates.removeAll(keepingCapacity: false)
+        guard protectedSlotCount > 0 else {
+            return
+        }
+        for logicalIndex in 0..<batchCount {
+            batches[physicalIndex(forLogicalIndex: logicalIndex)]!.isProtected = false
+        }
+        protectedSlotCount = 0
     }
 
     private func physicalIndex(forLogicalIndex logicalIndex: Int) -> Int {
@@ -671,16 +684,38 @@ struct LearningCandidateCache {
         return (batchIndex, Int(offset))
     }
 
-    private mutating func evictOldestBatch() {
-        guard batchCount > 0,
-              let oldestBatch = batches[firstBatchIndex] else {
-            return
+    private mutating func evictOldestUnprotectedBatch() -> Bool {
+        guard batchCount > 0 else {
+            return false
         }
 
-        slotCount -= oldestBatch.candidates.count
-        batches[firstBatchIndex] = nil
-        firstBatchIndex = (firstBatchIndex + 1) % maxBatchCount
+        var victimLogicalIndex: Int?
+        for logicalIndex in 0..<batchCount {
+            let batchIndex = physicalIndex(forLogicalIndex: logicalIndex)
+            if !batches[batchIndex]!.isProtected {
+                victimLogicalIndex = logicalIndex
+                break
+            }
+        }
+        guard let victimLogicalIndex else {
+            return false
+        }
+
+        let victimBatchIndex = physicalIndex(forLogicalIndex: victimLogicalIndex)
+        slotCount -= batches[victimBatchIndex]!.candidates.count
+        if victimLogicalIndex == 0 {
+            batches[victimBatchIndex] = nil
+            firstBatchIndex = (firstBatchIndex + 1) % maxBatchCount
+        } else {
+            for logicalIndex in victimLogicalIndex..<(batchCount - 1) {
+                let destination = physicalIndex(forLogicalIndex: logicalIndex)
+                let source = physicalIndex(forLogicalIndex: logicalIndex + 1)
+                batches[destination] = batches[source]
+            }
+            batches[physicalIndex(forLogicalIndex: batchCount - 1)] = nil
+        }
         batchCount -= 1
+        return true
     }
 }
 
@@ -718,7 +753,7 @@ struct LearningCandidateCache {
 // so release their selected candidates without adding another IPC round trip.
 @MainActor func discardPinnedLearningCandidatesBeforeCompositionEdit() {
     guard composingTextSnapshots.isEmpty,
-          learningCandidateCache.pinnedCandidateCount > 0 else {
+          learningCandidateCache.protectedSlotCount > 0 else {
         return
     }
     learningCandidateCache.removeAllPins()
@@ -1719,7 +1754,7 @@ private struct WarmupExecutionSnapshot: Sendable {
     let useZenzai: Bool
     let learningCacheBatchCount: Int
     let learningCacheSlotCount: Int
-    let learningCachePinnedCount: Int
+    let learningCacheProtectedSlotCount: Int
     let diagnosticDetails: String
 }
 
@@ -1794,7 +1829,7 @@ private final class BackgroundWarmupRunner: @unchecked Sendable {
             operation: "warmup_resources",
             stage: "before_request_candidates",
             elapsedMs: 0,
-            details: "foreground_converter_count=2;background_converter_count=\(converter == nil ? 0 : 1);background_converter_reused=\(reusedConverter);background_preload_dictionary=\(snapshot.preloadDictionary);background_use_zenzai=\(snapshot.useZenzai);learning_cache_batches=\(snapshot.learningCacheBatchCount);learning_cache_slots=\(snapshot.learningCacheSlotCount);learning_cache_pinned=\(snapshot.learningCachePinnedCount)"
+            details: "foreground_converter_count=2;background_converter_count=\(converter == nil ? 0 : 1);background_converter_reused=\(reusedConverter);background_preload_dictionary=\(snapshot.preloadDictionary);background_use_zenzai=\(snapshot.useZenzai);learning_cache_batches=\(snapshot.learningCacheBatchCount);learning_cache_slots=\(snapshot.learningCacheSlotCount);learning_cache_protected_slots=\(snapshot.learningCacheProtectedSlotCount)"
         )
         if converterKey != key || converter == nil {
             converter = KanaKanjiConverter(
@@ -1823,7 +1858,7 @@ private final class BackgroundWarmupRunner: @unchecked Sendable {
             operation: "warmup",
             stage: "request_candidates",
             elapsedMs: requestMs,
-            details: "candidate_count=\(converted.mainResults.count);foreground_converter_count=2;background_converter_count=1;background_converter_reused=\(reusedConverter);learning_cache_batches=\(snapshot.learningCacheBatchCount);learning_cache_slots=\(snapshot.learningCacheSlotCount);learning_cache_pinned=\(snapshot.learningCachePinnedCount);\(snapshot.diagnosticDetails)"
+            details: "candidate_count=\(converted.mainResults.count);foreground_converter_count=2;background_converter_count=1;background_converter_reused=\(reusedConverter);learning_cache_batches=\(snapshot.learningCacheBatchCount);learning_cache_slots=\(snapshot.learningCacheSlotCount);learning_cache_protected_slots=\(snapshot.learningCacheProtectedSlotCount);\(snapshot.diagnosticDetails)"
         )
         crashTrace(
             requestId: snapshot.requestId,
@@ -1895,7 +1930,7 @@ private let backgroundWarmupRunner = BackgroundWarmupRunner()
         useZenzai: useZenzai,
         learningCacheBatchCount: learningCandidateCache.batchCount,
         learningCacheSlotCount: learningCandidateCache.slotCount,
-        learningCachePinnedCount: learningCandidateCache.pinnedCandidateCount,
+        learningCacheProtectedSlotCount: learningCandidateCache.protectedSlotCount,
         diagnosticDetails: diagnosticDetails
     )
 }
@@ -2495,7 +2530,7 @@ func cursorPrefixBoundaryFirstClauseResults(
     composingTextSnapshots.append(composingText)
     serverLog(
         "DEBUG",
-        "PushComposingTextSnapshot: completed count=\(composingTextSnapshots.count) pinnedLearningCandidates=\(learningCandidateCache.pinnedCandidateCount)"
+        "PushComposingTextSnapshot: completed count=\(composingTextSnapshots.count) protectedLearningCandidateSlots=\(learningCandidateCache.protectedSlotCount)"
     )
 }
 
@@ -2879,7 +2914,7 @@ public func free_candidate_list(
             operation: "get_composed_text",
             stage: "build_ffi_candidates_total",
             elapsedMs: elapsedPerformanceMilliseconds(since: buildStart),
-            details: "candidate_count=\(result.count);main_candidate_count=\(mainResults.count);zenzai_candidate_count=\(converted.mainResults.count);normal_nbest_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);cache_entries=\(resolutionCache.count);string_allocations=\(stringAllocationCount);learning_cache_batches=\(learningCandidateCache.batchCount);learning_cache_slots=\(learningCandidateCache.slotCount);learning_cache_pinned=\(learningCandidateCache.pinnedCandidateCount);\(diagnosticDetails)"
+            details: "candidate_count=\(result.count);main_candidate_count=\(mainResults.count);zenzai_candidate_count=\(converted.mainResults.count);normal_nbest_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);cache_entries=\(resolutionCache.count);string_allocations=\(stringAllocationCount);learning_cache_batches=\(learningCandidateCache.batchCount);learning_cache_slots=\(learningCandidateCache.slotCount);learning_cache_protected_slots=\(learningCandidateCache.protectedSlotCount);\(diagnosticDetails)"
         )
     }
     candidateCrashTrace(
@@ -3210,7 +3245,7 @@ public func free_candidate_list(
             operation: "get_composed_text_for_cursor_prefix",
             stage: "build_ffi_candidates_total",
             elapsedMs: elapsedPerformanceMilliseconds(since: buildStart),
-            details: "candidate_count=\(result.count);first_clause_candidate_count=\(cursorPrefixFirstClauseResults.count);main_candidate_count=\(cursorPrefixMainResults.count);zenzai_first_clause_candidate_count=\(converted.firstClauseResults.count);zenzai_main_candidate_count=\(converted.mainResults.count);normal_nbest_first_clause_candidate_count=\(normalNBestConverted?.firstClauseResults.count ?? 0);normal_nbest_main_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);exact_clause_candidate_count=\(exactClauseResults.count);cache_entries=\(cursorPrefixResolutionCache.count);string_allocations=\(stringAllocationCount);learning_cache_batches=\(learningCandidateCache.batchCount);learning_cache_slots=\(learningCandidateCache.slotCount);learning_cache_pinned=\(learningCandidateCache.pinnedCandidateCount);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+            details: "candidate_count=\(result.count);first_clause_candidate_count=\(cursorPrefixFirstClauseResults.count);main_candidate_count=\(cursorPrefixMainResults.count);zenzai_first_clause_candidate_count=\(converted.firstClauseResults.count);zenzai_main_candidate_count=\(converted.mainResults.count);normal_nbest_first_clause_candidate_count=\(normalNBestConverted?.firstClauseResults.count ?? 0);normal_nbest_main_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);exact_clause_candidate_count=\(exactClauseResults.count);cache_entries=\(cursorPrefixResolutionCache.count);string_allocations=\(stringAllocationCount);learning_cache_batches=\(learningCandidateCache.batchCount);learning_cache_slots=\(learningCandidateCache.slotCount);learning_cache_protected_slots=\(learningCandidateCache.protectedSlotCount);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
         )
     }
     candidateCrashTrace(

--- a/server-swift/Sources/azookey-server/azookey_server.swift
+++ b/server-swift/Sources/azookey-server/azookey_server.swift
@@ -45,8 +45,16 @@ let zenzaiWarmupRomanInput = "nihongo"
 let warmupRequestCandidatesWarningMs = 5_000
 // Request exact-clause supplements only when boundary-matched candidates are sparse.
 let cursorPrefixExactClauseSupplementCandidateThreshold = 5
+// Bound bulk candidate generations while retaining the current clause plus at
+// most 16 prepared future clauses with more than 2x slot headroom at the
+// observed high-water mark of 201 candidates per generation. Past clauses can
+// outlive this ring, so their one selected candidate is pinned separately until
+// the composition is cleared.
+let maxLearningCandidateCacheBatchCount = 64
+let maxLearningCandidateCacheSlotCount = 8_192
 let maxLearningSelectionOverrideCount = 4_096
 let learningSelectionOverridesFilename = "selection-overrides.json"
+let backgroundWarmupPreloadsDictionary = false
 
 @MainActor var currentRequestId: UInt64 = 0
 
@@ -511,19 +519,29 @@ struct LearningCandidateCache {
     private struct Batch {
         let firstId: UInt64
         let candidates: [Candidate]
+        var consumedOffsets: Set<Int> = []
     }
 
-    private var batches: [Batch] = []
+    private let maxBatchCount: Int
+    private let maxSlotCount: Int
+    private var batches: [Batch?]
+    private var firstBatchIndex = 0
     private var nextCandidateId: UInt64 = 1
     private var idSpaceExhausted = false
-    private var consumedCandidateIds: Set<UInt64> = []
+    private var pinnedCandidates: [UInt64: Candidate] = [:]
+    private(set) var slotCount = 0
+    private(set) var batchCount = 0
+    var pinnedCandidateCount: Int { pinnedCandidates.count }
 
-    var slotCount: Int {
-        batches.reduce(into: 0) { $0 += $1.candidates.count }
-    }
-
-    var batchCount: Int {
-        batches.count
+    init(
+        maxBatchCount: Int = maxLearningCandidateCacheBatchCount,
+        maxSlotCount: Int = maxLearningCandidateCacheSlotCount
+    ) {
+        precondition(maxBatchCount > 0)
+        precondition(maxSlotCount > 0)
+        self.maxBatchCount = maxBatchCount
+        self.maxSlotCount = maxSlotCount
+        self.batches = Array(repeating: nil, count: maxBatchCount)
     }
 
     mutating func appendBatch(_ candidates: [Candidate]) -> UInt64? {
@@ -531,22 +549,40 @@ struct LearningCandidateCache {
             return nil
         }
 
-        let candidateCount = UInt64(candidates.count)
+        let retainedCandidates = if candidates.count > maxSlotCount {
+            Array(candidates.prefix(maxSlotCount))
+        } else {
+            candidates
+        }
+        let candidateCount = UInt64(retainedCandidates.count)
         let (nextId, overflow) = nextCandidateId.addingReportingOverflow(candidateCount)
         if overflow {
             idSpaceExhausted = true
             return nil
         }
 
+        while batchCount == maxBatchCount
+            || slotCount > maxSlotCount - retainedCandidates.count
+        {
+            evictOldestBatch()
+        }
+
         let firstId = nextCandidateId
-        batches.append(Batch(firstId: firstId, candidates: candidates))
+        let insertionIndex = physicalIndex(forLogicalIndex: batchCount)
+        batches[insertionIndex] = Batch(
+            firstId: firstId,
+            candidates: retainedCandidates
+        )
+        batchCount += 1
+        slotCount += retainedCandidates.count
         nextCandidateId = nextId
         return firstId
     }
 
     func candidateId(at index: Int, batchFirstId: UInt64) -> UInt64 {
         guard index >= 0,
-              let batch = batches.last,
+              batchCount > 0,
+              let batch = batches[physicalIndex(forLogicalIndex: batchCount - 1)],
               batch.firstId == batchFirstId,
               index < batch.candidates.count else {
             return 0
@@ -555,17 +591,68 @@ struct LearningCandidateCache {
         return batchFirstId + UInt64(index)
     }
 
+    mutating func pin(_ candidateId: UInt64) -> Bool {
+        guard candidateId > 0 else {
+            return false
+        }
+        if pinnedCandidates[candidateId] != nil {
+            return true
+        }
+        guard let location = candidateLocation(for: candidateId),
+              !batches[location.batchIndex]!.consumedOffsets.contains(location.candidateIndex)
+        else {
+            return false
+        }
+
+        pinnedCandidates[candidateId] =
+            batches[location.batchIndex]!.candidates[location.candidateIndex]
+        return true
+    }
+
     mutating func consume(_ candidateId: UInt64) -> Candidate? {
-        guard candidateId > 0,
-              consumedCandidateIds.insert(candidateId).inserted else {
+        guard candidateId > 0 else {
+            return nil
+        }
+        let pinnedCandidate = pinnedCandidates.removeValue(forKey: candidateId)
+        guard let location = candidateLocation(for: candidateId) else {
+            return pinnedCandidate
+        }
+        guard batches[location.batchIndex]!.consumedOffsets
+            .insert(location.candidateIndex).inserted else {
             return nil
         }
 
+        return pinnedCandidate
+            ?? batches[location.batchIndex]!.candidates[location.candidateIndex]
+    }
+
+    mutating func removeAll() {
+        for index in batches.indices {
+            batches[index] = nil
+        }
+        firstBatchIndex = 0
+        batchCount = 0
+        slotCount = 0
+        pinnedCandidates.removeAll(keepingCapacity: false)
+    }
+
+    mutating func removeAllPins() {
+        pinnedCandidates.removeAll(keepingCapacity: false)
+    }
+
+    private func physicalIndex(forLogicalIndex logicalIndex: Int) -> Int {
+        (firstBatchIndex + logicalIndex) % maxBatchCount
+    }
+
+    private func candidateLocation(
+        for candidateId: UInt64
+    ) -> (batchIndex: Int, candidateIndex: Int)? {
         var lowerBound = 0
-        var upperBound = batches.count
+        var upperBound = batchCount
         while lowerBound < upperBound {
             let middle = lowerBound + (upperBound - lowerBound) / 2
-            if batches[middle].firstId <= candidateId {
+            let batch = batches[physicalIndex(forLogicalIndex: middle)]!
+            if batch.firstId <= candidateId {
                 lowerBound = middle + 1
             } else {
                 upperBound = middle
@@ -573,22 +660,27 @@ struct LearningCandidateCache {
         }
 
         guard lowerBound > 0 else {
-            consumedCandidateIds.remove(candidateId)
             return nil
         }
-        let batch = batches[lowerBound - 1]
+        let batchIndex = physicalIndex(forLogicalIndex: lowerBound - 1)
+        let batch = batches[batchIndex]!
         let offset = candidateId - batch.firstId
         guard offset < UInt64(batch.candidates.count) else {
-            consumedCandidateIds.remove(candidateId)
             return nil
         }
-
-        return batch.candidates[Int(offset)]
+        return (batchIndex, Int(offset))
     }
 
-    mutating func removeAll() {
-        batches.removeAll(keepingCapacity: false)
-        consumedCandidateIds.removeAll(keepingCapacity: true)
+    private mutating func evictOldestBatch() {
+        guard batchCount > 0,
+              let oldestBatch = batches[firstBatchIndex] else {
+            return
+        }
+
+        slotCount -= oldestBatch.candidates.count
+        batches[firstBatchIndex] = nil
+        firstBatchIndex = (firstBatchIndex + 1) % maxBatchCount
+        batchCount -= 1
     }
 }
 
@@ -614,6 +706,22 @@ struct LearningCandidateCache {
 
 @MainActor func consumeLearningCandidate(_ candidateId: UInt64) -> Candidate? {
     learningCandidateCache.consume(candidateId)
+}
+
+@_silgen_name("PinLearningCandidate")
+@MainActor public func pin_learning_candidate(candidateId: UInt64) -> Bool {
+    learningCandidateCache.pin(candidateId)
+}
+
+// Client-side future snapshots do not have matching server composition
+// snapshots. The first subsequent composition edit invalidates those futures,
+// so release their selected candidates without adding another IPC round trip.
+@MainActor func discardPinnedLearningCandidatesBeforeCompositionEdit() {
+    guard composingTextSnapshots.isEmpty,
+          learningCandidateCache.pinnedCandidateCount > 0 else {
+        return
+    }
+    learningCandidateCache.removeAllPins()
 }
 
 private func normalizedLearningRuby(_ ruby: String) -> String {
@@ -1609,6 +1717,9 @@ private struct WarmupExecutionSnapshot: Sendable {
     let context: String
     let input: String
     let useZenzai: Bool
+    let learningCacheBatchCount: Int
+    let learningCacheSlotCount: Int
+    let learningCachePinnedCount: Int
     let diagnosticDetails: String
 }
 
@@ -1677,6 +1788,14 @@ private final class BackgroundWarmupRunner: @unchecked Sendable {
             dictionaryURL: snapshot.dictionaryURL,
             preloadDictionary: snapshot.preloadDictionary
         )
+        let reusedConverter = converterKey == key && converter != nil
+        performanceLog(
+            requestId: snapshot.requestId,
+            operation: "warmup_resources",
+            stage: "before_request_candidates",
+            elapsedMs: 0,
+            details: "foreground_converter_count=2;background_converter_count=\(converter == nil ? 0 : 1);background_converter_reused=\(reusedConverter);background_preload_dictionary=\(snapshot.preloadDictionary);background_use_zenzai=\(snapshot.useZenzai);learning_cache_batches=\(snapshot.learningCacheBatchCount);learning_cache_slots=\(snapshot.learningCacheSlotCount);learning_cache_pinned=\(snapshot.learningCachePinnedCount)"
+        )
         if converterKey != key || converter == nil {
             converter = KanaKanjiConverter(
                 dictionaryURL: snapshot.dictionaryURL,
@@ -1704,7 +1823,7 @@ private final class BackgroundWarmupRunner: @unchecked Sendable {
             operation: "warmup",
             stage: "request_candidates",
             elapsedMs: requestMs,
-            details: "candidate_count=\(converted.mainResults.count);\(snapshot.diagnosticDetails)"
+            details: "candidate_count=\(converted.mainResults.count);foreground_converter_count=2;background_converter_count=1;background_converter_reused=\(reusedConverter);learning_cache_batches=\(snapshot.learningCacheBatchCount);learning_cache_slots=\(snapshot.learningCacheSlotCount);learning_cache_pinned=\(snapshot.learningCachePinnedCount);\(snapshot.diagnosticDetails)"
         )
         crashTrace(
             requestId: snapshot.requestId,
@@ -1764,7 +1883,7 @@ private let backgroundWarmupRunner = BackgroundWarmupRunner()
     return WarmupExecutionSnapshot(
         requestId: currentRequestId,
         dictionaryURL: converterDictionaryURL,
-        preloadDictionary: converterPreloadDictionary,
+        preloadDictionary: backgroundWarmupPreloadsDictionary,
         runtimeDirectoryURL: converterRuntimeDirectoryURL(),
         emojiDictionaryURL: execURL
             .appendingPathComponent("EmojiDictionary")
@@ -1774,6 +1893,9 @@ private let backgroundWarmupRunner = BackgroundWarmupRunner()
         context: contextString,
         input: input,
         useZenzai: useZenzai,
+        learningCacheBatchCount: learningCandidateCache.batchCount,
+        learningCacheSlotCount: learningCandidateCache.slotCount,
+        learningCachePinnedCount: learningCandidateCache.pinnedCandidateCount,
         diagnosticDetails: diagnosticDetails
     )
 }
@@ -2033,6 +2155,7 @@ func cursorPrefixBoundaryFirstClauseResults(
         }
         composingText = ComposingText()
         composingTextSnapshots.removeAll()
+        clearLearningCandidateCache()
     }
     if previousLearningType != currentLearningType
         || previousLearningMemoryDirectoryURL != currentLearningMemoryDirectoryURL
@@ -2132,6 +2255,7 @@ func cursorPrefixBoundaryFirstClauseResults(
     input: UnsafePointer<CChar>,
     cursorPtr: UnsafeMutablePointer<CInt>
 ) -> UnsafeMutablePointer<CChar> {
+    discardPinnedLearningCandidatesBeforeCompositionEdit()
     let inputString = String(cString: input)
     serverLog("DEBUG", "AppendText: start inputLength=\(inputString.count) inputStyle=\(String(describing: currentInputStyle))")
     composingText.insertAtCursorPosition(inputString, inputStyle: currentInputStyle)
@@ -2149,6 +2273,7 @@ func cursorPrefixBoundaryFirstClauseResults(
     input: UnsafePointer<CChar>,
     cursorPtr: UnsafeMutablePointer<CInt>
 ) -> UnsafeMutablePointer<CChar> {
+    discardPinnedLearningCandidatesBeforeCompositionEdit()
     let inputString = String(cString: input)
     serverLog("DEBUG", "AppendTextDirect: start inputLength=\(inputString.count)")
     composingText.insertAtCursorPosition(inputString, inputStyle: .direct)
@@ -2165,6 +2290,7 @@ func cursorPrefixBoundaryFirstClauseResults(
 @MainActor public func remove_text(
     cursorPtr: UnsafeMutablePointer<CInt>
 ) -> UnsafeMutablePointer<CChar> {
+    discardPinnedLearningCandidatesBeforeCompositionEdit()
     serverLog("DEBUG", "RemoveText: start")
     composingText.deleteBackwardFromCursorPosition(count: 1)
 
@@ -2354,20 +2480,33 @@ func cursorPrefixBoundaryFirstClauseResults(
 @_silgen_name("ClearComposingTextSnapshots")
 @MainActor public func clear_composing_text_snapshots() {
     composingTextSnapshots.removeAll()
+    learningCandidateCache.removeAllPins()
     serverLog("DEBUG", "ClearComposingTextSnapshots: completed")
 }
 
 @_silgen_name("PushComposingTextSnapshot")
-@MainActor public func push_composing_text_snapshot() {
+@MainActor public func push_composing_text_snapshot(selectedCandidateId: UInt64) {
+    if selectedCandidateId != 0 && !pin_learning_candidate(candidateId: selectedCandidateId) {
+        serverLog(
+            "DEBUG",
+            "PushComposingTextSnapshot: learning candidate unavailable id=\(selectedCandidateId)"
+        )
+    }
     composingTextSnapshots.append(composingText)
     serverLog(
         "DEBUG",
-        "PushComposingTextSnapshot: completed count=\(composingTextSnapshots.count)"
+        "PushComposingTextSnapshot: completed count=\(composingTextSnapshots.count) pinnedLearningCandidates=\(learningCandidateCache.pinnedCandidateCount)"
     )
 }
 
 @_silgen_name("PopComposingTextSnapshot")
-@MainActor public func pop_composing_text_snapshot() {
+@MainActor public func pop_composing_text_snapshot(selectedCandidateId: UInt64) {
+    if selectedCandidateId != 0 && !pin_learning_candidate(candidateId: selectedCandidateId) {
+        serverLog(
+            "DEBUG",
+            "PopComposingTextSnapshot: learning candidate unavailable id=\(selectedCandidateId)"
+        )
+    }
     if let restored = composingTextSnapshots.popLast() {
         composingText = restored
     }
@@ -2740,7 +2879,7 @@ public func free_candidate_list(
             operation: "get_composed_text",
             stage: "build_ffi_candidates_total",
             elapsedMs: elapsedPerformanceMilliseconds(since: buildStart),
-            details: "candidate_count=\(result.count);main_candidate_count=\(mainResults.count);zenzai_candidate_count=\(converted.mainResults.count);normal_nbest_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);cache_entries=\(resolutionCache.count);string_allocations=\(stringAllocationCount);\(diagnosticDetails)"
+            details: "candidate_count=\(result.count);main_candidate_count=\(mainResults.count);zenzai_candidate_count=\(converted.mainResults.count);normal_nbest_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);cache_entries=\(resolutionCache.count);string_allocations=\(stringAllocationCount);learning_cache_batches=\(learningCandidateCache.batchCount);learning_cache_slots=\(learningCandidateCache.slotCount);learning_cache_pinned=\(learningCandidateCache.pinnedCandidateCount);\(diagnosticDetails)"
         )
     }
     candidateCrashTrace(
@@ -3071,7 +3210,7 @@ public func free_candidate_list(
             operation: "get_composed_text_for_cursor_prefix",
             stage: "build_ffi_candidates_total",
             elapsedMs: elapsedPerformanceMilliseconds(since: buildStart),
-            details: "candidate_count=\(result.count);first_clause_candidate_count=\(cursorPrefixFirstClauseResults.count);main_candidate_count=\(cursorPrefixMainResults.count);zenzai_first_clause_candidate_count=\(converted.firstClauseResults.count);zenzai_main_candidate_count=\(converted.mainResults.count);normal_nbest_first_clause_candidate_count=\(normalNBestConverted?.firstClauseResults.count ?? 0);normal_nbest_main_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);exact_clause_candidate_count=\(exactClauseResults.count);cache_entries=\(cursorPrefixResolutionCache.count);string_allocations=\(stringAllocationCount);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
+            details: "candidate_count=\(result.count);first_clause_candidate_count=\(cursorPrefixFirstClauseResults.count);main_candidate_count=\(cursorPrefixMainResults.count);zenzai_first_clause_candidate_count=\(converted.firstClauseResults.count);zenzai_main_candidate_count=\(converted.mainResults.count);normal_nbest_first_clause_candidate_count=\(normalNBestConverted?.firstClauseResults.count ?? 0);normal_nbest_main_candidate_count=\(normalNBestConverted?.mainResults.count ?? 0);exact_clause_candidate_count=\(exactClauseResults.count);cache_entries=\(cursorPrefixResolutionCache.count);string_allocations=\(stringAllocationCount);learning_cache_batches=\(learningCandidateCache.batchCount);learning_cache_slots=\(learningCandidateCache.slotCount);learning_cache_pinned=\(learningCandidateCache.pinnedCandidateCount);suffix_len=\(suffixAfterCursor.count);\(diagnosticDetails)"
         )
     }
     candidateCrashTrace(
@@ -3091,6 +3230,7 @@ public func free_candidate_list(
 @MainActor public func shrink_text(
     offset: Int32
 ) -> UnsafeMutablePointer<CChar>  {
+    discardPinnedLearningCandidatesBeforeCompositionEdit()
     serverLog("DEBUG", "ShrinkText: start offset=\(offset)")
     var afterComposingText = composingText
     let boundedOffset = min(max(Int(offset), 0), afterComposingText.input.count)

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -306,10 +306,52 @@ private func testCandidate(
 
     #expect(cache.batchCount == 2)
     #expect(cache.slotCount == 2)
-    #expect(cache.pinnedCandidateCount == 1)
+    #expect(cache.protectedSlotCount == 1)
     #expect(cache.consume(firstId)?.text == "今日")
     #expect(cache.consume(firstId) == nil)
-    #expect(cache.pinnedCandidateCount == 0)
+    #expect(cache.protectedSlotCount == 1)
+    cache.removeAllPins()
+    #expect(cache.protectedSlotCount == 0)
+}
+
+@Test func protectedLearningCandidateBatchesShareTheExplicitSlotLimit() {
+    var cache = LearningCandidateCache(maxBatchCount: 4, maxSlotCount: 3)
+    let first = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let alternate = testCandidate(
+        word: "教",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let later = testCandidate(
+        word: "京",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+
+    let firstBatchId = cache.appendBatch([first, alternate])!
+    let firstId = cache.candidateId(at: 0, batchFirstId: firstBatchId)
+    let alternateId = cache.candidateId(at: 1, batchFirstId: firstBatchId)
+    #expect(cache.pin(firstId))
+    #expect(cache.protectedSlotCount == 2)
+
+    let laterBatchId = cache.appendBatch([later])!
+    let laterId = cache.candidateId(at: 0, batchFirstId: laterBatchId)
+    #expect(cache.pin(laterId))
+    #expect(cache.slotCount == 3)
+    #expect(cache.protectedSlotCount == 3)
+    #expect(cache.appendBatch([later]) == nil)
+
+    // Protecting one selection preserves alternate nonzero IDs from the same
+    // client snapshot instead of copying only the selected candidate.
+    #expect(cache.consume(alternateId)?.text == "教")
+    #expect(cache.consume(laterId)?.text == "京")
+    cache.removeAllPins()
+    #expect(cache.protectedSlotCount == 0)
+    #expect(cache.appendBatch([later]) != nil)
 }
 
 @Test func compositionEditDiscardsFutureOnlyPinsWithoutExtraRPC() async {
@@ -342,7 +384,8 @@ private func testCandidate(
         composingTextSnapshots.removeAll()
         discardPinnedLearningCandidatesBeforeCompositionEdit()
 
-        #expect(learningCandidateCache.pinnedCandidateCount == 0)
+        #expect(learningCandidateCache.protectedSlotCount == 0)
+        _ = learningCandidateCache.appendBatch([candidate])
         #expect(learningCandidateCache.consume(candidateId) == nil)
 
         learningCandidateCache.removeAll()
@@ -355,7 +398,7 @@ private func testCandidate(
         #expect(pinnedActive)
         composingTextSnapshots = [ComposingText()]
         discardPinnedLearningCandidatesBeforeCompositionEdit()
-        #expect(learningCandidateCache.pinnedCandidateCount == 1)
+        #expect(learningCandidateCache.protectedSlotCount == 1)
     }
 }
 
@@ -450,32 +493,37 @@ private func testCandidate(
     #expect(cache.consume(newestId)?.text == "今日")
 }
 
-@Test func selectedPastClauseCandidatesSurviveBulkCacheEviction() {
+@Test func protectedClauseCandidateBatchSurvivesBulkCacheEviction() {
     var cache = LearningCandidateCache()
     let candidate = testCandidate(
         word: "今日",
         ruby: "きょう",
         composingCount: .inputCount(3)
     )
+    let alternate = testCandidate(
+        word: "教",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
     let candidates = Array(repeating: candidate, count: 201)
-    var selectedIds: [UInt64] = []
+    let protectedBatchId = cache.appendBatch([candidate, alternate])!
+    let selectedId = cache.candidateId(at: 0, batchFirstId: protectedBatchId)
+    let alternateId = cache.candidateId(at: 1, batchFirstId: protectedBatchId)
+    #expect(cache.pin(selectedId))
+    var newestId: UInt64 = 0
 
     // More than 40 high-water candidate generations exceed the 8,192-slot
-    // ring. Each past clause keeps only its selected candidate alive.
+    // ring. Unprotected batches are evicted around the protected source batch.
     for _ in 0..<48 {
         let batchFirstId = cache.appendBatch(candidates)!
-        let selectedId = cache.candidateId(at: 0, batchFirstId: batchFirstId)
-        let pinnedSelected = cache.pin(selectedId)
-        #expect(pinnedSelected)
-        selectedIds.append(selectedId)
+        newestId = cache.candidateId(at: 0, batchFirstId: batchFirstId)
     }
 
     #expect(cache.slotCount <= maxLearningCandidateCacheSlotCount)
-    #expect(cache.pinnedCandidateCount == selectedIds.count)
-    for selectedId in selectedIds {
-        #expect(cache.consume(selectedId)?.text == "今日")
-    }
-    #expect(cache.pinnedCandidateCount == 0)
+    #expect(cache.protectedSlotCount == 2)
+    #expect(cache.consume(selectedId)?.text == "今日")
+    #expect(cache.consume(alternateId)?.text == "教")
+    #expect(cache.consume(newestId)?.text == "今日")
 }
 
 @Test func learningCandidateCacheIsSkippedWhenLearningDoesNotAcceptInput() async throws {

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -259,6 +259,225 @@ private func testCandidate(
     #expect(cache.slotCount == 0)
 }
 
+@Test func learningCandidateCacheEvictsOldestBatchesAtConfiguredLimit() {
+    var cache = LearningCandidateCache(maxBatchCount: 2, maxSlotCount: 8)
+    let candidate = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+
+    let firstBatchId = cache.appendBatch([candidate])!
+    let firstId = cache.candidateId(at: 0, batchFirstId: firstBatchId)
+    let secondBatchId = cache.appendBatch([candidate])!
+    let secondId = cache.candidateId(at: 0, batchFirstId: secondBatchId)
+    let thirdBatchId = cache.appendBatch([candidate])!
+    let thirdId = cache.candidateId(at: 0, batchFirstId: thirdBatchId)
+
+    #expect(firstId != secondId)
+    #expect(secondId != thirdId)
+    #expect(cache.batchCount == 2)
+    #expect(cache.slotCount == 2)
+    #expect(cache.consume(firstId) == nil)
+    #expect(cache.consume(secondId)?.text == "今日")
+    #expect(cache.consume(thirdId)?.text == "今日")
+}
+
+@Test func pinnedLearningCandidateSurvivesBatchEvictionUntilConsumed() {
+    var cache = LearningCandidateCache(maxBatchCount: 2, maxSlotCount: 2)
+    let first = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let later = testCandidate(
+        word: "教",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+
+    let firstBatchId = cache.appendBatch([first])!
+    let firstId = cache.candidateId(at: 0, batchFirstId: firstBatchId)
+    let pinnedFirst = cache.pin(firstId)
+    #expect(pinnedFirst)
+
+    _ = cache.appendBatch([later])
+    _ = cache.appendBatch([later])
+
+    #expect(cache.batchCount == 2)
+    #expect(cache.slotCount == 2)
+    #expect(cache.pinnedCandidateCount == 1)
+    #expect(cache.consume(firstId)?.text == "今日")
+    #expect(cache.consume(firstId) == nil)
+    #expect(cache.pinnedCandidateCount == 0)
+}
+
+@Test func compositionEditDiscardsFutureOnlyPinsWithoutExtraRPC() async {
+    await MainActor.run {
+        let previousLearningCandidateCache = learningCandidateCache
+        let previousComposingTextSnapshots = composingTextSnapshots
+        defer {
+            learningCandidateCache = previousLearningCandidateCache
+            composingTextSnapshots = previousComposingTextSnapshots
+        }
+
+        learningCandidateCache = LearningCandidateCache(
+            maxBatchCount: 1,
+            maxSlotCount: 1
+        )
+        let candidate = testCandidate(
+            word: "今日",
+            ruby: "きょう",
+            composingCount: .inputCount(3)
+        )
+        let batchFirstId = learningCandidateCache.appendBatch([candidate])!
+        let candidateId = learningCandidateCache.candidateId(
+            at: 0,
+            batchFirstId: batchFirstId
+        )
+        let pinnedFuture = learningCandidateCache.pin(candidateId)
+        #expect(pinnedFuture)
+        _ = learningCandidateCache.appendBatch([candidate])
+
+        composingTextSnapshots.removeAll()
+        discardPinnedLearningCandidatesBeforeCompositionEdit()
+
+        #expect(learningCandidateCache.pinnedCandidateCount == 0)
+        #expect(learningCandidateCache.consume(candidateId) == nil)
+
+        learningCandidateCache.removeAll()
+        let activeBatchFirstId = learningCandidateCache.appendBatch([candidate])!
+        let activeCandidateId = learningCandidateCache.candidateId(
+            at: 0,
+            batchFirstId: activeBatchFirstId
+        )
+        let pinnedActive = learningCandidateCache.pin(activeCandidateId)
+        #expect(pinnedActive)
+        composingTextSnapshots = [ComposingText()]
+        discardPinnedLearningCandidatesBeforeCompositionEdit()
+        #expect(learningCandidateCache.pinnedCandidateCount == 1)
+    }
+}
+
+@Test func learningCandidateCacheEvictsWholeBatchesToStayWithinSlotLimit() {
+    var cache = LearningCandidateCache(maxBatchCount: 4, maxSlotCount: 3)
+    let first = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let second = testCandidate(
+        word: "教",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+
+    let oldestBatchId = cache.appendBatch([first, second])!
+    let oldestId = cache.candidateId(at: 0, batchFirstId: oldestBatchId)
+    let middleBatchId = cache.appendBatch([first])!
+    let middleId = cache.candidateId(at: 0, batchFirstId: middleBatchId)
+    let newestBatchId = cache.appendBatch([second])!
+    let newestId = cache.candidateId(at: 0, batchFirstId: newestBatchId)
+
+    #expect(cache.batchCount == 2)
+    #expect(cache.slotCount == 2)
+    #expect(cache.consume(oldestId) == nil)
+    #expect(cache.consume(middleId)?.text == "今日")
+    #expect(cache.consume(newestId)?.text == "教")
+}
+
+@Test func oversizedLearningCandidateBatchCachesOnlyBoundedPrefix() {
+    var cache = LearningCandidateCache(maxBatchCount: 2, maxSlotCount: 2)
+    let first = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let second = testCandidate(
+        word: "教",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let third = testCandidate(
+        word: "京",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+
+    let batchFirstId = cache.appendBatch([first, second, third])!
+    let firstId = cache.candidateId(at: 0, batchFirstId: batchFirstId)
+    let secondId = cache.candidateId(at: 1, batchFirstId: batchFirstId)
+
+    #expect(firstId != 0)
+    #expect(secondId == firstId + 1)
+    #expect(cache.candidateId(at: 2, batchFirstId: batchFirstId) == 0)
+    #expect(cache.batchCount == 1)
+    #expect(cache.slotCount == 2)
+    #expect(cache.consume(firstId)?.text == "今日")
+    #expect(cache.consume(secondId)?.text == "教")
+}
+
+@Test func defaultLearningCandidateCacheRetainsPreparedFutureClauseWindow() {
+    var cache = LearningCandidateCache()
+    let candidate = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let observedHighWaterCandidateCount = 201
+    let candidates = Array(
+        repeating: candidate,
+        count: observedHighWaterCandidateCount
+    )
+    var oldestId: UInt64 = 0
+    var newestId: UInt64 = 0
+
+    // The client retains the current clause and up to 16 prepared advances.
+    for generation in 0..<17 {
+        let batchFirstId = cache.appendBatch(candidates)!
+        if generation == 0 {
+            oldestId = cache.candidateId(at: 0, batchFirstId: batchFirstId)
+        }
+        newestId = cache.candidateId(
+            at: observedHighWaterCandidateCount - 1,
+            batchFirstId: batchFirstId
+        )
+    }
+
+    #expect(cache.batchCount == 17)
+    #expect(cache.slotCount == 17 * observedHighWaterCandidateCount)
+    #expect(cache.consume(oldestId)?.text == "今日")
+    #expect(cache.consume(newestId)?.text == "今日")
+}
+
+@Test func selectedPastClauseCandidatesSurviveBulkCacheEviction() {
+    var cache = LearningCandidateCache()
+    let candidate = testCandidate(
+        word: "今日",
+        ruby: "きょう",
+        composingCount: .inputCount(3)
+    )
+    let candidates = Array(repeating: candidate, count: 201)
+    var selectedIds: [UInt64] = []
+
+    // More than 40 high-water candidate generations exceed the 8,192-slot
+    // ring. Each past clause keeps only its selected candidate alive.
+    for _ in 0..<48 {
+        let batchFirstId = cache.appendBatch(candidates)!
+        let selectedId = cache.candidateId(at: 0, batchFirstId: batchFirstId)
+        let pinnedSelected = cache.pin(selectedId)
+        #expect(pinnedSelected)
+        selectedIds.append(selectedId)
+    }
+
+    #expect(cache.slotCount <= maxLearningCandidateCacheSlotCount)
+    #expect(cache.pinnedCandidateCount == selectedIds.count)
+    for selectedId in selectedIds {
+        #expect(cache.consume(selectedId)?.text == "今日")
+    }
+    #expect(cache.pinnedCandidateCount == 0)
+}
+
 @Test func learningCandidateCacheIsSkippedWhenLearningDoesNotAcceptInput() async throws {
     let candidate = testCandidate(
         word: "今日",
@@ -524,7 +743,7 @@ private func testCandidate(
         composingText = ComposingText()
         composingText.insertAtCursorPosition(input, inputStyle: .direct)
         composingTextSnapshots.removeAll()
-        push_composing_text_snapshot()
+        push_composing_text_snapshot(selectedCandidateId: 0)
         #expect(composingTextSnapshots.count == 1)
 
         var cursor: CInt = 0
@@ -534,11 +753,11 @@ private func testCandidate(
         #expect(composingText.convertTargetCursorPosition == 1149)
         #expect(composingTextSnapshots.count == 1)
 
-        pop_composing_text_snapshot()
+        pop_composing_text_snapshot(selectedCandidateId: 0)
         #expect(composingText.convertTargetCursorPosition == inputLength)
         #expect(composingTextSnapshots.isEmpty)
 
-        push_composing_text_snapshot()
+        push_composing_text_snapshot(selectedCandidateId: 0)
         clear_composing_text_snapshots()
         #expect(composingTextSnapshots.isEmpty)
     }
@@ -1879,6 +2098,7 @@ private func testCandidate(
             hiraganaCount: metrics.enabled.convertTarget.count
         )
     )
+    #expect(backgroundWarmupPreloadsDictionary == false)
 }
 
 @Test func cursorPrefixCandidatesSupplementFirstClauseWithMainResultsForSameBoundary() async throws {

--- a/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
+++ b/server-swift/Tests/azookey-serverTests/azookey_serverTests.swift
@@ -335,12 +335,14 @@ private func testCandidate(
     let firstBatchId = cache.appendBatch([first, alternate])!
     let firstId = cache.candidateId(at: 0, batchFirstId: firstBatchId)
     let alternateId = cache.candidateId(at: 1, batchFirstId: firstBatchId)
-    #expect(cache.pin(firstId))
+    let pinnedFirst = cache.pin(firstId)
+    #expect(pinnedFirst)
     #expect(cache.protectedSlotCount == 2)
 
     let laterBatchId = cache.appendBatch([later])!
     let laterId = cache.candidateId(at: 0, batchFirstId: laterBatchId)
-    #expect(cache.pin(laterId))
+    let pinnedLater = cache.pin(laterId)
+    #expect(pinnedLater)
     #expect(cache.slotCount == 3)
     #expect(cache.protectedSlotCount == 3)
     #expect(cache.appendBatch([later]) == nil)
@@ -509,7 +511,8 @@ private func testCandidate(
     let protectedBatchId = cache.appendBatch([candidate, alternate])!
     let selectedId = cache.candidateId(at: 0, batchFirstId: protectedBatchId)
     let alternateId = cache.candidateId(at: 1, batchFirstId: protectedBatchId)
-    #expect(cache.pin(selectedId))
+    let pinnedSelected = cache.pin(selectedId)
+    #expect(pinnedSelected)
     var newestId: UInt64 = 0
 
     // More than 40 high-water candidate generations exceed the 8,192-slot


### PR DESCRIPTION
## Summary
- 長い composition でも server の learning candidate cache が増え続けないよう、固定上限と選択候補を含む候補 batch の明示的な寿命管理を追加します。
- 既存 RPC に候補IDを同梱して学習対象を保持し、通常入力の同期 RPC 回数を増やさずに correctness と資源上限を両立します。
- process priority と Zenzai warmup は Windows VM の A/B 計測で変更による遅延悪化を確認したため、既存の低遅延挙動を維持します。

## Background
- Issue: #145
- Issue close: 対象リリース公開・成果物確認後
- server は変換候補生成ごとに learning candidate batch を composition 終了まで保持しており、長文入力で明示的な上限がありませんでした。また、priority・warmup converter・idle時の CPU / memory を同一環境で比較する計測手段が不足していました。

## Changes
- Learning candidate cache: 最大64 batch / 8192 candidate slot の固定リングへ変更し、保持件数を O(1) で管理して古い unprotected batch をまとめて破棄
- Candidate lifetime: past / future clause が参照する選択候補の source batch 全体を protected として同じ8192 slot上限へ算入し、alternate候補IDも維持。既存の Advance / Prepare / Push / Pop payload で選択候補IDを伝播し、編集・確定・clear時に保護を解除
- Hot path: future-only snapshot破棄を既存 Append / Remove / Shrink 内で処理し、追加の同期 RPC・lock・I/Oを回避
- Converter / warmup: background converter の辞書 preload を無効化。converter自体の再生成やZenzai周期warmup停止は実測回帰があるため実施せず、再利用を維持
- Diagnostics / metrics: diagnostic log無効時にlazy closureを評価しない回帰test、converter/cache件数のdebug performance log、外部CPU・private bytes・working set probeを追加
- Documentation: READMEの設定・ビルド説明を整理

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/31398534435
  - Static checks / frontend tests、Windows Swift / Rust全test、Windows buildが成功
  - Silent installer smoke testはPR runの条件によりskip
- [x] Windows VM確認
  - `.local/vm_build_master.sh feature/145-server-resource-management`: validation buildとInno installer生成に成功
  - `.local/vm_stage_for_manual_test.sh <installer>`: silent install、build identity確認、startup smokeに成功
  - `.local/vm_test_client_composition.sh feature/145-server-resource-management move_clause_right_uses_one_batched_backend_operation 'learningCandidateCache|pinnedLearningCandidate|selectedPastClauseCandidates|compositionEditDiscardsFutureOnlyPins|backgroundWarmup|cursorOffsetsUseFullInt32Range'`: Rust 1件、Swift Release 8件が成功
  - protected batch追補後のVM再実行はSwiftPM依存取得時のGitHub TLS証明書期限切れでtest開始前に停止。最終HEADはGitHub ActionsのSwift/Rust全testで確認
  - CPU競合時の1文字入力 `rpc_total`: BelowNormal p95=341ms / Normal p95=74ms / High p95=61ms。Highのp99=96ms、最大=105msに対し、Normalはp99=183ms、最大=493msだったため `HIGH_PRIORITY_CLASS` を維持
  - Zenzai periodic warmupをnormal-onlyへ変更した比較では `requestCandidates` 平均が72.9msから82.0ms、p95が113.8msから127.8msへ悪化したため、Zenzai warmupを維持
  - 95秒idle計測: CPU増分0.141秒、private bytes最大66.9MB、working setは77.0MBから41.2MBへ低下
- [x] ローカル確認
  - `cargo fmt --all --check`: 成功
  - `git diff --check`: 成功
  - PowerShell resource probe parser / sample output確認: 成功
- [x] Read-only review
  - P0 / P1 / P2 指摘なし
  - proto / Rust / Swift FFI、candidate pin lifetime、fixed ring上限、warmup・priority方針、通常入力hot pathを確認
  - README整理後の残存内容に事実誤認・文脈破損なし
  - Codex follow-up review（`6164fad`）: major issueなし

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
