### PR TITLE
fix(client): prevent stale Shift from forcing Latin input

### DIFF
--- a/crates/client/src/engine/composition.rs
+++ b/crates/client/src/engine/composition.rs
@@ -84,6 +84,24 @@ struct ModifierState {
     win: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ShiftKeyState {
+    physical: bool,
+    tracked: bool,
+}
+
+impl ShiftKeyState {
+    #[inline]
+    fn for_regular_key(self) -> bool {
+        self.physical
+    }
+
+    #[inline]
+    fn for_eisu_shortcut(self) -> bool {
+        self.physical || self.tracked
+    }
+}
+
 fn reconversion_shortcut_matches(
     preset: ReconversionKey,
     key_code: usize,
@@ -527,6 +545,18 @@ impl TextServiceFactory {
                     .iter()
                     .any(|key| GetAsyncKeyState(key.0 as i32) as u16 & 0x8000 != 0)
             }
+    }
+
+    #[inline]
+    fn shift_key_state(&self) -> ShiftKeyState {
+        let tracked = self
+            .borrow()
+            .map(|text_service| text_service.shift_key_down)
+            .unwrap_or(false);
+        ShiftKeyState {
+            physical: Self::is_shift_pressed(),
+            tracked,
+        }
     }
 
     #[inline]
@@ -5339,13 +5369,7 @@ impl TextServiceFactory {
             .shortcuts
             .reconversion_key;
         let modifiers = ModifierState {
-            shift: {
-                let tracked = self
-                    .borrow()
-                    .map(|text_service| text_service.shift_key_down)
-                    .unwrap_or(false);
-                tracked || Self::is_shift_pressed()
-            },
+            shift: self.shift_key_state().for_regular_key(),
             ctrl: Self::is_ctrl_pressed(),
             alt: Self::is_alt_pressed(),
             win: Self::is_win_pressed(),
@@ -5620,13 +5644,8 @@ impl TextServiceFactory {
             let is_ctrl_pressed = Self::is_ctrl_pressed();
             let is_alt_pressed = Self::is_alt_pressed();
             let is_win_pressed = Self::is_win_pressed();
-            let is_shift_pressed = {
-                let tracked_shift = self
-                    .borrow()
-                    .map(|text_service| text_service.shift_key_down)
-                    .unwrap_or(false);
-                tracked_shift || Self::is_shift_pressed()
-            };
+            let shift_key_state = self.shift_key_state();
+            let is_shift_pressed = shift_key_state.for_regular_key();
             let is_ctrl_space = is_ctrl_pressed && wparam.0 == 0x20;
             let is_capslock_key = wparam.0 == VK_CAPITAL_KEY_CODE
                 || Self::is_translated_capslock_key(wparam.0, lparam);
@@ -5635,7 +5654,7 @@ impl TextServiceFactory {
                 Self::is_eisu_shortcut(
                     wparam.0,
                     lparam,
-                    is_shift_pressed,
+                    shift_key_state.for_eisu_shortcut(),
                     is_ctrl_pressed,
                     is_alt_pressed,
                     keyboard_layout,
@@ -6146,20 +6165,14 @@ impl TextServiceFactory {
                 return Ok(false);
             }
 
-            let is_shift_pressed = {
-                let tracked_shift = self
-                    .borrow()
-                    .map(|text_service| text_service.shift_key_down)
-                    .unwrap_or(false);
-                tracked_shift || Self::is_shift_pressed()
-            };
+            let shift_key_state = self.shift_key_state();
             let is_ctrl_pressed = Self::is_ctrl_pressed();
             let is_alt_pressed = Self::is_alt_pressed();
             let keyboard_layout = Self::current_caps_lock_keyboard_layout();
             if !Self::is_eisu_shortcut(
                 VK_CAPITAL_KEY_CODE,
                 LPARAM(0),
-                is_shift_pressed,
+                shift_key_state.for_eisu_shortcut(),
                 is_ctrl_pressed,
                 is_alt_pressed,
                 keyboard_layout,
@@ -6183,7 +6196,7 @@ impl TextServiceFactory {
 
             let deferred = DeferredUserAction {
                 action: UserAction::ToggleInputMode,
-                is_shift_pressed,
+                is_shift_pressed: shift_key_state.for_regular_key(),
                 is_shift_key: false,
                 shift_alphabet_shortcut: false,
             };

--- a/crates/client/src/engine/composition/tests.rs
+++ b/crates/client/src/engine/composition/tests.rs
@@ -8,7 +8,7 @@ use super::{
     ClauseBoundarySync, ClauseNavigationReadyUiSync, ClauseSnapshot, ClauseState, Composition,
     CompositionReducer, CompositionState, ConsumedPrefixRestore, DeferredClientAction,
     DeferredInputEvent, DeferredProjection, DeferredUserAction, FutureClauseSnapshot,
-    ModifierState, TextServiceFactory,
+    ModifierState, ShiftKeyState, TextServiceFactory,
 };
 use crate::engine::{
     client_action::{
@@ -22,7 +22,10 @@ use crate::tsf::edit_session::EditSessionFailure;
 use shared::{
     get_default_romaji_rows, AppConfig, PunctuationStyle, ReconversionKey, RomajiRule, WidthMode,
 };
-use windows::Win32::{Foundation::LPARAM, UI::TextServices::TF_E_LOCKED};
+use windows::Win32::{
+    Foundation::{LPARAM, WPARAM},
+    UI::TextServices::TF_E_LOCKED,
+};
 
 #[test]
 fn deadline_recovery_defers_all_actions_from_failure_point() {
@@ -1574,6 +1577,59 @@ fn eisu_shortcut_matches_ms_ime_capslock_rules_by_keyboard_layout() {
         false,
         false,
         CapsLockKeyboardLayout::Japanese
+    ));
+}
+
+#[test]
+fn stale_tracked_shift_is_limited_to_eisu_shortcut_fallback() {
+    let stale_state = ShiftKeyState {
+        physical: false,
+        tracked: true,
+    };
+
+    let shift_alphabet_shortcut =
+        TextServiceFactory::is_shift_alphabet_shortcut(WPARAM(0x41), stale_state.for_regular_key());
+    assert!(!shift_alphabet_shortcut);
+
+    let app_config = AppConfig::default();
+    let romaji_lookup = super::RomajiLookup::from_rows(&app_config.romaji_table.rows);
+    let (_, actions) = TextServiceFactory::plan_deferred_user_action(
+        &Composition::default(),
+        &DeferredUserAction {
+            action: UserAction::Input('a'),
+            is_shift_pressed: stale_state.for_regular_key(),
+            is_shift_key: false,
+            shift_alphabet_shortcut,
+        },
+        &InputMode::Kana,
+        &app_config,
+        &romaji_lookup,
+    )
+    .expect("ordinary alphabet input should remain plannable after a stale tracked Shift");
+    assert_eq!(
+        actions,
+        vec![
+            ClientAction::StartComposition,
+            ClientAction::AppendText("a".to_string())
+        ]
+    );
+
+    assert!(TextServiceFactory::is_eisu_shortcut(
+        0x14,
+        LPARAM(0),
+        stale_state.for_eisu_shortcut(),
+        false,
+        false,
+        CapsLockKeyboardLayout::English
+    ));
+
+    let pressed_state = ShiftKeyState {
+        physical: true,
+        tracked: false,
+    };
+    assert!(TextServiceFactory::is_shift_alphabet_shortcut(
+        WPARAM(0x41),
+        pressed_state.for_regular_key()
     ));
 }
 

--- a/crates/client/src/tsf/key_event_sink.rs
+++ b/crates/client/src/tsf/key_event_sink.rs
@@ -112,15 +112,17 @@ impl ITfKeyEventSink_Impl for TextServiceFactory_Impl {
         wparam: WPARAM,
         lparam: LPARAM,
     ) -> Result<BOOL> {
-        let result = self.process_key_up(pic, wparam, lparam)?.is_some();
+        // Release the tracked modifier before fallible composition work so an
+        // error cannot leave later ordinary keys looking Shift-modified.
         self.update_shift_key_state(wparam, false);
+        let result = self.process_key_up(pic, wparam, lparam)?.is_some();
         Ok(result.into())
     }
 
     #[macros::anyhow]
     fn OnKeyUp(&self, pic: Option<&ITfContext>, wparam: WPARAM, lparam: LPARAM) -> Result<BOOL> {
-        let result = self.handle_key_up(pic, wparam, lparam)?;
         self.update_shift_key_state(wparam, false);
+        let result = self.handle_key_up(pic, wparam, lparam)?;
         Ok(result.into())
     }
 
@@ -185,7 +187,7 @@ impl TextServiceFactory_Impl {
         }
     }
 
-    fn clear_tracked_modifier_key_state(&self) {
+    pub(crate) fn clear_tracked_modifier_key_state(&self) {
         if let Ok(mut text_service) = self.borrow_mut() {
             text_service.shift_key_down = false;
         }

--- a/crates/client/src/tsf/text_input_proccesor.rs
+++ b/crates/client/src/tsf/text_input_proccesor.rs
@@ -143,6 +143,7 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
     #[tracing::instrument]
     fn Deactivate(&self) -> Result<()> {
         tracing::debug!("Deactivated");
+        self.clear_tracked_modifier_key_state();
 
         // remove reference to the dll instance
         let mut dll_instance = DllModule::get()?;
@@ -206,7 +207,6 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
         // clear display attribute
         text_service.display_attribute_atom.clear();
 
-        text_service.shift_key_down = false;
         text_service.tid = 0;
         text_service.thread_mgr = None;
 

--- a/crates/client/src/tsf/thread_mgr_event_sink.rs
+++ b/crates/client/src/tsf/thread_mgr_event_sink.rs
@@ -72,6 +72,10 @@ impl ITfThreadMgrEventSink_Impl for TextServiceFactory_Impl {
         focus: Option<&ITfDocumentMgr>,
         _prevfocus: Option<&ITfDocumentMgr>,
     ) -> Result<()> {
+        // A modifier key-up can be delivered to the newly focused thread or
+        // document instead of this text service.
+        self.clear_tracked_modifier_key_state();
+
         // if focus is changed, the text layout sink should be updated
         if let Some(focus) = focus {
             self.borrow_mut()?.advise_text_layout_sink(focus.clone())?;
@@ -104,6 +108,7 @@ impl ITfThreadMgrEventSink_Impl for TextServiceFactory_Impl {
 impl ITfThreadFocusSink_Impl for TextServiceFactory_Impl {
     #[macros::anyhow]
     fn OnSetThreadFocus(&self) -> Result<()> {
+        self.clear_tracked_modifier_key_state();
         let focus = {
             let text_service = self.borrow()?;
             let thread_mgr = text_service.thread_mgr()?;
@@ -117,6 +122,7 @@ impl ITfThreadFocusSink_Impl for TextServiceFactory_Impl {
 
     #[macros::anyhow]
     fn OnKillThreadFocus(&self) -> Result<()> {
+        self.clear_tracked_modifier_key_state();
         self.set_keyboard_disabled_state(true)?;
 
         Ok(())


### PR DESCRIPTION
## Summary
- 取りこぼされた Shift KeyUp により、かな入力中の通常英字が一時英数入力として扱われ続ける問題を修正します。
- 通常キーは物理 Shift 状態だけを使い、追跡状態は CapsLock/Eisu ショートカットの補助に限定します。

## Background
- Issue: N/A
- Issue close: N/A
- Shift KeyUp が別コンテキストへ渡る、または KeyUp 処理が途中で失敗すると、クライアントの追跡状態が押下中のまま残ることがありました。
- この状態では確定や削除で一時英数状態を解除しても、次の通常英字入力で直ちに再開されるため、再起動や一部のフォーカス遷移まで復旧しないように見えていました。

## Changes
- client/composition: 通常入力、Space、Shift+矢印、再変換では物理 Shift 状態のみを参照し、追跡 Shift は CapsLock/Eisu 判定の補助に限定
- client/TSF: KeyUp の失敗可能な処理より先に追跡 Shift を解除し、document/thread focus 変更と Deactivate でも初期化
- client/tests: stale な追跡 Shift が通常英字を一時英数化せず、物理 Shift と CapsLock/Eisu の既存挙動を維持する回帰テストを追加

## Verification
- [x] GitHub Actions build 成功
  - run: https://github.com/batao9/azooKey-Windows/actions/runs/31813538414
- [ ] Windows 実機確認
  - Windows 11 VM client test: 新規回帰テスト 1件成功
  - Windows 11 VM client test: temporary_latin 関連 7件成功
  - Windows 11 VM build/install: validation build、silent install、DLL登録、build identity 確認に成功
  - Notepad 自動入力プローブ: フォーカスとIMEモードの固定が不安定で、有効な前後比較結果は未取得
- [x] ローカル確認
  - cargo fmt --all --check
  - Windows target cargo check --tests
  - Windows target cargo clippy --tests -- -D warnings
  - git diff --check
  - release metadata 同期確認

## Checklist
- [x] CI run URL と実機確認結果を記載した
- [x] 影響範囲を確認した

---

## Review Rules

<!--
このセクションはレビューコメントの分類ルールです。PR本文の記入項目とは分けて扱います。

GitHub Copilot review rule:
- [must] 必ず対応が必要な指摘。修正するか、対応しない理由を明記してください。
- [imo] 修正必須ではない提案。レビュアーの意見として検討してください。
- [nits] 軽微な指摘。表記、命名、整形などの小さな改善提案です。
- [ask] 質問。実装意図や判断理由の確認です。
- [fyi] 参考情報。対応は不要です。
-->
