### PR TITLE
fix(client): reconcile UI after direct commit

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -1089,13 +1089,24 @@ impl TextServiceFactory {
     }
 
     #[inline]
-    fn run_terminal_end_cleanup<T>(
-        ui_cleanup_already_sent: bool,
-        end_composition: impl FnOnce() -> Result<()>,
+    fn followup_owns_terminal_ui_cleanup(
+        actions: &[DeferredClientAction],
+        action_index: usize,
+    ) -> bool {
+        actions.get(action_index + 1).is_some_and(|next| {
+            next.transition == CompositionState::None
+                && matches!(next.action, ClientAction::CommitTextDirect(_))
+        })
+    }
+
+    #[inline]
+    fn run_terminal_action_cleanup<T>(
+        skip_ui_cleanup: bool,
+        terminal_action: impl FnOnce() -> Result<()>,
         hide_candidate_window: impl FnOnce() -> Result<T>,
     ) -> Result<()> {
-        let end_result = end_composition();
-        if !ui_cleanup_already_sent {
+        let terminal_result = terminal_action();
+        if !skip_ui_cleanup {
             if let Err(error) = hide_candidate_window() {
                 tracing::warn!(
                     ?error,
@@ -1104,10 +1115,18 @@ impl TextServiceFactory {
             }
         }
 
-        // EndComposition is irreversible once it succeeds. UI cleanup remains
-        // best-effort so a transient window RPC failure cannot replay the
-        // terminal action over the next composition.
-        end_result
+        // A terminal TSF edit is irreversible once it succeeds. UI cleanup remains
+        // best-effort so a transient window RPC failure cannot replay the action
+        // over the next composition.
+        terminal_result
+    }
+
+    #[inline]
+    fn terminal_ui_cleanup_required_after_failure(
+        requested_transition: &CompositionState,
+        delegated_to_followup: bool,
+    ) -> bool {
+        *requested_transition == CompositionState::None || delegated_to_followup
     }
 
     #[inline]
@@ -6589,6 +6608,7 @@ impl TextServiceFactory {
         let mut retry_actions = None;
         let mut failed_action_index = 0usize;
         let mut failed_ledger_snapshot = None;
+        let mut terminal_ui_cleanup_delegated_to_followup = false;
         let result: Result<()> = (|| {
             #[allow(clippy::let_and_return)]
             let (composition, mode) = {
@@ -6911,14 +6931,18 @@ impl TextServiceFactory {
                     ClientAction::EndComposition => {
                         // Let TSF commit the document before waiting for the synchronous UI
                         // RPC. UI cleanup is still attempted after a TSF error, and terminal
-                        // RemoveText can own the cleanup before its fallible final edit.
-                        let ui_cleanup_already_sent =
-                            Self::preceding_action_sent_terminal_ui_cleanup(
-                                terminal_ui_cleanup_sent_at,
-                                action_index,
-                            );
-                        Self::run_terminal_end_cleanup(
-                            ui_cleanup_already_sent,
+                        // RemoveText can own the cleanup before its fallible final edit. A
+                        // following standalone direct commit owns cleanup after its own TSF
+                        // composition, so the logical terminal operation is reconciled once.
+                        let followup_owns_ui_cleanup =
+                            Self::followup_owns_terminal_ui_cleanup(actions, action_index);
+                        terminal_ui_cleanup_delegated_to_followup = followup_owns_ui_cleanup;
+                        let skip_ui_cleanup = Self::preceding_action_sent_terminal_ui_cleanup(
+                            terminal_ui_cleanup_sent_at,
+                            action_index,
+                        ) || followup_owns_ui_cleanup;
+                        Self::run_terminal_action_cleanup(
+                            skip_ui_cleanup,
                             || self.end_composition(),
                             || self.hide_candidate_window_ui(&mut ipc_service),
                         )?;
@@ -7160,9 +7184,22 @@ impl TextServiceFactory {
                         }
                     }
                     ClientAction::CommitTextDirect(text) => {
-                        self.start_composition()?;
-                        self.set_text(text, "")?;
-                        self.end_composition()?;
+                        // This action creates and ends a standalone TSF composition while the
+                        // logical state is already terminal. It must therefore own the final UI
+                        // reconciliation instead of relying on an earlier EndComposition.
+                        let direct_commit_result = Self::run_terminal_action_cleanup(
+                            false,
+                            || {
+                                self.start_composition()?;
+                                self.set_text(text, "")?;
+                                self.end_composition()
+                            },
+                            || self.hide_candidate_window_ui(&mut ipc_service),
+                        );
+                        // The direct commit attempts cleanup on both success and failure, so
+                        // the postamble no longer needs to recover the delegated ownership.
+                        terminal_ui_cleanup_delegated_to_followup = false;
+                        direct_commit_result?;
                     }
                     ClientAction::RestoreReconversionOriginal => {
                         if let Some(original) = reconversion_original.as_deref() {
@@ -8398,10 +8435,16 @@ impl TextServiceFactory {
             Ok(())
         })();
 
-        if result.is_err() && requested_transition == CompositionState::None {
+        if result.is_err()
+            && Self::terminal_ui_cleanup_required_after_failure(
+                &requested_transition,
+                terminal_ui_cleanup_delegated_to_followup,
+            )
+        {
             // The requested state is authoritative even when a TSF callback fails
-            // midway through the edit. Repeat the cheap best-effort UI cleanup so
-            // deferred action replay is never required merely to hide stale UI.
+            // midway through the edit. A deferred replay can carry the old persisted
+            // state, so also reclaim cleanup delegated to a follow-up action that was
+            // never reached. UI cleanup must not require terminal action replay.
             if let Ok(Some(mut ipc_service)) = IMEState::ipc_service() {
                 let _ = self.hide_candidate_window_ui(&mut ipc_service);
                 let _ = IMEState::set_ipc_service(ipc_service);

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -144,10 +144,132 @@ fn terminal_end_reuses_only_a_delivered_preceding_ui_cleanup() {
 }
 
 #[test]
+fn direct_commit_followup_owns_terminal_ui_cleanup_only_for_terminal_transition() {
+    let terminal_direct_commit = vec![
+        DeferredClientAction {
+            action: ClientAction::EndComposition,
+            transition: CompositionState::None,
+        },
+        DeferredClientAction {
+            action: ClientAction::CommitTextDirect("、".to_string()),
+            transition: CompositionState::None,
+        },
+    ];
+    assert!(TextServiceFactory::followup_owns_terminal_ui_cleanup(
+        &terminal_direct_commit,
+        0,
+    ));
+
+    let composing_direct_commit = vec![
+        terminal_direct_commit[0].clone(),
+        DeferredClientAction {
+            action: ClientAction::CommitTextDirect("、".to_string()),
+            transition: CompositionState::Composing,
+        },
+    ];
+    assert!(!TextServiceFactory::followup_owns_terminal_ui_cleanup(
+        &composing_direct_commit,
+        0,
+    ));
+
+    let ordinary_followup = vec![
+        terminal_direct_commit[0].clone(),
+        DeferredClientAction {
+            action: ClientAction::SetIMEMode(InputMode::Latin),
+            transition: CompositionState::None,
+        },
+    ];
+    assert!(!TextServiceFactory::followup_owns_terminal_ui_cleanup(
+        &ordinary_followup,
+        0,
+    ));
+    assert!(!TextServiceFactory::followup_owns_terminal_ui_cleanup(
+        &terminal_direct_commit,
+        1,
+    ));
+}
+
+#[test]
+fn punctuation_terminal_cleanup_runs_once_after_direct_commit() {
+    let actions = vec![
+        DeferredClientAction {
+            action: ClientAction::EndComposition,
+            transition: CompositionState::None,
+        },
+        DeferredClientAction {
+            action: ClientAction::CommitTextDirect("、".to_string()),
+            transition: CompositionState::None,
+        },
+    ];
+    let order = std::cell::RefCell::new(Vec::new());
+
+    TextServiceFactory::run_terminal_action_cleanup(
+        TextServiceFactory::followup_owns_terminal_ui_cleanup(&actions, 0),
+        || {
+            order.borrow_mut().push("end-current");
+            Ok(())
+        },
+        || {
+            order.borrow_mut().push("hide");
+            Ok(WindowRpcDelivery::Sent)
+        },
+    )
+    .expect("the current composition should end");
+    TextServiceFactory::run_terminal_action_cleanup(
+        false,
+        || {
+            order
+                .borrow_mut()
+                .extend(["start-direct", "set-direct", "end-direct"]);
+            Ok(())
+        },
+        || {
+            order.borrow_mut().push("hide");
+            Ok(WindowRpcDelivery::Sent)
+        },
+    )
+    .expect("the standalone punctuation composition should commit");
+
+    assert_eq!(
+        *order.borrow(),
+        [
+            "end-current",
+            "start-direct",
+            "set-direct",
+            "end-direct",
+            "hide"
+        ]
+    );
+}
+
+#[test]
+fn delegated_terminal_ui_cleanup_is_reclaimed_after_sequence_failure() {
+    assert!(
+        TextServiceFactory::terminal_ui_cleanup_required_after_failure(
+            &CompositionState::Composing,
+            true,
+        )
+    );
+    assert!(
+        TextServiceFactory::terminal_ui_cleanup_required_after_failure(
+            &CompositionState::None,
+            false,
+        )
+    );
+    assert!(
+        !TextServiceFactory::terminal_ui_cleanup_required_after_failure(
+            &CompositionState::Composing,
+            false,
+        ),
+        "a non-terminal failure without delegated ownership must preserve its UI"
+    );
+}
+
+#[test]
 fn terminal_end_commits_tsf_before_waiting_for_ui_cleanup() {
     let order = std::cell::RefCell::new(Vec::new());
 
-    TextServiceFactory::run_terminal_end_cleanup(
+    TextServiceFactory::run_terminal_action_cleanup(
         false,
         || {
             order.borrow_mut().push("end");
@@ -167,7 +289,7 @@ fn terminal_end_commits_tsf_before_waiting_for_ui_cleanup() {
 fn terminal_end_still_hides_ui_after_tsf_failure_and_preserves_the_tsf_error() {
     let order = std::cell::RefCell::new(Vec::new());
 
-    let error = TextServiceFactory::run_terminal_end_cleanup(
+    let error = TextServiceFactory::run_terminal_action_cleanup(
         false,
         || {
             order.borrow_mut().push("end");
@@ -185,10 +307,31 @@ fn terminal_end_still_hides_ui_after_tsf_failure_and_preserves_the_tsf_error() {
 }
 
 #[test]
+fn terminal_direct_commit_still_hides_ui_after_tsf_failure() {
+    let order = std::cell::RefCell::new(Vec::new());
+
+    let error = TextServiceFactory::run_terminal_action_cleanup(
+        false,
+        || {
+            order.borrow_mut().extend(["start-direct", "set-direct"]);
+            anyhow::bail!("direct set failed")
+        },
+        || {
+            order.borrow_mut().push("hide");
+            Ok(WindowRpcDelivery::Sent)
+        },
+    )
+    .expect_err("the TSF failure must remain visible to recovery");
+
+    assert_eq!(*order.borrow(), ["start-direct", "set-direct", "hide"]);
+    assert!(error.to_string().contains("direct set failed"));
+}
+
+#[test]
 fn terminal_end_skips_duplicate_ui_cleanup_after_terminal_remove() {
     let order = std::cell::RefCell::new(Vec::new());
 
-    TextServiceFactory::run_terminal_end_cleanup(
+    TextServiceFactory::run_terminal_action_cleanup(
         true,
         || {
             order.borrow_mut().push("end");
@@ -208,7 +351,7 @@ fn terminal_end_skips_duplicate_ui_cleanup_after_terminal_remove() {
 fn terminal_end_does_not_replay_after_ui_cleanup_failure() {
     let order = std::cell::RefCell::new(Vec::new());
 
-    TextServiceFactory::run_terminal_end_cleanup(
+    TextServiceFactory::run_terminal_action_cleanup(
         false,
         || {
             order.borrow_mut().push("end");


### PR DESCRIPTION
## Summary
- 句読点確定時に、変換文字列は確定されてもライブ変換の読みと候補ウィンドウが残る問題を修正します。
- 一つの論理確定で最後に終了するTSF compositionがUI cleanupを所有するよう、確定処理の契約を整理します。
- cleanupの順序、失敗時の回収、deferred replayを検証する回帰testを追加します。

## Background
- Issue: #169
- Issue close: 対象リリース公開・成果物確認後
- ライブ変換の読み表示と句読点確定を有効にして `kyouha` → `,` と入力すると、本文は `今日は、` と確定される一方、ruby `きょうは` と候補一覧が残りました。
- 句読点確定は `EndComposition` の後に `CommitTextDirect` が短命のcompositionを `start → set → end` する唯一の通常確定経路ですが、UI cleanupは最初のcomposition終了時に実行されていました。論理操作全体の最終TSF終了後にUI状態を整合させることが目的です。

## Changes
- Client / TSF lifecycle: 後続がterminalな `CommitTextDirect` の場合だけ、`EndComposition` から後続actionへUI cleanup ownershipを委譲
- Client / failure recovery: direct commitのTSF操作失敗時もbest-effort cleanupを実行し、End後の中断やdeferred replayでは未実行の委譲cleanupをpostambleで回収
- Client / performance: 正常時の同期UI RPCを従来どおり1回に保ち、最後のTSF composition終了後へ移動
- Client test: cleanup順序、実行回数、terminal transition判定、TSF失敗、UI RPC失敗、deferred replayの回帰testを追加
- Commit path audit: Enter、候補確定、最終削除、Escape、再変換取消、モード変更、フォーカス喪失、外部終了のcleanup経路を確認

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/31804323328
  - Static checks / frontend tests、Windows Swift / Rust全test、Windows build、installer metadata検証、artifact uploadが成功
  - Silent installer smoke testはPR runの条件によりskip。clean VMへのローカルsilent installで確認
- [x] Windows VM確認
  - `.local/vm_test_client_composition.sh fix/169-clear-live-conversion-ui-on-commit terminal skip`: 28件成功
  - `.local/vm_test_client_composition.sh fix/169-clear-live-conversion-ui-on-commit punctuation_commit skip`: 11件成功
  - `.local/vm_build_master.sh fix/169-clear-live-conversion-ui-on-commit`: x64 / x86 Rust、Swift、frontend / Tauri、Inno installer生成に成功
  - clean snapshotへのsilent install、validation build identity、IME登録を確認
  - Notepad: `kyouha` → commaで本文 `今日は、`、ruby / 候補が非表示、句読点重複なし
  - Notepad: Enter確定、comma直後の再入力とperiod確定、感嘆符・疑問符確定で旧UIの残留・復活がないことを確認
- [x] ローカル確認
  - `cargo fmt --all --check`: 成功
  - `git diff --check`: 成功
- [x] Read-only review
  - P0 / P1 / P2 指摘なし

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
