### PR TITLE
fix(ui): specify candidate spacing units

### DIFF
--- a/crates/ui/src/candidate.rs
+++ b/crates/ui/src/candidate.rs
@@ -44,8 +44,8 @@ pub fn create_candidate_window(event_loop: &EventLoop<UserEvent>) -> Result<Wind
     Ok(window)
 }
 
-pub fn create_candidate_webview<'a>(web_context: &'a mut WebContext) -> Result<WebViewBuilder<'a>> {
-    let html = r##"
+fn candidate_html() -> String {
+    r##"
         <html>
             <head>
                 <style>
@@ -103,7 +103,7 @@ pub fn create_candidate_webview<'a>(web_context: &'a mut WebContext) -> Result<W
                             color: #636363;
                             font-weight: bold;
                             font-size: 0.75rem;
-                            margin: 0 0.75rem 0 2;
+                            margin: 0 0.75rem 0 2px;
                             width: 0.75rem;
                         }
 
@@ -135,7 +135,7 @@ pub fn create_candidate_webview<'a>(web_context: &'a mut WebContext) -> Result<W
                         display: flex;
                         justify-content: space-between;
                         align-items: center;
-                        padding: 8 10 5 10;
+                        padding: 8px 10px 5px 10px;
                         border-top: 1px solid #E4E4E4;
                         font-size: 0.8rem;
                         user-select: none;
@@ -431,11 +431,77 @@ pub fn create_candidate_webview<'a>(web_context: &'a mut WebContext) -> Result<W
                 </main>
             </body>
         </html>"##
-        .replace("__CANDIDATE_SCROLLER_SCRIPT__", CANDIDATE_SCROLLER_SCRIPT);
+        .replace("__CANDIDATE_SCROLLER_SCRIPT__", CANDIDATE_SCROLLER_SCRIPT)
+}
+
+pub fn create_candidate_webview<'a>(web_context: &'a mut WebContext) -> Result<WebViewBuilder<'a>> {
+    let html = candidate_html();
 
     let webview_builder = WebViewBuilder::with_web_context(web_context)
         .with_transparent(true)
         .with_html(html);
 
     Ok(webview_builder)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::candidate_html;
+
+    fn style_contents(html: &str) -> &str {
+        html.split_once("<style>")
+            .and_then(|(_, rest)| rest.split_once("</style>"))
+            .map(|(style, _)| style)
+            .expect("candidate HTML must contain a style element")
+    }
+
+    fn assert_nonzero_lengths_have_units(value: &str) {
+        for component in value.split_ascii_whitespace() {
+            if let Ok(number) = component.parse::<f64>() {
+                if number == 0.0 {
+                    continue;
+                }
+            }
+
+            let unit_start = component
+                .find(|character: char| {
+                    !character.is_ascii_digit()
+                        && character != '.'
+                        && character != '-'
+                        && character != '+'
+                })
+                .unwrap_or(component.len());
+            let (number, unit) = component.split_at(unit_start);
+
+            assert!(
+                number.parse::<f64>().is_ok() && !unit.is_empty(),
+                "non-zero CSS length must include a unit: {component}"
+            );
+        }
+    }
+
+    #[test]
+    fn candidate_spacing_lengths_have_explicit_units() {
+        let html = candidate_html();
+        let style = style_contents(&html);
+
+        for declaration in style.lines().map(str::trim) {
+            let Some((property, value)) = declaration
+                .strip_suffix(';')
+                .and_then(|declaration| declaration.split_once(':'))
+            else {
+                continue;
+            };
+            if property == "margin"
+                || property == "padding"
+                || property.starts_with("margin-")
+                || property.starts_with("padding-")
+            {
+                assert_nonzero_lengths_have_units(value.trim());
+            }
+        }
+
+        assert!(style.contains("margin: 0 0.75rem 0 2px;"));
+        assert!(style.contains("padding: 8px 10px 5px 10px;"));
+    }
 }

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -932,8 +932,10 @@ mod tests {
 
     #[test]
     fn candidate_window_resize_preserves_physical_width_at_high_dpi() {
+        assert_eq!(logical_width_for_physical_width(300, 1.0), 300.0);
         assert_eq!(logical_width_for_physical_width(300, 1.25), 240.0);
         assert_eq!(logical_width_for_physical_width(300, 1.5), 200.0);
+        assert_eq!(logical_width_for_physical_width(300, 2.0), 150.0);
     }
 
     #[test]

--- a/crates/ui/tests/candidate_scroller.test.cjs
+++ b/crates/ui/tests/candidate_scroller.test.cjs
@@ -1,5 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 
 const {
     MAX_RENDERED_ITEM_COUNT,
@@ -92,4 +94,36 @@ test("selection scrolling keeps visible rows and reveals hidden pages", () => {
     assert.equal(isSelectionFullyVisible(11, 5 * 32, 30, 32), false);
     assert.equal(selectionPageScrollTop(11, 30, 32), 10 * 32);
     assert.equal(selectionPageScrollTop(29, 30, 32), 25 * 32);
+});
+
+test("candidate spacing declarations use explicit CSS length units", () => {
+    const source = fs.readFileSync(
+        path.join(__dirname, "../src/candidate.rs"),
+        "utf8"
+    );
+    const style = source.match(/<style>([\s\S]*?)<\/style>/)?.[1];
+
+    assert.ok(style, "candidate HTML must contain a style element");
+    for (const line of style.split(/\r?\n/)) {
+        const declaration = line.trim().match(
+            /^(margin(?:-[a-z]+)?|padding(?:-[a-z]+)?):\s*(.*?)\s*;$/
+        );
+        if (!declaration) {
+            continue;
+        }
+
+        for (const component of declaration[2].split(/\s+/)) {
+            if (Number(component) === 0) {
+                continue;
+            }
+            assert.match(
+                component,
+                /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)[a-zA-Z%]+$/,
+                `non-zero CSS length must include a unit: ${component}`
+            );
+        }
+    }
+
+    assert.match(style, /&::before\s*\{[^}]*margin:\s*0 0\.75rem 0 2px;/);
+    assert.match(style, /footer\s*\{[^}]*padding:\s*8px 10px 5px 10px;/);
 });


### PR DESCRIPTION
## Summary
- 候補ウィンドウの埋め込みCSSに残っていた単位なしの非ゼロ `margin` / `padding` を `px` 指定へ修正します。
- 実際に生成される候補HTMLのCSSを検査する回帰testと、100% / 200% scalingの幅計算testを追加します。
- Windows VMで一般的な解像度、100% / 150% / 200% scaling、light / dark、候補0件 / 多数件を確認します。

## Background
- Issue: #147
- Issue close: 対象リリース公開・成果物確認後
- 非ゼロのCSS lengthに単位がなく、WebViewの解釈によって候補番号とfooterの余白宣言が無効になる可能性がありました。

## Changes
- Candidate UI: 候補番号の左余白を `2px`、footerの余白を `8px 10px 5px 10px` として明示
- Candidate UI test: 生成されるHTMLからCSSを抽出し、margin / paddingの非ゼロ値に単位があることを検証
- Candidate scroller test: 既存Node testに実ソースのspacing宣言を検査する回帰testを追加
- DPI test: 既存の物理幅維持testに100% / 200% scalingを追加

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/31502104248
  - Static checks / frontend tests、Windows Swift / Rust全test、Windows buildが成功
  - Silent installer smoke testはPR runの条件によりskip
- [x] Windows 実機確認
  - 100%: 1280x720、1366x768、1920x1080、2560x1440、3840x2160で候補番号・本文・footerの重なりや欠けがないことを確認
  - 150%: 2560x1440、200%: 3840x2160で表示崩れがないことを確認
  - light / dark、候補0件 / 通常候補 / 多数候補のスクロールを確認
  - `.local/vm_build_master.sh fix/147-candidate-css-length-units`: validation buildとInno installer生成に成功
  - `.local/vm_stage_for_manual_test.sh <installer>`: clean snapshotへのsilent installとbuild identity確認に成功
- [x] ローカル確認
  - `cargo fmt --all -- --check`: 成功
  - `node.exe --test crates/ui/tests/candidate_scroller.test.cjs`: 8件成功
  - `node.exe scripts/sync-version.mjs --check-release`: 成功
  - `git diff --check`: 成功
  - 対象Rust testのVM単体実行は既存の `azookey-server.lib` 不在によりlink前に停止。同じCSS契約をNode testで検証し、製品全体のVM buildは成功
- [x] Read-only review
  - P0 / P1 / P2 指摘なし

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
